### PR TITLE
Fix bug with multiple tags in a SplitConfig.

### DIFF
--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -335,11 +335,13 @@ class ModelDataset(torch.utils.data.Dataset):
             # Filter the window.options.
             new_windows = []
             for window in windows:
+                tags_passed = True
                 for k, v in split_config.tags.items():
                     if k not in window.options:
-                        continue
+                        tags_passed = False
                     if v and window.options[k] != v:
-                        continue
+                        tags_passed = False
+                if tags_passed:
                     new_windows.append(window)
             windows = new_windows
 


### PR DESCRIPTION
Previously if there are multiple tags, then a window would be added as a training example for each tag that it matches. This means there would be duplicates, and also it doesn't match the intended behavior where the tags are additive constraints (i.e. the overall op should be logical and of all the specified tags).

This commit fixes the bug.