### PR TITLE
Fix bug in AWS Landsat data source where cloud cover is not used correctly

### DIFF
--- a/rslearn/data_sources/aws_landsat.py
+++ b/rslearn/data_sources/aws_landsat.py
@@ -180,7 +180,7 @@ class LandsatOliTirs(DataSource):
                             name=metadata["PRODUCT_CONTENTS"]["LANDSAT_PRODUCT_ID"],
                             geometry=geometry,
                             blob_path=blob_path,
-                            cloud_cover=image_attributes["CLOUD_COVER"],
+                            cloud_cover=float(image_attributes["CLOUD_COVER"]),
                         )
                     )
 
@@ -293,7 +293,7 @@ class LandsatOliTirs(DataSource):
                 cur_items.append(item)
 
             if self.sort_by == "cloud_cover":
-                items.sort(key=lambda item: item.cloud_cover)
+                cur_items.sort(key=lambda item: item.cloud_cover)
             elif self.sort_by is not None:
                 raise ValueError(f"invalid sort_by setting ({self.sort_by})")
 


### PR DESCRIPTION
It was string so sorting would not be in the right order.
And then also it wasn't sorting the right list.

I added a test that fails without this fix.