### PR TITLE
Fix bug when tags aren't specified on the window

### DIFF
--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -339,7 +339,7 @@ class ModelDataset(torch.utils.data.Dataset):
                 for k, v in split_config.tags.items():
                     if k not in window.options:
                         tags_passed = False
-                    if v and window.options[k] != v:
+                    elif v and window.options[k] != v:
                         tags_passed = False
                 if tags_passed:
                     new_windows.append(window)

--- a/tests/integration/train/test_dataset.py
+++ b/tests/integration/train/test_dataset.py
@@ -1,0 +1,59 @@
+import json
+import pathlib
+from typing import Any
+
+from rasterio.crs import CRS
+from upath import UPath
+
+from rslearn.dataset import Dataset, Window
+from rslearn.train.dataset import ModelDataset, SplitConfig
+from rslearn.train.tasks.classification import ClassificationTask
+from rslearn.utils.geometry import Projection
+
+
+class TestDataset:
+    """Test ModelDataset."""
+
+    def test_multiple_tags(self, tmp_path: pathlib.Path) -> None:
+        """Ensure that ModelDataset filters correctly when multile tags are configured.
+
+        Multiple tags should be treated as conjunction (logical and) so only windows
+        matching all of the tags should be accepted.
+        """
+        ds_path = UPath(tmp_path)
+        with (ds_path / "config.json").open("w") as f:
+            json.dump({"layers": {}}, f)
+        group = "default"
+        projection = Projection(CRS.from_epsg(32614), 10, -10)
+        bounds = (500000, 500000, 500040, 500040)
+
+        def add_window(name: str, options: dict[str, Any]) -> None:
+            Window(
+                path=Window.get_window_root(ds_path, group, name),
+                group=group,
+                name=name,
+                projection=projection,
+                bounds=bounds,
+                time_range=None,
+                options=options,
+            ).save()
+
+        # (1) Window with first tag only (skip).
+        add_window("window1", {"tag1": "yes"})
+        # (2) Window with second tag only (skip).
+        add_window("window2", {"tag2": "yes"})
+        # (3) Window with both tags (match).
+        add_window("window3", {"tag1": "yes", "tag2": "yes"})
+        # (4) Window with both tags plus one more (match).
+        add_window("window4", {"tag1": "yes", "tag2": "yes", "tag3": "yes"})
+
+        dataset = ModelDataset(
+            dataset=Dataset(ds_path),
+            split_config=SplitConfig(tags={"tag1": "yes", "tag2": "yes"}),
+            inputs={},
+            task=ClassificationTask(property_name="prop_name", classes=[]),
+            workers=4,
+        )
+        assert len(dataset) == 2
+        window_names = {window.name for window in dataset.get_windows()}
+        assert window_names == {"window3", "window4"}


### PR DESCRIPTION
https://github.com/allenai/rslearn/pull/156 introduced a bug where, if a window doesn't have a tag that's set in the model configuration file, then it will cause an error (KeyError). This PR fixes that bug while also adding a test.