### PR TITLE
Improve the API for RasterFormat and VectorFormat.

### DIFF
--- a/rslearn/data_sources/raster_source.py
+++ b/rslearn/data_sources/raster_source.py
@@ -157,8 +157,6 @@ def materialize_raster(
     window_projection, window_bounds = band_cfg.get_final_projection_and_bounds(
         window.projection, window.bounds
     )
-    if window_bounds is None:
-        raise ValueError(f"No windowbounds specified for {layer_name}")
     # Re-project to just extract the window.
     array = raster.read()
     window_width = window_bounds[2] - window_bounds[0]

--- a/rslearn/train/prediction_writer.py
+++ b/rslearn/train/prediction_writer.py
@@ -182,6 +182,4 @@ class RslearnWriter(BasePredictionWriter):
                 )
 
             elif self.layer_config.layer_type == LayerType.VECTOR:
-                self.format.encode_vector(
-                    layer_dir, metadata["projection"], pending_output
-                )
+                self.format.encode_vector(layer_dir, pending_output)

--- a/rslearn/utils/feature.py
+++ b/rslearn/utils/feature.py
@@ -11,7 +11,7 @@ from .geometry import Projection, STGeometry
 class Feature:
     """A GeoJSON-like feature that contains one vector geometry."""
 
-    def __init__(self, geometry: STGeometry, properties: dict[str, Any] | None = {}):
+    def __init__(self, geometry: STGeometry, properties: dict[str, Any] = {}):
         """Initialize a new Feature.
 
         Args:

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -10,6 +10,7 @@ import rasterio
 from class_registry import ClassRegistry
 from PIL import Image
 from rasterio.crs import CRS
+from rasterio.enums import Resampling
 from upath import UPath
 
 from rslearn.config import RasterFormatConfig
@@ -64,6 +65,25 @@ def get_raster_projection_and_bounds(
     )
 
 
+def get_transform_from_projection_and_bounds(
+    projection: Projection, bounds: PixelBounds
+) -> affine.Affine:
+    """Get the affine transform that corresponds to the given projection and bounds.
+
+    Args:
+        projection: the projection. Only the resolutions are used.
+        bounds: the bounding box. Only the top-left corner is used.
+    """
+    return affine.Affine(
+        projection.x_resolution,
+        0,
+        bounds[0] * projection.x_resolution,
+        0,
+        projection.y_resolution,
+        bounds[1] * projection.y_resolution,
+    )
+
+
 class RasterFormat:
     """An abstract class for writing raster data.
 
@@ -89,16 +109,22 @@ class RasterFormat:
         raise NotImplementedError
 
     def decode_raster(
-        self, path: UPath, bounds: PixelBounds
-    ) -> npt.NDArray[Any] | None:
+        self,
+        path: UPath,
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+    ) -> npt.NDArray[Any]:
         """Decodes raster data.
 
         Args:
             path: the directory to read from
-            bounds: the bounds of the raster to read
+            projection: the projection to read the raster in.
+            bounds: the bounds to read in the given projection.
+            resampling: resampling method to use in case resampling is needed.
 
         Returns:
-            the raster data, or None if no image content is found
+            the raster data
         """
         raise NotImplementedError
 
@@ -197,6 +223,19 @@ class ImageTileRasterFormat(RasterFormat):
             bounds: the bounds of the raster data in the projection
             array: the raster data (must be CHW)
         """
+        # Write metadata about the projection that we are writing under.
+        # We also save dtype and number of bands so we can return correct shape when
+        # there are no intersecting tiles.
+        with (path / "metadata.json").open("w") as f:
+            json.dump(
+                {
+                    "projection": projection.serialize(),
+                    "dtype": array.dtype.name,
+                    "num_bands": array.shape[0],
+                },
+                f,
+            )
+
         start_tile = (bounds[0] // self.tile_size, bounds[1] // self.tile_size)
         end_tile = (bounds[2] // self.tile_size + 1, bounds[3] // self.tile_size + 1)
         extension = self.get_extension()
@@ -235,17 +274,34 @@ class ImageTileRasterFormat(RasterFormat):
                     self.encode_tile(f, projection, cur_bounds, cur_array)
 
     def decode_raster(
-        self, path: UPath, bounds: PixelBounds
-    ) -> npt.NDArray[Any] | None:
+        self,
+        path: UPath,
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+    ) -> npt.NDArray[Any]:
         """Decodes raster data.
 
         Args:
             path: the directory to read from
-            bounds: the bounds of the raster to read
+            projection: the projection to read the raster in.
+            bounds: the bounds to read in the given projection.
+            resampling: resampling method to use in case resampling is needed.
 
         Returns:
-            the raster data, or None if no image content is found
+            the raster data
         """
+        # Verify that the source data has the same projection as the requested one.
+        # ImageTileRasterFormat currently does not support re-projecting.
+        with (path / "metadata.json").open() as f:
+            image_metadata = json.load(f)
+        source_data_projection = Projection.deserialize(image_metadata["projection"])
+        if source_data_projection != projection:
+            raise NotImplementedError(
+                "not implemented to re-project source data "
+                + f"(source projection {source_data_projection} does not match requested projection {projection})"
+            )
+
         extension = self.get_extension()
 
         # Load tiles one at a time.
@@ -254,7 +310,12 @@ class ImageTileRasterFormat(RasterFormat):
             (bounds[2] - 1) // self.tile_size + 1,
             (bounds[3] - 1) // self.tile_size + 1,
         )
-        dst = None
+        dst_shape = (
+            image_metadata["num_bands"],
+            bounds[3] - bounds[1],
+            bounds[2] - bounds[0],
+        )
+        dst = np.zeros(dst_shape, dtype=image_metadata["dtype"])
         for col in range(start_tile[0], end_tile[0]):
             for row in range(start_tile[1], end_tile[1]):
                 fname = path / f"{col}_{row}.{extension}"
@@ -403,82 +464,40 @@ class GeotiffRasterFormat(RasterFormat):
             dst.write(array)
 
     def decode_raster(
-        self, path: UPath, bounds: PixelBounds, fname: str | None = None
+        self,
+        path: UPath,
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+        fname: str | None = None,
     ) -> npt.NDArray[Any]:
         """Decodes raster data.
 
         Args:
             path: the directory to read from
-            bounds: the bounds of the raster to read
+            projection: the projection to read the raster in.
+            bounds: the bounds to read in the given projection.
+            resampling: resampling method to use in case resampling is needed.
             fname: override the filename to read from
 
         Returns:
-            the raster data, or None if no image content is found
+            the raster data
         """
         if fname is None:
             fname = self.fname
 
+        # Construct the transform to use for the warped dataset.
+        wanted_transform = get_transform_from_projection_and_bounds(projection, bounds)
         with open_rasterio_upath_reader(path / fname) as src:
-            transform = src.transform
-            x_resolution = transform.a
-            y_resolution = transform.e
-            offset = (
-                int(transform.c / x_resolution),
-                int(transform.f / y_resolution),
-            )
-            # bounds is in global pixel coordinates.
-            # We first convert that to pixels relative to top-left of the raster.
-            relative_bounds = [
-                bounds[0] - offset[0],
-                bounds[1] - offset[1],
-                bounds[2] - offset[0],
-                bounds[3] - offset[1],
-            ]
-
-            # Make sure the requested bounds intersects the raster, otherwise the
-            # windowed read cannot be performed.
-            if (
-                relative_bounds[2] < 0
-                or relative_bounds[3] < 0
-                or relative_bounds[0] >= src.width
-                or relative_bounds[1] >= src.height
-            ):
-                # Assume all of the bands have the same dtype, so just use first
-                # one (src.dtypes is list of dtype per band).
-                return np.zeros(
-                    (src.count, bounds[3] - bounds[1], bounds[2] - bounds[0]),
-                    dtype=src.dtypes[0],
-                )
-
-            # Now get the actual pixels we will read, which must be contained in
-            # the GeoTIFF.
-            # Padding is (before_x, before_y, after_x, after_y) and will be used to
-            # pad the output back to the originally requested bounds.
-            padding = [0, 0, 0, 0]
-            if relative_bounds[0] < 0:
-                padding[0] = -relative_bounds[0]
-                relative_bounds[0] = 0
-            if relative_bounds[1] < 0:
-                padding[1] = -relative_bounds[1]
-                relative_bounds[1] = 0
-            if relative_bounds[2] > src.width:
-                padding[2] = relative_bounds[2] - src.width
-                relative_bounds[2] = src.width
-            if relative_bounds[3] > src.height:
-                padding[3] = relative_bounds[3] - src.height
-                relative_bounds[3] = src.height
-
-            window = rasterio.windows.Window(
-                relative_bounds[0],
-                relative_bounds[1],
-                relative_bounds[2] - relative_bounds[0],
-                relative_bounds[3] - relative_bounds[1],
-            )
-            array = src.read(window=window)
-            array = np.pad(
-                array, ((0, 0), (padding[1], padding[3]), (padding[0], padding[2]))
-            )
-            return array
+            with rasterio.vrt.WarpedVRT(
+                src,
+                crs=projection.crs,
+                transform=wanted_transform,
+                width=bounds[2] - bounds[0],
+                height=bounds[3] - bounds[1],
+                resampling=resampling,
+            ) as vrt:
+                return vrt.read()
 
     def get_raster_bounds(self, path: UPath) -> PixelBounds:
         """Returns the bounds of the stored raster.
@@ -564,35 +583,57 @@ class SingleImageRasterFormat(RasterFormat):
             if array.shape[2] == 1:
                 array = array[:, :, 0]
             Image.fromarray(array).save(f, format=self.format.upper())
+
+        # Since the image file doesn't include the georeferencing, we store it in an
+        # auxiliary metadata file.
         with (path / "metadata.json").open("w") as f:
             json.dump(
                 {
+                    "projection": projection.serialize(),
                     "bounds": bounds,
                 },
                 f,
             )
 
     def decode_raster(
-        self, path: UPath, bounds: PixelBounds
-    ) -> npt.NDArray[Any] | None:
+        self,
+        path: UPath,
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+    ) -> npt.NDArray[Any]:
         """Decodes raster data.
 
         Args:
             path: the directory to read from
-            bounds: the bounds of the raster to read
+            projection: the projection to read the raster in.
+            bounds: the bounds to read in the given projection.
+            resampling: resampling method to use in case resampling is needed.
 
         Returns:
-            the raster data, or None if no image content is found
+            the raster data
         """
-        image_fname = path / ("image." + self.get_extension())
+        # Try to get the bounds of the saved image from the metadata file.
+        # In old versions, the file may be missing the projection key.
         metadata_fname = path / "metadata.json"
-        if metadata_fname.exists():
-            with metadata_fname.open() as f:
-                image_bounds = json.load(f)["bounds"]
-        else:
-            # Backwards compatibility -- assume that requested bounds matches the window bounds.
-            image_bounds = bounds
+        with metadata_fname.open() as f:
+            image_metadata = json.load(f)
 
+        image_bounds = image_metadata["bounds"]
+
+        # If the projection key is set, verify that it matches the requested projection
+        # since SingleImageRasterFormat currently does not support re-projecting.
+        if "projection" in image_metadata:
+            source_data_projection = Projection.deserialize(
+                image_metadata["projection"]
+            )
+            if projection != source_data_projection:
+                raise NotImplementedError(
+                    "not implemented to re-project source data "
+                    + f"(source projection {source_data_projection} does not match requested projection {projection})"
+                )
+
+        image_fname = path / ("image." + self.get_extension())
         with image_fname.open("rb") as f:
             array = np.array(Image.open(f, formats=[self.format.upper()]))
 

--- a/tests/fixtures/datasets/image_to_class.py
+++ b/tests/fixtures/datasets/image_to_class.py
@@ -71,7 +71,7 @@ def image_to_class_dataset(tmp_path: pathlib.Path) -> Dataset:
 
     # Add label.
     feature = Feature(
-        STGeometry(WGS84_PROJECTION, shapely.Point(1, 1), None),
+        STGeometry(window.projection, shapely.Point(1, 1), None),
         {
             "label": 1,
         },
@@ -80,7 +80,6 @@ def image_to_class_dataset(tmp_path: pathlib.Path) -> Dataset:
     layer_dir = window.get_layer_dir(layer_name)
     GeojsonVectorFormat().encode_vector(
         layer_dir,
-        window.projection,
         [feature],
     )
     window.mark_layer_completed(layer_name)

--- a/tests/integration/data_sources/test_earthdata_srtm.py
+++ b/tests/integration/data_sources/test_earthdata_srtm.py
@@ -77,7 +77,9 @@ def test_materialize_capitol_hill(tmp_path: pathlib.Path) -> None:
     materialize_dataset_windows(dataset, windows)
 
     raster_dir = window.get_raster_dir(layer_name, [band_name])
-    array = GeotiffRasterFormat().decode_raster(raster_dir, window.bounds)
+    array = GeotiffRasterFormat().decode_raster(
+        raster_dir, window.projection, window.bounds
+    )
     # Roughly 80-120 meters.
     print(f"min={array.min()} max={array.max()}")
     assert array.min() > 80

--- a/tests/integration/data_sources/test_local_files.py
+++ b/tests/integration/data_sources/test_local_files.py
@@ -45,7 +45,7 @@ class TestLocalFiles:
         assert isinstance(layer_config, VectorLayerConfig)
         vector_format = load_vector_format(layer_config.format)
         features = vector_format.decode_vector(
-            window.path / "layers" / "local_file", window.bounds
+            window.path / "layers" / "local_file", window.projection, window.bounds
         )
 
         assert len(features) == 2
@@ -128,7 +128,7 @@ class TestLocalFiles:
         assert isinstance(layer_config, VectorLayerConfig)
         vector_format = load_vector_format(layer_config.format)
         features = vector_format.decode_vector(
-            window.path / "layers" / "local_file", window.bounds
+            window.path / "layers" / "local_file", window.projection, window.bounds
         )
         assert len(features) == 1
         assert features[0].properties is not None
@@ -200,7 +200,7 @@ class TestLocalFiles:
         window = windows[0]
         raster_dir = window.get_raster_dir(layer_name, ["b1", "b2"])
         materialized_image = GeotiffRasterFormat().decode_raster(
-            raster_dir, window.bounds
+            raster_dir, window.projection, window.bounds
         )
         assert (
             materialized_image[0, :, :].min() == 0
@@ -244,7 +244,7 @@ class TestCoordinateModes:
         src_data_dir = ds_path / "src_data"
         src_data_dir.mkdir(parents=True, exist_ok=True)
         vector_format = GeojsonVectorFormat(coordinate_mode=request.param)
-        vector_format.encode_vector(src_data_dir, self.source_data_projection, features)
+        vector_format.encode_vector(src_data_dir, features)
 
         dataset_config = {
             "layers": {

--- a/tests/integration/utils/test_s3_dataset.py
+++ b/tests/integration/utils/test_s3_dataset.py
@@ -92,7 +92,7 @@ class TestLocalFiles:
         assert isinstance(layer_config, VectorLayerConfig)
         vector_format = load_vector_format(layer_config.format)
         features = vector_format.decode_vector(
-            window.get_layer_dir("local_file"), window.bounds
+            window.get_layer_dir("local_file"), window.projection, window.bounds
         )
 
         assert len(features) == 2

--- a/tests/unit/utils/test_raster_format.py
+++ b/tests/unit/utils/test_raster_format.py
@@ -46,27 +46,34 @@ def test_geotiff_tiling(tmp_path: pathlib.Path) -> None:
 
 
 class TestGeotiffInOrOutOfBounds:
+    PROJECTION = Projection(CRS.from_epsg(3857), 1, -1)
+
     @pytest.fixture
     def encoded_raster_path(self, tmp_path: pathlib.Path) -> UPath:
         path = UPath(tmp_path)
-        projection = Projection(CRS.from_epsg(3857), 1, -1)
         array = np.ones((1, 8, 8), dtype=np.uint8)
-        GeotiffRasterFormat().encode_raster(path, projection, (0, 0, 8, 8), array)
+        GeotiffRasterFormat().encode_raster(path, self.PROJECTION, (0, 0, 8, 8), array)
         return path
 
     def test_geotiff_in_bounds(self, encoded_raster_path: UPath) -> None:
-        array = GeotiffRasterFormat().decode_raster(encoded_raster_path, (2, 2, 6, 6))
+        array = GeotiffRasterFormat().decode_raster(
+            encoded_raster_path, self.PROJECTION, (2, 2, 6, 6)
+        )
         assert array.shape == (1, 4, 4)
         assert np.all(array == 1)
 
     def test_geotiff_partial_overlap(self, encoded_raster_path: UPath) -> None:
-        array = GeotiffRasterFormat().decode_raster(encoded_raster_path, (4, 4, 12, 12))
+        array = GeotiffRasterFormat().decode_raster(
+            encoded_raster_path, self.PROJECTION, (4, 4, 12, 12)
+        )
         assert array.shape == (1, 8, 8)
         assert np.all(array[:, 0:4, 0:4] == 1)
         assert np.all(array[:, 0:8, 4:8] == 0)
 
     def test_geotiff_out_of_bounds(self, encoded_raster_path: UPath) -> None:
-        array = GeotiffRasterFormat().decode_raster(encoded_raster_path, (8, 8, 12, 12))
+        array = GeotiffRasterFormat().decode_raster(
+            encoded_raster_path, self.PROJECTION, (8, 8, 12, 12)
+        )
         assert array.shape == (1, 4, 4)
         assert np.all(array == 0)
 

--- a/tests/unit/utils/test_vector_format.py
+++ b/tests/unit/utils/test_vector_format.py
@@ -32,7 +32,7 @@ def test_geojson(
     out_dir = UPath(tmp_path)
     out_fname = out_dir / "data.geojson"
 
-    GeojsonVectorFormat(coordinate_mode).encode_vector(out_dir, projection, features)
+    GeojsonVectorFormat(coordinate_mode).encode_vector(out_dir, features)
     with out_fname.open() as f:
         fc = json.load(f)
         feat_x, feat_y = fc["features"][0]["geometry"]["coordinates"]
@@ -44,9 +44,6 @@ def test_geojson(
 
     elif coordinate_mode == GeojsonCoordinateMode.CRS:
         # In CRS mode, it should be in CRS coordinates.
-        GeojsonVectorFormat(GeojsonCoordinateMode.CRS).encode_vector(
-            out_dir, projection, features
-        )
         assert feat_x == pytest.approx(12340)
         assert feat_y == pytest.approx(-56780)
 
@@ -58,8 +55,11 @@ def test_geojson(
 
     # Make sure that when we read the features back, we get the same geometry as
     # before. The bounds is ignored since it is GeoJSON (no index).
-    result = GeojsonVectorFormat().decode_vector(out_dir, (0, 0, 0, 0))[0].geometry
-    result = result.to_projection(projection)
+    result = (
+        GeojsonVectorFormat()
+        .decode_vector(out_dir, projection, (col - 1, row - 1, col + 1, row + 1))[0]
+        .geometry
+    )
     assert result.shp.x == pytest.approx(geometry.shp.x)
     assert result.shp.y == pytest.approx(geometry.shp.y)
 


### PR DESCRIPTION
Improve the API for RasterFormat and VectorFormat.

RasterFormat: the previous API accepts a projection and bounds when encoding, but only bounds when decoding. This commit changes it to also accept projection when decoding, and the RasterFormat is expected to re-project the data to the requested projection. Previously, the caller had to do extra work to ensure the bounds provided exactly matches the projection of the actual raster. Now, if the caller wants data in a different projection they can pass it rather than re-projecting themselves.

VectorFormat: the previous API accepts a projection when encoding (no bounds), and bounds when decoding (no projection). Encoding is changed to accept neither projection nor bounds: neither are necessary since the Features include a projection. Decoding is changed to accept both a projection and bounds for similar reasons to RasterFormat.

The original motivation of this change was because of issues employing TileVectorFormat for the vector format used in DefaultTileStore, since the API didn't really support a way for windows in different projections to ask for portions of the vector data.

I think the new API makes a lot more sense because (a) passing around bounds without a corresponding projection is strange especially when the formats don't necessarily have a way to get the projection of the stored data, and (b) there was already some re-projecting logic in DefaultTileStore which now is just moved to VectorFormat/RasterFormat.