### PR TITLE
v0.0.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.0.1"
+version = "0.0.2"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     {name = "Favyen Bastani", email = "favyenb@allenai.org"},


### PR DESCRIPTION
I think it makes sense to put a "v0.0.2" on pip before looking at PRs like #104 / #105 which have more substantial changes.

(e.g. it's possible that #104 will introduce subtle changes in how images are rendered and require retraining model)