### PR TITLE
Fix issues using custom samplers with multi-GPU training

### DIFF
--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -772,6 +772,10 @@ class RslearnLightningCLI(LightningCLI):
         if prediction_writer_callback:
             prediction_writer_callback.init_args.path = c.data.init_args.path
 
+        # Disable the sampler replacement, since the rslearn data module will set the
+        # sampler as needed.
+        c.trainer.use_distributed_sampler = False
+
 
 def model_handler() -> None:
     """Handler for any rslearn model X commands."""

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import lightning as L
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, DistributedSampler
 from upath import UPath
 
 from rslearn.dataset import Dataset
@@ -115,10 +115,19 @@ class RslearnDataModule(L.LightningDataModule):
             persistent_workers=persistent_workers,
         )
         sampler_factory = self.split_configs[split].sampler
+        should_shuffle = split == "train"
         if sampler_factory:
             kwargs["sampler"] = sampler_factory.get_sampler(dataset)
-        elif split == "train":
-            kwargs["shuffle"] = True
+        elif self.trainer.world_size is not None and self.trainer.world_size > 1:
+            # Use distributed sampler in case ddp is enabled.
+            kwargs["sampler"] = DistributedSampler(
+                dataset,
+                num_replicas=self.trainer.world_size,
+                rank=self.trainer.global_rank,
+                shuffle=should_shuffle,
+            )
+        else:
+            kwargs["shuffle"] = should_shuffle
         return DataLoader(**kwargs)
 
     def train_dataloader(self) -> DataLoader[dict[str, torch.Tensor]]:


### PR DESCRIPTION
Previously, when setting a sampler in SplitConfig with multi-GPU training, the sampler would just get overwritten by pytorch Lightning since it would configure a DistributedSampler. When using rslearn_projects, it happens even with single-GPU training since we currently always enable ddp to set find_unused_parameters.

This leads to confusing bugs where you expect it to use e.g. random weighted sampling but the option is effectively ignored since Lightning configures a different sampler.

Now the DistributedSampler replacement functionality is disabled, and we instead configure the sampler appropriately in the data module even when sampler factory is not set.