### PR TITLE
Some changes to speed up the prediction pipeline in reslearn_projects

### DIFF
--- a/rslearn/data_sources/__init__.py
+++ b/rslearn/data_sources/__init__.py
@@ -10,6 +10,7 @@ Each source supports operations to lookup items that match with spatiotemporal
 geometries, and ingest those items.
 """
 
+import functools
 import importlib
 
 from upath import UPath
@@ -19,6 +20,7 @@ from rslearn.config import LayerConfig
 from .data_source import DataSource, Item, ItemLookupDataSource, RetrieveItemDataSource
 
 
+@functools.cache
 def data_source_from_config(config: LayerConfig, ds_path: UPath) -> DataSource:
     """Loads a data source from config dict.
 

--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -124,6 +124,7 @@ class RslearnLightningModule(L.LightningModule):
         self.plateau_min_lr = plateau_min_lr
         self.plateau_cooldown = plateau_cooldown
         self.visualize_dir = visualize_dir
+        self.restore_config = restore_config
 
         if print_parameters:
             for name, param in self.named_parameters():
@@ -132,16 +133,6 @@ class RslearnLightningModule(L.LightningModule):
         if print_model:
             print(self.model)
 
-        if restore_config:
-            state_dict = restore_config.get_state_dict()
-            missing_keys, unexpected_keys = self.model.load_state_dict(
-                state_dict, strict=False
-            )
-            if missing_keys or unexpected_keys:
-                print(
-                    f"warning: restore yielded missing_keys={missing_keys} and unexpected_keys={unexpected_keys}"
-                )
-
         self.epochs = 0
 
         metrics = self.task.get_metrics()
@@ -149,6 +140,18 @@ class RslearnLightningModule(L.LightningModule):
         self.test_metrics = metrics.clone(prefix="test_")
 
         self.schedulers = {}
+
+    def on_train_start(self) -> None:
+        """Called when the train begins."""
+        if self.restore_config:
+            state_dict = self.restore_config.get_state_dict()
+            missing_keys, unexpected_keys = self.model.load_state_dict(
+                state_dict, strict=False
+            )
+            if missing_keys or unexpected_keys:
+                print(
+                    f"warning: restore yielded missing_keys={missing_keys} and unexpected_keys={unexpected_keys}"
+                )
 
     def configure_optimizers(self) -> OptimizerLRSchedulerConfig:
         """Initialize the optimizer and learning rate scheduler.


### PR DESCRIPTION
1. Apply `restore_config` only for training, in this way, using the same configuration file, we won't apply `restore_config` when doing validation, test, and predict.
2. Add cache decorator to `data_source_from_config` to store the call results in memory.