### PR TITLE
fix how metrics are computed (2)

### DIFF
--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -233,10 +233,8 @@ class RslearnLightningModule(L.LightningModule):
             on_step=False,
             on_epoch=True,
         )
-        self.val_metrics(outputs, targets)
-        self.log_dict(
-            self.val_metrics, batch_size=batch_size, on_step=False, on_epoch=True
-        )
+        self.val_metrics.update(outputs, targets)
+        self.log_dict(self.val_metrics, on_epoch=True)
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
@@ -259,10 +257,8 @@ class RslearnLightningModule(L.LightningModule):
         self.log(
             "test_loss", test_loss, batch_size=batch_size, on_step=False, on_epoch=True
         )
-        self.test_metrics(outputs, targets)
-        self.log_dict(
-            self.test_metrics, batch_size=batch_size, on_step=False, on_epoch=True
-        )
+        self.test_metrics.update(outputs, targets)
+        self.log_dict(self.test_metrics, on_epoch=True)
 
         if self.visualize_dir:
             for idx, (inp, target, output) in enumerate(zip(inputs, targets, outputs)):


### PR DESCRIPTION
now we call .update explicitly. there is note at
https://lightning.ai/docs/torchmetrics/stable/pages/lightning.html about it but it is not obvious that this is how the metric should be used when reporting epoch-level metric only.