### PR TITLE
Improve mosaic creation by adding items to ladder of mosaics.

### DIFF
--- a/rslearn/data_sources/aws_landsat.py
+++ b/rslearn/data_sources/aws_landsat.py
@@ -109,7 +109,6 @@ class LandsatOliTirs(DataSource, TileStore):
         self.config = config
         self.metadata_cache_dir = metadata_cache_dir
         self.sort_by = sort_by
-        print(self.metadata_cache_dir)
 
         self.client = boto3.client("s3")
         self.bucket = boto3.resource("s3").Bucket(self.bucket_name)

--- a/rslearn/data_sources/utils.py
+++ b/rslearn/data_sources/utils.py
@@ -1,7 +1,10 @@
 """Utilities shared by data sources."""
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TypeVar
+
+import shapely
 
 from rslearn.config import QueryConfig, SpaceMode, TimeMode
 from rslearn.data_sources import Item
@@ -15,6 +18,23 @@ MOSAIC_REMAINDER_EPSILON = 0.01
 entire geometry."""
 
 ItemType = TypeVar("ItemType", bound=Item)
+
+
+@dataclass
+class PendingMosaic:
+    """A mosaic being created by match_candidate_items_to_window.
+
+    Args:
+        items: the list of items in the mosaic.
+        remainder: the remainder of the geometry that is not covered by any of the
+            items.
+        completed: whether the mosaic is done (sufficient coverage of the geometry).
+    """
+
+    # Cannot use list[ItemType] here.
+    items: list
+    remainder: shapely.Polygon
+    completed: bool = False
 
 
 def match_candidate_items_to_window(
@@ -91,40 +111,70 @@ def match_candidate_items_to_window(
                 break
 
     elif query_config.space_mode == SpaceMode.MOSAIC:
-        # To create mosaic groups, we repeatedly try to fill the geometry.
-        # Each time the geometry is fully covered, we start another group.
-        # We terminate when there are no more items or we have exceeded max_matches.
-        cur_remainder = None
-        cur_group = []
+        # To create mosaics, we iterate over the items in order, and add each item to
+        # the first mosaic that the new item adds coverage to.
+
+        # max_matches could be very high if the user just wants us to create as many
+        # mosaics as possible, so we initialize the list here as empty and just add
+        # more pending mosaics when it is necessary.
+        pending_mosaics: list[PendingMosaic] = []
 
         for item, item_shp in zip(items, item_shps):
-            if cur_remainder is None:
-                cur_remainder = geometry.shp
+            # See if the item can match with any existing mosaic.
+            item_matched = False
 
-            if not shp_intersects(item_shp, cur_remainder):
+            for pending_mosaic in pending_mosaics:
+                if pending_mosaic.completed:
+                    continue
+                if not shp_intersects(item_shp, pending_mosaic.remainder):
+                    continue
+
+                # Check if the intersection area is too small.
+                # If it is a sizable part of the item or of the geometry, then proceed.
+                intersect_area = item_shp.intersection(pending_mosaic.remainder).area
+                if (
+                    intersect_area / item_shp.area < MOSAIC_MIN_ITEM_COVERAGE
+                    and intersect_area / pending_mosaic.remainder.area
+                    < MOSAIC_MIN_ITEM_COVERAGE
+                ):
+                    continue
+
+                pending_mosaic.remainder = pending_mosaic.remainder - item_shp
+                pending_mosaic.items.append(item)
+                item_matched = True
+
+                # Mark the mosaic completed if it has sufficient coverage of the
+                # geometry.
+                if (
+                    pending_mosaic.remainder.area / geometry.shp.area
+                    < MOSAIC_REMAINDER_EPSILON
+                ):
+                    pending_mosaic.completed = True
+
+                break
+
+            if item_matched:
                 continue
 
-            # Check if the intersection area is too small.
-            # If it is a sizable part of the item or of the geometry, then continue.
-            intersect_area = item_shp.intersection(cur_remainder).area
+            # See if we can add a new mosaic based on this item. There must be room for
+            # more mosaics, but the item must also intersect the requested geometry.
+            if len(pending_mosaics) >= query_config.max_matches:
+                continue
+            intersect_area = item_shp.intersection(geometry.shp).area
             if (
                 intersect_area / item_shp.area < MOSAIC_MIN_ITEM_COVERAGE
-                and intersect_area / cur_remainder.area < MOSAIC_MIN_ITEM_COVERAGE
+                and intersect_area / geometry.shp.area < MOSAIC_MIN_ITEM_COVERAGE
             ):
                 continue
 
-            cur_remainder = cur_remainder - item_shp
-            cur_group.append(item)
+            pending_mosaics.append(
+                PendingMosaic(
+                    items=[item],
+                    remainder=geometry.shp - item_shp,
+                )
+            )
 
-            if cur_remainder.area / geometry.shp.area < MOSAIC_REMAINDER_EPSILON:
-                cur_remainder = None
-                groups.append(cur_group)
-                cur_group = []
-
-            if len(groups) >= query_config.max_matches:
-                break
-
-        if len(cur_group) > 0:
-            groups.append(cur_group)
+        for pending_mosaic in pending_mosaics:
+            groups.append(pending_mosaic.items)
 
     return groups

--- a/tests/unit/data_sources/test_match_candidate_items_to_window.py
+++ b/tests/unit/data_sources/test_match_candidate_items_to_window.py
@@ -113,6 +113,23 @@ class TestMosaic:
             [six_items[1], six_items[4]],
         ]
 
+    def test_three_mosaics(self, six_items: list[Item]) -> None:
+        """Test mosaic creation.
+
+        Like above but three groups should be returned (we have exactly enough items
+        for those mosaics).
+        """
+        window_geom = STGeometry(WGS84_PROJECTION, shapely.box(0, 0, 1, 1), None)
+        query_config = QueryConfig(space_mode=SpaceMode.MOSAIC, max_matches=3)
+        item_groups = match_candidate_items_to_window(
+            window_geom, six_items, query_config
+        )
+        assert item_groups == [
+            [six_items[0], six_items[3]],
+            [six_items[1], six_items[4]],
+            [six_items[2], six_items[5]],
+        ]
+
     def test_ten_mosaics(self, six_items: list[Item]) -> None:
         """Test mosaic creation.
 
@@ -138,3 +155,29 @@ class TestMosaic:
             window_geom, six_items, query_config
         )
         assert len(item_groups) == 0
+
+    def test_partial_mosaics(self, six_items: list[Item]) -> None:
+        """Ensure partial mosaics are produced.
+
+        Here we will pass three items on the left and one item on the right, requesting
+        three mosaics. We should get three mosaics where the second two only have
+        partial coverage of the window geometry.
+        """
+        items_to_use = [
+            # Left.
+            six_items[0],
+            six_items[1],
+            six_items[2],
+            # Right.
+            six_items[3],
+        ]
+        window_geom = STGeometry(WGS84_PROJECTION, shapely.box(0, 0, 1, 1), None)
+        query_config = QueryConfig(space_mode=SpaceMode.MOSAIC, max_matches=3)
+        item_groups = match_candidate_items_to_window(
+            window_geom, items_to_use, query_config
+        )
+        assert item_groups == [
+            [six_items[0], six_items[3]],
+            [six_items[1]],
+            [six_items[2]],
+        ]


### PR DESCRIPTION
Previously we would iterate over items, and if an item didn't add coverage to the current mosaic then we would skip it. Now we push it down to the next mosaic and so on to see if it can be added to any of them.

Resolves #159.