### PR TITLE
Support using ZSTD compression in GeoTIFFs

### DIFF
--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -323,7 +323,12 @@ class GeotiffRasterFormat(RasterFormat):
 
     fname = "geotiff.tif"
 
-    def __init__(self, block_size: int = TILE_SIZE, always_enable_tiling: bool = False):
+    def __init__(
+        self,
+        block_size: int = TILE_SIZE,
+        always_enable_tiling: bool = False,
+        geotiff_options: dict[str, Any] = {},
+    ):
         """Initializes a GeotiffRasterFormat.
 
         Args:
@@ -332,9 +337,11 @@ class GeotiffRasterFormat(RasterFormat):
                 GeoTIFFs. The default is False so that tiling is only used if the size
                 of the GeoTIFF exceeds the block_size on either dimension. If True,
                 then tiling is always enabled (cloud-optimized GeoTIFF).
+            geotiff_options: other options to pass to rasterio.open (for writes).
         """
         self.block_size = block_size
         self.always_enable_tiling = always_enable_tiling
+        self.geotiff_options = geotiff_options
 
     def encode_raster(
         self,
@@ -382,6 +389,8 @@ class GeotiffRasterFormat(RasterFormat):
             profile["tiled"] = True
             profile["blockxsize"] = self.block_size
             profile["blockysize"] = self.block_size
+
+        profile.update(self.geotiff_options)
 
         path.mkdir(parents=True, exist_ok=True)
         logger.info(f"Writing geotiff to {path / self.fname}")

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -498,6 +498,8 @@ class GeotiffRasterFormat(RasterFormat):
             kwargs["block_size"] = config["block_size"]
         if "always_enable_tiling" in config:
             kwargs["always_enable_tiling"] = config["always_enable_tiling"]
+        if "geotiff_options" in config:
+            kwargs["geotiff_options"] = config["geotiff_options"]
         return GeotiffRasterFormat(**kwargs)
 
 

--- a/tests/unit/utils/test_raster_format.py
+++ b/tests/unit/utils/test_raster_format.py
@@ -82,3 +82,18 @@ def test_geotiff_out_of_bounds(tmp_path: pathlib.Path, monkeypatch: Any) -> None
     assert array.shape == (1, 4, 4)
     assert np.all(array == 0)
     assert logger.warned
+
+
+def test_geotiff_compress_zstd(tmp_path: pathlib.Path) -> None:
+    # Make sure we can use ZSTD compression successfully.
+    path = UPath(tmp_path)
+    projection = Projection(CRS.from_epsg(3857), 1, -1)
+    array = np.zeros((1, 4, 4))
+    raster_format = GeotiffRasterFormat(
+        geotiff_options=dict(
+            compress="zstd",
+        )
+    )
+    raster_format.encode_raster(path, projection, (0, 0, 4, 4), array)
+    with rasterio.open(path / "geotiff.tif") as raster:
+        assert raster.profile["compress"] == "zstd"


### PR DESCRIPTION
This PR depends on #104 since it changes functionality in the new DefaultTileStore.

Currently we use LZW compression only.

This PR adds geotiff_options to GeotiffRasterFormat and DefaultTileStore so that arbitrary rasterio profile options can be overwritten. Then we can use the geotiff_options to enable ZSTD compression. In particular this seems to give a good tradeoff between speed and compression ratio:

```
raster_format = GeotiffRasterFormat(geotiff_options=dict(compress="zstd", zstd_level=1, predictor=2))
```