### PR TITLE
Fix bug in NAIP data source relating to writing manifest partially.

### DIFF
--- a/rslearn/data_sources/aws_open_data.py
+++ b/rslearn/data_sources/aws_open_data.py
@@ -141,7 +141,7 @@ class Naip(DataSource):
         """
         manifest_path = self.index_cache_dir / self.manifest_fname
         if not manifest_path.exists():
-            with manifest_path.open("wb") as dst:
+            with open_atomic(manifest_path, "wb") as dst:
                 self.bucket.download_fileobj(
                     self.manifest_fname,
                     dst,


### PR DESCRIPTION
It was not using open_atomic so if manifest.txt was written partially by previous attempt, then the next time it would assume it was fully downloaded already and then it would create a partial rtree index and stuff.