### PR TITLE
Add ERA5 monthly data

### DIFF
--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -1,11 +1,13 @@
 # These are requirements that are specific to a subset of data sources or models.
 accelerate>=1.0
+cdsapi>=0.7.4
 earthengine-api>=0.1
 einops>=0.8
 gcsfs>=2024.10
 google-cloud-bigquery>=2.18
 google-cloud-storage>=2.18
 interrogate>=1.7
+netCDF4>=1.7.2
 osmium>=3.7
 planet>=2.10
 pycocotools>=2.0

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -190,9 +190,9 @@ class ERA5LandMonthlyMeans(DataSource):
                 raise ValueError(
                     f"Latitude spacing is not uniform: {lat[i + 1] - lat[i]}"
                 )
-        west = lon.min()
-        north = lat.max()
-        pixel_size_x, pixel_size_y = self.PIXEL_SIZE, -self.PIXEL_SIZE
+        west = lon.min() - self.PIXEL_SIZE / 2
+        north = lat.max() + self.PIXEL_SIZE / 2
+        pixel_size_x, pixel_size_y = self.PIXEL_SIZE, self.PIXEL_SIZE
         transform = from_origin(west, north, pixel_size_x, pixel_size_y)
         crs = f"EPSG:{WGS84_EPSG}"
         with rasterio.open(

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -36,7 +36,7 @@ class ERA5LandMonthlyMeans(DataSource):
     PIXEL_SIZE = 0.1  # degrees, native resolution is 9km
 
     # see: https://confluence.ecmwf.int/display/CKB/ERA5-Land%3A+data+documentation
-    # Table 2 & 3 for variable shortnames
+    # For variable full & short names
 
     def __init__(
         self,
@@ -140,7 +140,7 @@ class ERA5LandMonthlyMeans(DataSource):
             # Variable data is stored in a 3D array (1, height, width)
             if len(band_data.shape) == 3:
                 bands_data.append(band_data[0, :, :])
-        tif_data = np.array(bands_data)  # shape (num_bands, height, width)
+        tif_data = np.array(bands_data)  # (num_bands, height, width)
         # Get metadata for the GeoTIFF
         lat = nc.variables["latitude"][:]
         lon = nc.variables["longitude"][:]
@@ -197,16 +197,16 @@ class ERA5LandMonthlyMeans(DataSource):
                 "year": [f"{item.geometry.time_range[0].year}"],  # type: ignore
                 "month": [
                     f"{item.geometry.time_range[0].month:02d}"  # type: ignore
-                ],  # Zero-padded month
-                "time": ["00:00"],  # default to 00:00
+                ],
+                "time": ["00:00"],
                 "area": [
                     bounds[3],
                     bounds[0],
                     bounds[1],
                     bounds[2],
-                ],  # [max_lat, min_lon, min_lat, max_lon]
-                "data_format": "netcdf",  # default to netcdf
-                "download_format": "unarchived",  # default to unarchived
+                ],
+                "data_format": "netcdf",
+                "download_format": "unarchived",
             }
             with tempfile.TemporaryDirectory() as tmp_dir:
                 local_nc_fname = os.path.join(tmp_dir, f"{item.name}.nc")

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -50,8 +50,6 @@ class ERA5LandMonthlyMeans(DataSource):
             api_key: the API key
         """
         self.config = config
-        self.dataset = self.DATASET
-        self.product_type = self.PRODUCT_TYPE
 
         if api_key is None:
             api_key = os.environ["CDS_API_KEY"]
@@ -192,7 +190,7 @@ class ERA5LandMonthlyMeans(DataSource):
             # Send the request to the CDS API
             bounds = item.geometry.shp.bounds
             request = {
-                "product_type": [self.product_type],
+                "product_type": [self.PRODUCT_TYPE],
                 "variable": bands,
                 "year": [f"{item.geometry.time_range[0].year}"],  # type: ignore
                 "month": [
@@ -211,7 +209,7 @@ class ERA5LandMonthlyMeans(DataSource):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 local_nc_fname = os.path.join(tmp_dir, f"{item.name}.nc")
                 local_tif_fname = os.path.join(tmp_dir, f"{item.name}.tif")
-                self.client.retrieve(self.dataset, request, local_nc_fname)
+                self.client.retrieve(self.DATASET, request, local_nc_fname)
                 self._convert_nc_to_tif(
                     UPath(local_nc_fname),
                     UPath(local_tif_fname),

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -235,6 +235,8 @@ class ERA5LandMonthlyMeans(DataSource):
             if tile_store.is_raster_ready(item.name, bands):
                 continue
             # Send the request to the CDS API
+            # Given that ERA5 is at a very coarse resolution, we add a buffer of half a pixel size
+            # to the bounds to ensure that we fully cover the geometries
             bounds = item.geometry.shp.bounds
             request = {
                 "product_type": [self.PRODUCT_TYPE],
@@ -245,10 +247,10 @@ class ERA5LandMonthlyMeans(DataSource):
                 ],
                 "time": ["00:00"],
                 "area": [
-                    bounds[3],  # North
-                    bounds[0],  # West
-                    bounds[1],  # South
-                    bounds[2],  # East
+                    bounds[3] + self.PIXEL_SIZE / 2,  # North
+                    bounds[0] - self.PIXEL_SIZE / 2,  # West
+                    bounds[1] - self.PIXEL_SIZE / 2,  # South
+                    bounds[2] + self.PIXEL_SIZE / 2,  # East
                 ],
                 "data_format": self.DATA_FORMAT,
                 "download_format": self.DOWNLOAD_FORMAT,

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -157,6 +157,17 @@ class ERA5LandMonthlyMeans(DataSource):
         # Get metadata for the GeoTIFF
         lat = nc.variables["latitude"][:]
         lon = nc.variables["longitude"][:]
+        # Check the spacing of the grid, make sure it's uniform
+        for i in range(len(lon) - 1):
+            if lon[i + 1] - lon[i] != self.PIXEL_SIZE:
+                raise ValueError(
+                    f"Longitude spacing is not uniform: {lon[i + 1] - lon[i]}"
+                )
+        for i in range(len(lat) - 1):
+            if lat[i + 1] - lat[i] != self.PIXEL_SIZE:
+                raise ValueError(
+                    f"Latitude spacing is not uniform: {lat[i + 1] - lat[i]}"
+                )
         west = lon.min()
         north = lat.max()
         pixel_size_x, pixel_size_y = self.PIXEL_SIZE, self.PIXEL_SIZE

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -140,7 +140,7 @@ class ERA5LandMonthlyMeans(DataSource):
             # Variable data is stored in a 3D array (1, height, width)
             if len(band_data.shape) == 3:
                 bands_data.append(band_data[0, :, :])
-        tif_data = np.array(bands_data)  # (num_bands, height, width)
+        array = np.array(bands_data)  # (num_bands, height, width)
         # Get metadata for the GeoTIFF
         lat = nc.variables["latitude"][:]
         lon = nc.variables["longitude"][:]
@@ -153,15 +153,15 @@ class ERA5LandMonthlyMeans(DataSource):
             tif_path,
             "w",
             driver="GTiff",
-            height=tif_data.shape[1],
-            width=tif_data.shape[2],
-            count=tif_data.shape[0],
-            dtype=tif_data.dtype,
+            height=array.shape[1],
+            width=array.shape[2],
+            count=array.shape[0],
+            dtype=array.dtype,
             crs=crs,
             transform=transform,
         ) as dst:
-            for i in range(tif_data.shape[0]):
-                dst.write(tif_data[i, :, :], i + 1)  # Write each band to the GeoTIFF
+            for i in range(array.shape[0]):
+                dst.write(array[i, :, :], i + 1)  # Write each band to the GeoTIFF
 
     def ingest(
         self,

--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -1,0 +1,219 @@
+"""Data source for Copernicus Climate Data Store."""
+
+import os
+import tempfile
+
+import cdsapi
+import netCDF4
+import numpy as np
+import rasterio
+from dateutil.relativedelta import relativedelta
+from rasterio.transform import from_origin
+from upath import UPath
+
+from rslearn.config import QueryConfig, RasterLayerConfig
+from rslearn.const import WGS84_EPSG, WGS84_PROJECTION
+from rslearn.data_sources import DataSource, Item
+from rslearn.data_sources.utils import match_candidate_items_to_window
+from rslearn.log_utils import get_logger
+from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils import STGeometry
+
+logger = get_logger(__name__)
+
+
+class ERA5LandMonthlyMeans(DataSource):
+    """A data source for ingesting ERA5 land monthly averaged data from the Copernicus Climate Data Store.
+
+    The API key should be set via environment variable (CDS_API_KEY).
+    """
+
+    api_url = "https://cds.climate.copernicus.eu/api"
+
+    # see: https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means
+    DATASET = "reanalysis-era5-land-monthly-means"
+    PRODUCT_TYPE = "monthly_averaged_reanalysis"
+    PIXEL_SIZE = 0.1  # degrees, native resolution is 9km
+
+    # see: https://confluence.ecmwf.int/display/CKB/ERA5-Land%3A+data+documentation
+    # Table 2 & 3 for variable shortnames
+
+    def __init__(
+        self,
+        config: RasterLayerConfig,
+        api_key: str | None = None,
+    ):
+        """Initialize a new ERA5LandMonthlyMeans instance.
+
+        Args:
+            config: the LayerConfig of the layer containing this data source
+            api_key: the API key
+        """
+        self.config = config
+        self.dataset = self.DATASET
+        self.product_type = self.PRODUCT_TYPE
+
+        if api_key is None:
+            api_key = os.environ["CDS_API_KEY"]
+        # Follow CDS API docs: https://pypi.org/project/cdsapi/
+        # Copy both url and key to $HOME/.cdsapirc
+        with open(os.path.expanduser("~/.cdsapirc"), "w") as f:
+            f.write(f"url: {self.api_url}\nkey: {api_key}")
+
+        self.client = cdsapi.Client()
+
+    @staticmethod
+    def from_config(
+        config: RasterLayerConfig, ds_path: UPath
+    ) -> "ERA5LandMonthlyMeans":
+        """Creates a new ERA5LandMonthlyMeans instance from a configuration dictionary.
+
+        Args:
+            config: the LayerConfig of the layer containing this data source
+            ds_path: the path to the data source
+
+        Returns:
+            A new ERA5LandMonthlyMeans instance
+        """
+        if config.data_source is None:
+            raise ValueError("data_source is required")
+        d = config.data_source.config_dict
+        return ERA5LandMonthlyMeans(
+            config=config,
+            api_key=d["api_key"],
+        )
+
+    def get_items(
+        self, geometries: list[STGeometry], query_config: QueryConfig
+    ) -> list[list[list[Item]]]:
+        """Get a list if items in the data source intersecting the given geometries.
+
+        Args:
+            geometries: the spatiotemporal geometries
+            query_config: the query configuration
+
+        Returns:
+            List of groups of items that should be retrieved for each geometry.
+        """
+        wgs84_geometries = [
+            geometry.to_projection(WGS84_PROJECTION) for geometry in geometries
+        ]
+        groups = []
+        for geometry in wgs84_geometries:
+            cur_items = []
+            # Create an item for each year & month within the time range
+            start_date = geometry.time_range[0].replace(day=1)  # type: ignore
+            end_date = geometry.time_range[1].replace(day=1)  # type: ignore
+            while start_date <= end_date:
+                # Get the first and last day of the current year & month
+                # Use this as the item's time range
+                item_start_date, item_end_date = (
+                    start_date,
+                    start_date + relativedelta(months=1) - relativedelta(days=1),
+                )
+                item_geometry = STGeometry(
+                    geometry.projection, geometry.shp, (item_start_date, item_end_date)
+                )
+                item_bounds = item_geometry.shp.bounds
+                item_name = f"{item_bounds[0]}_{item_bounds[1]}_{item_start_date.year}_{item_start_date.month:02d}"
+                item = Item(item_name, item_geometry)
+                cur_items.append(item)
+                start_date += relativedelta(months=1)
+            cur_groups = match_candidate_items_to_window(
+                geometry, cur_items, query_config
+            )
+            groups.append(cur_groups)
+
+        return groups
+
+    def _convert_nc_to_tif(self, nc_path: UPath, tif_path: UPath) -> None:
+        """Convert a netCDF file to a GeoTIFF file.
+
+        Args:
+            nc_path: the path to the netCDF file
+            tif_path: the path to the output GeoTIFF file
+        """
+        nc = netCDF4.Dataset(nc_path)
+        bands_data = []
+        for band_name in nc.variables:
+            band_data = nc.variables[band_name]
+            # Variable data is stored in a 3D array (1, height, width)
+            if len(band_data.shape) == 3:
+                bands_data.append(band_data[0, :, :])
+        tif_data = np.array(bands_data)  # shape (num_bands, height, width)
+        # Get metadata for the GeoTIFF
+        lat = nc.variables["latitude"][:]
+        lon = nc.variables["longitude"][:]
+        west = lon.min()
+        north = lat.max()
+        pixel_size_x, pixel_size_y = self.PIXEL_SIZE, self.PIXEL_SIZE
+        transform = from_origin(west, north, pixel_size_x, pixel_size_y)
+        crs = f"EPSG:{WGS84_EPSG}"
+        with rasterio.open(
+            tif_path,
+            "w",
+            driver="GTiff",
+            height=tif_data.shape[1],
+            width=tif_data.shape[2],
+            count=tif_data.shape[0],
+            dtype=tif_data.dtype,
+            crs=crs,
+            transform=transform,
+        ) as dst:
+            for i in range(tif_data.shape[0]):
+                dst.write(tif_data[i, :, :], i + 1)  # Write each band to the GeoTIFF
+
+    def ingest(
+        self,
+        tile_store: TileStoreWithLayer,
+        items: list[Item],
+        geometries: list[list[STGeometry]],
+    ) -> None:
+        """Ingest items into the given tile store.
+
+        Args:
+            tile_store: the tile store to ingest into
+            items: the items to ingest
+            geometries: a list of geometries needed for each item
+        """
+        bands = []
+        for band_set in self.config.band_sets:
+            if band_set.bands is None:
+                continue
+            for band in band_set.bands:
+                if band in bands:
+                    continue
+                bands.append(band)
+
+        for item in items:
+            if tile_store.is_raster_ready(item.name, bands):
+                continue
+
+            # Send the request to the CDS API
+            bounds = item.geometry.shp.bounds
+            request = {
+                "product_type": [self.product_type],
+                "variable": bands,
+                "year": [f"{item.geometry.time_range[0].year}"],  # type: ignore
+                "month": [
+                    f"{item.geometry.time_range[0].month:02d}"  # type: ignore
+                ],  # Zero-padded month
+                "time": ["00:00"],  # default to 00:00
+                "area": [
+                    bounds[3],
+                    bounds[0],
+                    bounds[1],
+                    bounds[2],
+                ],  # [max_lat, min_lon, min_lat, max_lon]
+                "data_format": "netcdf",  # default to netcdf
+                "download_format": "unarchived",  # default to unarchived
+            }
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                local_nc_fname = os.path.join(tmp_dir, f"{item.name}.nc")
+                local_tif_fname = os.path.join(tmp_dir, f"{item.name}.tif")
+                self.client.retrieve(self.dataset, request, local_nc_fname)
+                self._convert_nc_to_tif(
+                    UPath(local_nc_fname),
+                    UPath(local_tif_fname),
+                )
+                tile_store.write_raster_file(item.name, bands, UPath(local_tif_fname))

--- a/tests/integration/data_sources/test_climate_data_store.py
+++ b/tests/integration/data_sources/test_climate_data_store.py
@@ -1,0 +1,68 @@
+import os
+import pathlib
+import random
+
+from upath import UPath
+
+from rslearn.config import (
+    BandSetConfig,
+    DType,
+    LayerType,
+    QueryConfig,
+    RasterLayerConfig,
+    SpaceMode,
+    TimeMode,
+)
+from rslearn.data_sources.climate_data_store import ERA5LandMonthlyMeans
+from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
+from rslearn.utils import STGeometry
+
+
+class TestERA5LandMonthlyMeans:
+    """Tests the ERA5LandMonthlyMeans data source from the Climate Data Store."""
+
+    TEST_BANDS = ["2t", "tp"]  # 2m temperature and total precipitation
+
+    def run_simple_test(self, tile_store_dir: UPath, seattle2020: STGeometry) -> None:
+        """Apply test where we ingest an item corresponding to seattle2020."""
+        layer_config = RasterLayerConfig(
+            LayerType.RASTER,
+            [BandSetConfig(config_dict={}, dtype=DType.FLOAT32, bands=self.TEST_BANDS)],
+        )
+        query_config = QueryConfig(
+            space_mode=SpaceMode.INTERSECTS,
+            time_mode=TimeMode.WITHIN,
+            max_matches=2,  # We expect two items to match
+        )
+        data_source = ERA5LandMonthlyMeans(config=layer_config)
+        print("get items")
+        item_groups = data_source.get_items([seattle2020], query_config)[0]  # type: ignore
+        item_0 = item_groups[0][0]
+        item_1 = item_groups[1][0]
+        tile_store = DefaultTileStore(str(tile_store_dir))
+        tile_store.set_dataset_path(tile_store_dir)
+        layer_name = "layer"
+        print("ingest")
+        data_source.ingest(
+            TileStoreWithLayer(tile_store, layer_name), item_groups[0], [[seattle2020]]
+        )
+        data_source.ingest(
+            TileStoreWithLayer(tile_store, layer_name), item_groups[1], [[seattle2020]]
+        )
+        assert tile_store.is_raster_ready(layer_name, item_0.name, self.TEST_BANDS)
+        assert tile_store.is_raster_ready(layer_name, item_1.name, self.TEST_BANDS)
+
+    def test_local(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
+        """Test ingesting to local filesystem."""
+        tile_store_dir = UPath(tmp_path) / "tiles"
+        tile_store_dir.mkdir(parents=True, exist_ok=True)
+        self.run_simple_test(tile_store_dir, seattle2020)
+
+    def test_gcs(self, seattle2020: STGeometry) -> None:
+        """Test ingesting to GCS."""
+        test_id = random.randint(10000, 99999)
+        bucket_name = os.environ["TEST_BUCKET"]
+        prefix = os.environ["TEST_PREFIX"]
+        test_path = UPath(f"gcs://{bucket_name}/{prefix}/test_{test_id}")
+        tile_store_dir = test_path / "tiles"
+        self.run_simple_test(tile_store_dir, seattle2020)

--- a/tests/integration/data_sources/test_climate_data_store.py
+++ b/tests/integration/data_sources/test_climate_data_store.py
@@ -54,7 +54,6 @@ class TestERA5LandMonthlyMeans:
 
     def test_local(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
         """Test ingesting to local filesystem."""
-        tmp_path = pathlib.Path.cwd()
         tile_store_dir = UPath(tmp_path) / "tiles"
         tile_store_dir.mkdir(parents=True, exist_ok=True)
         self.run_simple_test(tile_store_dir, seattle2020)

--- a/tests/integration/data_sources/test_climate_data_store.py
+++ b/tests/integration/data_sources/test_climate_data_store.py
@@ -54,6 +54,7 @@ class TestERA5LandMonthlyMeans:
 
     def test_local(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
         """Test ingesting to local filesystem."""
+        tmp_path = pathlib.Path.cwd()
         tile_store_dir = UPath(tmp_path) / "tiles"
         tile_store_dir.mkdir(parents=True, exist_ok=True)
         self.run_simple_test(tile_store_dir, seattle2020)


### PR DESCRIPTION
For ERA5 data, I used the Climate Data Store (CDS) api: https://cds.climate.copernicus.eu/how-to-api. The ERA5-Land monthly averaged data from 1950 to present, specifically monthly averaged analysis data, link: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means?tab=download, has been added.

Since it's monthly data, I created one item per month, and its time_range covers the start and end date for a month. For a given STGeometry, it will generate all the year & month items within its time_range. 