### PR TITLE
Add class_names/class_property_name to dataset config file

### DIFF
--- a/tests/unit/config/test_dataset.py
+++ b/tests/unit/config/test_dataset.py
@@ -1,0 +1,47 @@
+"""Test the dataset configuration file.
+
+Mostly just makes sure there aren't runtime errors with the parsing.
+"""
+
+from rslearn.config import RasterLayerConfig, VectorLayerConfig
+
+
+class TestBandSetConfig:
+    """Test BandSetConfig."""
+
+    def test_class_names_option(self) -> None:
+        """Verify that config parsing works when class_names option is set."""
+        class_names = ["class0", "class1", "class2"]
+        layer_cfg_dict = {
+            "type": "raster",
+            "band_sets": [
+                {
+                    "dtype": "uint8",
+                    "bands": ["class"],
+                    "class_names": [class_names],
+                }
+            ],
+        }
+        layer_cfg = RasterLayerConfig.from_config(layer_cfg_dict)
+        assert len(layer_cfg.band_sets) == 1
+        band_set = layer_cfg.band_sets[0]
+        assert len(band_set.bands) == 1
+        assert band_set.class_names is not None
+        assert band_set.class_names[0] == class_names
+
+
+class TestVectorLayerConfig:
+    """Test VectorLayerConfig."""
+
+    def test_class_names_option(self) -> None:
+        """Verify that config parsing works when property_name/class_names are set."""
+        property_name = "my_class_prop"
+        class_names = ["class0", "class1", "class2"]
+        layer_cfg_dict = {
+            "type": "vector",
+            "class_property_name": property_name,
+            "class_names": class_names,
+        }
+        layer_cfg = VectorLayerConfig.from_config(layer_cfg_dict)
+        assert layer_cfg.class_property_name == property_name
+        assert layer_cfg.class_names == class_names


### PR DESCRIPTION
These are for annotation / prediction layers to indicate which GeoJSON properties correspond to some notion of a class, or for non-image single-band GeoTIFFs to define what the different values in the band mean.

It could be useful in the future to do things like rasterize a vector layer to a corresponding raster layer; or we can move some similar definitions from model configuration file to dataset configuration file (e.g. make property_name/classes unnecessary in rslearn.train.tasks.classification.ClassificationTask). For now it will be used for ES Studio syncing.