### PR TITLE
Fix issue between restore_config and model checkpoints

### DIFF
--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -141,8 +141,8 @@ class RslearnLightningModule(L.LightningModule):
 
         self.schedulers = {}
 
-    def on_train_start(self) -> None:
-        """Called when the train begins."""
+    def on_fit_start(self) -> None:
+        """Called when the fit begins."""
         if self.restore_config:
             state_dict = self.restore_config.get_state_dict()
             missing_keys, unexpected_keys = self.model.load_state_dict(

--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -143,7 +143,8 @@ class RslearnLightningModule(L.LightningModule):
 
     def on_fit_start(self) -> None:
         """Called when the fit begins."""
-        if self.restore_config:
+        # Only restore if doing a fresh fit.
+        if self.trainer.ckpt_path is None and self.restore_config:
             state_dict = self.restore_config.get_state_dict()
             missing_keys, unexpected_keys = self.model.load_state_dict(
                 state_dict, strict=False


### PR DESCRIPTION
Add condition to make sure that restoring weights is only triggered when it's a fresh fit (no previous checkpoints). 

Tested in rslearn_projects, when autoresume is True, only loading checkpoints, and when autoresume is False, only loading restored weights.