### PR TITLE
Henryh/bumpdockerfiletorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime@sha256:58a28ab734f23561aa146fbaf777fb319a953ca1e188832863ed57d510c9f197
+FROM pytorch/pytorch:2.5.0-cuda11.8-cudnn9-runtime@sha256:d15e9803095e462e351f097fb1f5e7cdaa4f5e855d7ff6d6f36ec4c2aa2938ea
 
 # Weirdly this stopped working
 # RUN apt-get update \
@@ -16,4 +16,4 @@ COPY ./test_requirements.txt /rslearn/test_requirements.txt
 RUN pip install --no-cache-dir -r test_requirements.txt
 
 COPY ./ /rslearn
-RUN pip install --no-cache-dir  .
+RUN pip install --no-cache-dir  rslearn[extra]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY ./test_requirements.txt /rslearn/test_requirements.txt
 RUN pip install --no-cache-dir -r test_requirements.txt
 
 COPY ./ /rslearn
-RUN pip install --no-cache-dir  rslearn[extra]
+RUN pip install --no-cache-dir  .

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -3,7 +3,6 @@ accelerate>=1.0
 cdsapi>=0.7.4
 earthengine-api>=0.1
 einops>=0.8
-gcsfs>=2024.10
 google-cloud-bigquery>=2.18
 google-cloud-storage>=2.18
 interrogate>=1.7

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -11,7 +11,6 @@ osmium>=3.7
 planet>=2.10
 pycocotools>=2.0
 rtree>=1.2
-s3fs>=2024.10.0
 satlaspretrain_models>=0.3
 scipy>=1.13
 transformers>=4.45


### PR DESCRIPTION
Also, solves dependency issue occuring in rslp where pip picks different version of gcsfs when installing from extra_requirements.txt in pip install rslearn[extra]. This issue appears because there is a new latest gcsfs package available as of this afternoon.