### PR TITLE
Fast geometry to_projection when dst crs matches src crs.

### DIFF
--- a/rslearn/utils/geometry.py
+++ b/rslearn/utils/geometry.py
@@ -262,8 +262,12 @@ class STGeometry:
             ),
         )
         # Change crs.
-        shp = rasterio.warp.transform_geom(self.projection.crs, projection.crs, shp)
-        shp = shapely.geometry.shape(shp)
+        # We only apply transform_geom if the CRS doesn't match, because even if we
+        # call transform_geom with the same source and destination CRS, it takes
+        # several milliseconds.
+        if self.projection.crs != projection.crs:
+            shp = rasterio.warp.transform_geom(self.projection.crs, projection.crs, shp)
+            shp = shapely.geometry.shape(shp)
         # Apply new resolution.
         shp = shapely.transform(
             shp,


### PR DESCRIPTION
The main motivation was to increase the speed of rtree index creation in the gcp_public_data data source. It seems rasterio.warp.transform_geom takes 10+ ms even when the src/dst CRS are the same, so skipping the call saves a lot of time when we are doing many re-projections.