### PR TITLE
Add functions to get WGS84/proj bounds of UTM zones.

### DIFF
--- a/tests/unit/utils/test_get_utm_ups_crs.py
+++ b/tests/unit/utils/test_get_utm_ups_crs.py
@@ -1,6 +1,10 @@
 from rasterio.crs import CRS
 
-from rslearn.utils import get_utm_ups_crs
+from rslearn.utils.get_utm_ups_crs import (
+    get_proj_bounds,
+    get_utm_ups_crs,
+    get_wgs84_bounds,
+)
 
 
 def test_seattle():
@@ -9,6 +13,17 @@ def test_seattle():
     lat = 47.62
     crs = get_utm_ups_crs(lon, lat)
     assert crs == CRS.from_epsg(32610)
+
+    epsilon = 1e-6
+    wgs84_bounds = get_wgs84_bounds(crs)
+    expected = [-126, 0, -120, 84]
+    assert all([abs(a - b) < epsilon for a, b in zip(wgs84_bounds, expected)])
+
+    epsilon = 1e-2
+    proj_bounds = get_proj_bounds(crs)
+    # from https://epsg.io/32610
+    expected = [166021.44, 0, 833978.56, 9329005.18]
+    assert all([abs(a - b) < epsilon for a, b in zip(proj_bounds, expected)])
 
 
 def test_antarctica():


### PR DESCRIPTION
This will be helpful later for starting inference jobs spanning all grid cells in all UTM zones.