### PR TITLE
Improve ERA5 data source to work with larger-scale window collections.

### DIFF
--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -1,5 +1,6 @@
 """Data source for Copernicus Climate Data Store."""
 
+import math
 import os
 import tempfile
 from datetime import datetime, timezone
@@ -9,18 +10,17 @@ import cdsapi
 import netCDF4
 import numpy as np
 import rasterio
+import shapely
 from dateutil.relativedelta import relativedelta
 from rasterio.transform import from_origin
-from shapely.geometry import box
 from upath import UPath
 
-from rslearn.config import QueryConfig, RasterLayerConfig
-from rslearn.const import WGS84_EPSG, WGS84_PROJECTION
+from rslearn.config import QueryConfig, RasterLayerConfig, SpaceMode
+from rslearn.const import WGS84_BOUNDS, WGS84_EPSG, WGS84_PROJECTION
 from rslearn.data_sources import DataSource, Item
-from rslearn.data_sources.utils import match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
-from rslearn.utils import STGeometry
+from rslearn.utils.geometry import STGeometry
 
 logger = get_logger(__name__)
 
@@ -28,12 +28,24 @@ logger = get_logger(__name__)
 class ERA5LandMonthlyMeans(DataSource):
     """A data source for ingesting ERA5 land monthly averaged data from the Copernicus Climate Data Store.
 
-    The API key should be set via environment variable (CDSAPI_KEY).
+    An API key must be passed either in the configuration or via the CDSAPI_KEY
+    environment variable. You can acquire an API key by going to the Climate Data Store
+    website (https://cds.climate.copernicus.eu/), registering an account and logging
+    in, and then
 
-    We recommend using the default number of workers (0, which means using the main process only)
-    and batch size equal to the number of windows when preparing the ERA5LandMonthlyMeans dataset,
-    as it will combine multiple geometries into a single CDS API request for each month to speed up
-    dataset ingestion.
+    The band names should match CDS variable names (see the reference at
+    https://confluence.ecmwf.int/display/CKB/ERA5-Land%3A+data+documentation). However,
+    replace "_" with "-" in the variable names when specifying bands in the layer
+    configuration.
+
+    This data source corresponds to the reanalysis-era5-land-monthly-means product.
+
+    All requests to the API will be for patches corresponding to the specified patch
+    size (defaulting to 10x10 degrees). The patch size defines a grid in WGS84
+    coordinates, and windows are matched to items that correspond to these grid cells.
+    (Temporally, the items are gridded by month.) Although the API supports arbitrary
+    bounds in the requests, using the fixed grid helps to minimize duplicative requests
+    across windows.
     """
 
     api_url = "https://cds.climate.copernicus.eu/api"
@@ -45,21 +57,24 @@ class ERA5LandMonthlyMeans(DataSource):
     DOWNLOAD_FORMAT = "unarchived"
     PIXEL_SIZE = 0.1  # degrees, native resolution is 9km
 
-    # CDS variable names reference: https://confluence.ecmwf.int/display/CKB/ERA5-Land%3A+data+documentation
-    # Replace "_" with "-" in variable names when specifying bands in the data configuration
-
     def __init__(
         self,
-        config: RasterLayerConfig,
+        band_names: list[str],
         api_key: str | None = None,
+        patch_size: float = 10,
     ):
         """Initialize a new ERA5LandMonthlyMeans instance.
 
         Args:
-            config: the LayerConfig of the layer containing this data source
-            api_key: the API key
+            band_names: list of band names to acquire. These should correspond to CDS
+                variable names but with "_" replaced with "-".
+            api_key: the API key. If not set, it should be set via the CDSAPI_KEY
+                environment variable.
+            patch_size: the size of items to request from the data store, in degrees.
         """
-        self.config = config
+        self.band_names = band_names
+        self.patch_size = patch_size
+
         self.client = cdsapi.Client(
             url=self.api_url,
             key=api_key,
@@ -81,11 +96,60 @@ class ERA5LandMonthlyMeans(DataSource):
         if config.data_source is None:
             raise ValueError("data_source is required")
         d = config.data_source.config_dict
-        api_key = d.get("api_key")
-        return ERA5LandMonthlyMeans(
-            config=config,
-            api_key=api_key,
+
+        # Determine band names based on the configured band sets.
+        band_names = []
+        for band_set in config.band_sets:
+            for band in band_set.bands:
+                if band in band_names:
+                    continue
+                band_names.append(band)
+        kwargs: dict[str, Any] = dict(
+            band_names=band_names,
         )
+
+        simple_optionals = ["api_key", "patch_size"]
+        for k in simple_optionals:
+            if k in d:
+                kwargs[k] = d[k]
+
+        return ERA5LandMonthlyMeans(**kwargs)
+
+    def _tile_to_item(self, col: int, row: int, year: int, month: int) -> Item:
+        """Get the Item for the given column and row on our fixed grid.
+
+        Args:
+            col: the column.
+            row: the row.
+            year: the year.
+            month: the month.
+
+        Returns:
+            the corresponding Item.
+        """
+        item_name = f"{col}_{row}_{year}_{month}"
+
+        # The bounds is based on the grid.
+        bounds = (
+            col * self.patch_size,
+            row * self.patch_size,
+            (col + 1) * self.patch_size,
+            (row + 1) * self.patch_size,
+        )
+
+        # Time is just the given month.
+        start_date = datetime(year, month, 1, tzinfo=timezone.utc)
+        time_range = (
+            start_date,
+            start_date + relativedelta(months=1),
+        )
+
+        geometry = STGeometry(
+            WGS84_PROJECTION,
+            shapely.box(*bounds),
+            time_range,
+        )
+        return Item(item_name, geometry)
 
     def get_items(
         self, geometries: list[STGeometry], query_config: QueryConfig
@@ -99,67 +163,57 @@ class ERA5LandMonthlyMeans(DataSource):
         Returns:
             List of groups of items that should be retrieved for each geometry.
         """
-        wgs84_geometries = [
-            geometry.to_projection(WGS84_PROJECTION) for geometry in geometries
-        ]
-        # Union all the geometries to form the request geometry
-        union_bounds = [geometry.shp.bounds for geometry in wgs84_geometries]
-        minx = min([b[0] for b in union_bounds])
-        miny = min([b[1] for b in union_bounds])
-        maxx = max([b[2] for b in union_bounds])
-        maxy = max([b[3] for b in union_bounds])
-        union_shp = box(minx, miny, maxx, maxy)
-        union_time_range = (
-            min([geometry.time_range[0] for geometry in wgs84_geometries]),  # type: ignore
-            max([geometry.time_range[1] for geometry in wgs84_geometries]),  # type: ignore
-        )
-        union_geometry = STGeometry(WGS84_PROJECTION, union_shp, union_time_range)
-        # Create an item for each month within the time range
-        union_items = []
-        start_date = datetime(
-            union_geometry.time_range[0].year,  # type: ignore
-            union_geometry.time_range[0].month,  # type: ignore
-            day=1,
-            hour=0,
-            minute=0,
-            second=0,
-            tzinfo=timezone.utc,
-        )
-        end_date = datetime(
-            union_geometry.time_range[1].year,  # type: ignore
-            union_geometry.time_range[1].month,  # type: ignore
-            day=1,
-            hour=0,
-            minute=0,
-            second=0,
-            tzinfo=timezone.utc,
-        )
-        while start_date <= end_date:
-            # Get the first and last day of the current year & month
-            # Use this as the item's time range
-            item_start_date, item_end_date = (
-                start_date,
-                start_date + relativedelta(months=1) - relativedelta(days=1),
-            )
-            item_geometry = STGeometry(
-                union_geometry.projection,
-                union_geometry.shp,
-                (item_start_date, item_end_date),
-            )
-            item_bounds = item_geometry.shp.bounds
-            item_name = f"{item_bounds[0]}_{item_bounds[1]}_{item_start_date.year}_{item_start_date.month:02d}"
-            item = Item(item_name, item_geometry)
-            union_items.append(item)
-            start_date += relativedelta(months=1)
+        # We only support mosaic here, other query modes don't really make sense.
+        if query_config.space_mode != SpaceMode.MOSAIC:
+            raise ValueError("expected mosaic space mode in the query configuration")
 
-        groups = []
-        for geometry in wgs84_geometries:
-            cur_groups = match_candidate_items_to_window(
-                geometry, union_items, query_config
-            )
-            groups.append(cur_groups)
+        all_groups = []
+        for geometry in geometries:
+            if geometry.time_range is None:
+                raise ValueError("expected all geometries to have a time range")
 
-        return groups
+            # Compute one mosaic for each month in this geometry.
+            cur_date = datetime(
+                geometry.time_range[0].year,
+                geometry.time_range[0].month,
+                1,
+                tzinfo=timezone.utc,
+            )
+            end_date = datetime(
+                geometry.time_range[1].year,
+                geometry.time_range[1].month,
+                1,
+                tzinfo=timezone.utc,
+            )
+
+            month_dates: list[datetime] = []
+            while cur_date <= end_date:
+                month_dates.append(cur_date)
+                cur_date += relativedelta(months=1)
+
+            # Determine which patches on our fixed grid that this geometry intersects.
+            wgs84_geometry = geometry.to_projection(WGS84_PROJECTION)
+            shp_bounds = wgs84_geometry.shp.bounds
+            cell_bounds = (
+                math.floor(shp_bounds[0] / self.patch_size),
+                math.floor(shp_bounds[1] / self.patch_size),
+                math.floor(shp_bounds[2] / self.patch_size) + 1,
+                math.floor(shp_bounds[3] / self.patch_size) + 1,
+            )
+
+            cur_groups = []
+            for cur_date in month_dates:
+                # Collect Item list corresponding to the patches and the current month.
+                items = []
+                for col in range(cell_bounds[0], cell_bounds[2]):
+                    for row in range(cell_bounds[1], cell_bounds[3]):
+                        items.append(
+                            self._tile_to_item(col, row, cur_date.year, cur_date.month)
+                        )
+                cur_groups.append(items)
+            all_groups.append(cur_groups)
+
+        return all_groups
 
     def deserialize_item(self, serialized_item: Any) -> Item:
         """Deserializes an item from JSON-decoded data."""
@@ -174,13 +228,35 @@ class ERA5LandMonthlyMeans(DataSource):
             tif_path: the path to the output GeoTIFF file
         """
         nc = netCDF4.Dataset(nc_path)
+        # The file contains a list of variables.
+        # These variables include things that are not bands that we want, such as
+        # latitude, longitude, valid_time, expver, etc.
+        # But the list of variables should include the bands we want in the correct
+        # order. And we can distinguish those bands from other "variables" because they
+        # will be 3D while the others will be scalars or 1D.
         bands_data = []
         for band_name in nc.variables:
             band_data = nc.variables[band_name]
+            if len(band_data.shape) != 3:
+                # This should be one of those variables that we want to skip.
+                continue
+
+            logger.debug(
+                f"NC file {nc_path} has variable {band_name} with shape {band_data.shape}"
+            )
             # Variable data is stored in a 3D array (1, height, width)
-            if len(band_data.shape) == 3:
-                bands_data.append(band_data[0, :, :])
+            if band_data.shape[0] != 1:
+                raise ValueError(
+                    f"Bad shape for band {band_name}, expected 1 band but got {band_data.shape[0]}"
+                )
+            bands_data.append(band_data[0, :, :])
+
         array = np.array(bands_data)  # (num_bands, height, width)
+        if array.shape[0] != len(self.band_names):
+            raise ValueError(
+                f"Expected to get {len(self.band_names)} bands but got {array.shape[0]}"
+            )
+
         # Get metadata for the GeoTIFF
         lat = nc.variables["latitude"][:]
         lon = nc.variables["longitude"][:]
@@ -211,8 +287,7 @@ class ERA5LandMonthlyMeans(DataSource):
             crs=crs,
             transform=transform,
         ) as dst:
-            for i in range(array.shape[0]):
-                dst.write(array[i, :, :], i + 1)  # Write each band to the GeoTIFF
+            dst.write(array)
 
     def ingest(
         self,
@@ -227,22 +302,31 @@ class ERA5LandMonthlyMeans(DataSource):
             items: the items to ingest
             geometries: a list of geometries needed for each item
         """
-        bands = []
-        for band_set in self.config.band_sets:
-            if band_set.bands is None:
-                continue
-            for band in band_set.bands:
-                if band in bands:
-                    continue
-                bands.append(band)
         # for CDS variable names, replace "-" with "_"
-        variable_names = [band.replace("-", "_") for band in bands]
+        variable_names = [band.replace("-", "_") for band in self.band_names]
+
         for item in items:
-            if tile_store.is_raster_ready(item.name, bands):
+            if tile_store.is_raster_ready(item.name, self.band_names):
                 continue
-            # Send the request to the CDS API
+
+            # Compute the bounds to request.
             # Given that ERA5 is at a very coarse resolution, we add a buffer of half a pixel size
             # to the bounds to ensure that we fully cover the geometries
+            # But we don't go beyond the valid WGS84 bounds.
+            bounds = (
+                item.geometry.shp.bounds[0] - self.PIXEL_SIZE / 2,
+                item.geometry.shp.bounds[1] - self.PIXEL_SIZE / 2,
+                item.geometry.shp.bounds[2] - self.PIXEL_SIZE / 2,
+                item.geometry.shp.bounds[3] - self.PIXEL_SIZE / 2,
+            )
+            bounds = (
+                max(bounds[0], WGS84_BOUNDS[0]),
+                max(bounds[1], WGS84_BOUNDS[1]),
+                min(bounds[2], WGS84_BOUNDS[2]),
+                min(bounds[3], WGS84_BOUNDS[3]),
+            )
+
+            # Send the request to the CDS API
             bounds = item.geometry.shp.bounds
             request = {
                 "product_type": [self.PRODUCT_TYPE],
@@ -253,14 +337,17 @@ class ERA5LandMonthlyMeans(DataSource):
                 ],
                 "time": ["00:00"],
                 "area": [
-                    bounds[3] + self.PIXEL_SIZE / 2,  # North
-                    bounds[0] - self.PIXEL_SIZE / 2,  # West
-                    bounds[1] - self.PIXEL_SIZE / 2,  # South
-                    bounds[2] + self.PIXEL_SIZE / 2,  # East
+                    bounds[3],  # North
+                    bounds[0],  # West
+                    bounds[1],  # South
+                    bounds[2],  # East
                 ],
                 "data_format": self.DATA_FORMAT,
                 "download_format": self.DOWNLOAD_FORMAT,
             }
+            logger.debug(
+                f"CDS API request for bounds {request['area']} and year={request['year']} month={request['month']}"
+            )
             with tempfile.TemporaryDirectory() as tmp_dir:
                 local_nc_fname = os.path.join(tmp_dir, f"{item.name}.nc")
                 local_tif_fname = os.path.join(tmp_dir, f"{item.name}.tif")
@@ -269,4 +356,6 @@ class ERA5LandMonthlyMeans(DataSource):
                     UPath(local_nc_fname),
                     UPath(local_tif_fname),
                 )
-                tile_store.write_raster_file(item.name, bands, UPath(local_tif_fname))
+                tile_store.write_raster_file(
+                    item.name, self.band_names, UPath(local_tif_fname)
+                )

--- a/tests/integration/data_sources/test_climate_data_store.py
+++ b/tests/integration/data_sources/test_climate_data_store.py
@@ -1,17 +1,9 @@
-import os
 import pathlib
-import random
 
 from upath import UPath
 
 from rslearn.config import (
-    BandSetConfig,
-    DType,
-    LayerType,
     QueryConfig,
-    RasterLayerConfig,
-    SpaceMode,
-    TimeMode,
 )
 from rslearn.data_sources.climate_data_store import ERA5LandMonthlyMeans
 from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
@@ -23,25 +15,23 @@ class TestERA5LandMonthlyMeans:
 
     TEST_BANDS = ["2m-temperature", "total-precipitation"]
 
-    def run_simple_test(self, tile_store_dir: UPath, seattle2020: STGeometry) -> None:
+    def test_local(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
         """Apply test where we ingest an item corresponding to seattle2020."""
-        layer_config = RasterLayerConfig(
-            LayerType.RASTER,
-            [BandSetConfig(config_dict={}, dtype=DType.FLOAT32, bands=self.TEST_BANDS)],
-        )
         query_config = QueryConfig(
-            space_mode=SpaceMode.INTERSECTS,
-            time_mode=TimeMode.WITHIN,
             max_matches=2,  # We expect two items to match
         )
-        data_source = ERA5LandMonthlyMeans(config=layer_config)
+        data_source = ERA5LandMonthlyMeans(band_names=self.TEST_BANDS)
         print("get items")
         item_groups = data_source.get_items([seattle2020], query_config)[0]  # type: ignore
         item_0 = item_groups[0][0]
         item_1 = item_groups[1][0]
+
+        tile_store_dir = UPath(tmp_path) / "tiles"
+        tile_store_dir.mkdir(parents=True, exist_ok=True)
         tile_store = DefaultTileStore(str(tile_store_dir))
         tile_store.set_dataset_path(tile_store_dir)
         layer_name = "layer"
+
         print("ingest")
         data_source.ingest(
             TileStoreWithLayer(tile_store, layer_name), item_groups[0], [[seattle2020]]
@@ -51,18 +41,3 @@ class TestERA5LandMonthlyMeans:
         )
         assert tile_store.is_raster_ready(layer_name, item_0.name, self.TEST_BANDS)
         assert tile_store.is_raster_ready(layer_name, item_1.name, self.TEST_BANDS)
-
-    def test_local(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
-        """Test ingesting to local filesystem."""
-        tile_store_dir = UPath(tmp_path) / "tiles"
-        tile_store_dir.mkdir(parents=True, exist_ok=True)
-        self.run_simple_test(tile_store_dir, seattle2020)
-
-    def test_gcs(self, seattle2020: STGeometry) -> None:
-        """Test ingesting to GCS."""
-        test_id = random.randint(10000, 99999)
-        bucket_name = os.environ["TEST_BUCKET"]
-        prefix = os.environ["TEST_PREFIX"]
-        test_path = UPath(f"gcs://{bucket_name}/{prefix}/test_{test_id}")
-        tile_store_dir = test_path / "tiles"
-        self.run_simple_test(tile_store_dir, seattle2020)


### PR DESCRIPTION
Previously if the windows have global coverage, the data source would make a request for data across the world, but this request would fail for some reason.

Additionally, it is like OpenStreetMap data source where the items are dependent on the requested windows rather than independent.

This changes ERA5 to represent the underlying data as fixed 10x10 degree items (even though the API supports arbitrary geometry requests) and matches those to windows. The size of an item can be configured if desired but the point is there is a fixed grid. Temporally it is still gridded by calendar month.