### PR TITLE
relax requirements for lightning and torchvision.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ boto3>=1.35
 class_registry>=2.1
 fiona>=1.10
 fsspec==2025.2.0
-lightning[pytorch-extra]==2.5.0.post0
+lightning[pytorch-extra]>=2.5.0.post0
 Pillow>=11.0
 pyproj>=3.7
 python-dateutil>=2.9
 pytimeparse>=1.1
 rasterio>=1.4
 shapely>=2.0
-torchvision==0.21.0
+torchvision>=0.21.0
 tqdm>=4.66
 universal_pathlib>=0.2.5


### PR DESCRIPTION
It seems to work with pytorch 2.7 and corresponding lightning/torchvision versions. Relaxing the requirement enables compatability with Helios among other things.