### PR TITLE
Fix issue where tmp files created by open_atomic cause error in DefaultTileStore

### DIFF
--- a/rslearn/tile_stores/default.py
+++ b/rslearn/tile_stores/default.py
@@ -14,6 +14,7 @@ from upath import UPath
 from rslearn.utils import Feature, PixelBounds, Projection, STGeometry
 from rslearn.utils.fsspec import (
     join_upath,
+    open_atomic,
     open_rasterio_upath_reader,
     open_rasterio_upath_writer,
 )
@@ -75,10 +76,47 @@ class DefaultTileStore(TileStore):
     def _get_raster_dir(
         self, layer_name: str, item_name: str, bands: list[str]
     ) -> UPath:
+        """Get the directory where the specified raster is stored.
+
+        Args:
+            layer_name: the name of the dataset layer.
+            item_name: the name of the item from the data source.
+            bands: list of band names that are expected to be stored together.
+
+        Returns:
+            the UPath directory where the raster should be stored.
+        """
         assert self.path is not None
         if any(["_" in band for band in bands]):
             raise ValueError("band names must not contain '_'")
         return self.path / layer_name / item_name / "_".join(bands)
+
+    def _get_raster_fname(
+        self, layer_name: str, item_name: str, bands: list[str]
+    ) -> UPath:
+        """Get the filename of the specified raster.
+
+        Args:
+            layer_name: the name of the dataset layer.
+            item_name: the name of the item from the data source.
+            bands: list of band names that are expected to be stored together.
+
+        Returns:
+            the UPath filename of the raster, which should be readable by rasterio.
+
+        Raises:
+            ValueError: if no file is found.
+        """
+        raster_dir = self._get_raster_dir(layer_name, item_name, bands)
+        for fname in raster_dir.iterdir():
+            # Ignore completed sentinel files as well as temporary files created by
+            # open_atomic (in case this tile store is on local filesystem).
+            if fname.name == COMPLETED_FNAME:
+                continue
+            if ".tmp." in fname.name:
+                continue
+            return fname
+        raise ValueError(f"no raster found in {raster_dir}")
 
     def is_raster_ready(
         self, layer_name: str, item_name: str, bands: list[str]
@@ -134,12 +172,7 @@ class DefaultTileStore(TileStore):
         Returns:
             the bounds of the raster in the projection.
         """
-        raster_dir = self._get_raster_dir(layer_name, item_name, bands)
-        fnames = [
-            fname for fname in raster_dir.iterdir() if fname.name != COMPLETED_FNAME
-        ]
-        assert len(fnames) == 1
-        raster_fname = fnames[0]
+        raster_fname = self._get_raster_fname(layer_name, item_name, bands)
 
         with open_rasterio_upath_reader(raster_fname) as src:
             with rasterio.vrt.WarpedVRT(src, crs=projection.crs) as vrt:
@@ -179,12 +212,7 @@ class DefaultTileStore(TileStore):
         Returns:
             the raster data
         """
-        raster_dir = self._get_raster_dir(layer_name, item_name, bands)
-        fnames = [
-            fname for fname in raster_dir.iterdir() if fname.name != COMPLETED_FNAME
-        ]
-        assert len(fnames) == 1
-        raster_fname = fnames[0]
+        raster_fname = self._get_raster_fname(layer_name, item_name, bands)
 
         # Construct the transform to use for the warped dataset.
         wanted_transform = affine.Affine(
@@ -275,7 +303,7 @@ class DefaultTileStore(TileStore):
             # Just copy the file directly.
             dst_fname = raster_dir / fname.name
             with fname.open("rb") as src:
-                with dst_fname.open("wb") as dst:
+                with open_atomic(dst_fname, "wb") as dst:
                     shutil.copyfileobj(src, dst)
 
         (raster_dir / COMPLETED_FNAME).touch()


### PR DESCRIPTION
Fix issue where tmp files created by open_atomic cause error in DefaultTileStore.

The tmp files are created if there is an error during atomic write. The atomic write successfully prevents the actual filename from being written to, but the caller is expected to ignore these additional files that could get created.

Resolves #125.