### PR TITLE
move context setting within main

### DIFF
--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -712,8 +712,17 @@ def model_predict() -> None:
 
 def main() -> None:
     """CLI entrypoint."""
-    multiprocessing.set_start_method(MULTIPROCESSING_CONTEXT)
-    logger.info(f"Using multiprocessing context: {multiprocessing.get_context()}")
+    try:
+        multiprocessing.set_start_method(MULTIPROCESSING_CONTEXT)
+    except RuntimeError as e:
+        logger.error(
+            f"Multiprocessing context already set to {multiprocessing.get_context()}: "
+            + f"ignoring {e}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to set multiprocessing context: {e}")
+    finally:
+        logger.info(f"Using multiprocessing context: {multiprocessing.get_context()}")
     parser = argparse.ArgumentParser(description="rslearn")
     parser.add_argument(
         "category", help="Command category: dataset, annotate, or model"

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -721,6 +721,7 @@ def main() -> None:
         )
     except Exception as e:
         logger.error(f"Failed to set multiprocessing context: {e}")
+        raise e
     finally:
         logger.info(f"Using multiprocessing context: {multiprocessing.get_context()}")
     parser = argparse.ArgumentParser(description="rslearn")

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -33,6 +33,8 @@ handler_registry = {}
 
 ItemType = TypeVar("ItemType", bound="Item")
 
+MULTIPROCESSING_CONTEXT = "forkserver"
+
 
 def register_handler(category: Any, command: str) -> Callable:
     """Register a new handler for a command."""
@@ -710,6 +712,8 @@ def model_predict() -> None:
 
 def main() -> None:
     """CLI entrypoint."""
+    multiprocessing.set_start_method(MULTIPROCESSING_CONTEXT)
+    logger.info(f"Using multiprocessing context: {multiprocessing.get_context()}")
     parser = argparse.ArgumentParser(description="rslearn")
     parser.add_argument(
         "category", help="Command category: dataset, annotate, or model"
@@ -726,5 +730,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method("forkserver")
     main()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import subprocess
 import sys
 from datetime import datetime, timezone
 from typing import Any
@@ -177,6 +178,24 @@ class TestIngestion:
         rslearn.main.main()
 
         assert not ingested_fname.exists()
+
+    def test_ingestion_from_command_line(
+        self, prepared_dataset: Dataset, ingested_fname: UPath, monkeypatch: Any
+    ) -> None:
+        args = [
+            "rslearn",
+            "dataset",
+            "ingest",
+            "--root",
+            str(prepared_dataset.path),
+            "--disabled-layers",
+            "sentinel2",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
+
+        subprocess.run(args, check=True)
+
+        assert ingested_fname.exists()
 
     def test_ingest_ignore_errors(
         self, prepared_dataset: Dataset, ingested_fname: UPath, monkeypatch: Any


### PR DESCRIPTION
When we call the main cli through rslearn dataset materialize (or a similar command we are calling the main function directly so the mp context is not set from the if __name__ == "__main__":. We set it in the main function instead so it works for the entire rslearn main cli