### PR TITLE
Improve performance of GCP Sentinel-2 data source get_items

### DIFF
--- a/rslearn/utils/geometry.py
+++ b/rslearn/utils/geometry.py
@@ -14,6 +14,7 @@ from rslearn.log_utils import get_logger
 
 logger = get_logger(__name__)
 PixelBounds = tuple[int, int, int, int]
+FloatBounds = tuple[float, float, float, float]
 
 RESOLUTION_EPSILON = 1e-6
 WGS84_EPSG = 4326

--- a/tests/integration/data_sources/test_gcp_public_data.py
+++ b/tests/integration/data_sources/test_gcp_public_data.py
@@ -68,9 +68,17 @@ class TestSentinel2:
         )
         assert tile_store.is_raster_ready(layer_name, item.name, [TEST_BAND])
 
-    @pytest.mark.parametrize("use_rtree_index", [False, True])
+    # use_rtree_index=True and use_bigquery=False is not supported, so we test all the
+    # other combinations.
+    @pytest.mark.parametrize(
+        "use_rtree_index,use_bigquery", [(False, False), (False, True), (True, True)]
+    )
     def test_local(
-        self, tmp_path: pathlib.Path, seattle2020: STGeometry, use_rtree_index: bool
+        self,
+        tmp_path: pathlib.Path,
+        seattle2020: STGeometry,
+        use_rtree_index: bool,
+        use_bigquery: bool,
     ) -> None:
         """Test ingesting to local filesystem."""
         tile_store_dir = UPath(tmp_path) / "tiles"
@@ -82,6 +90,7 @@ class TestSentinel2:
             seattle2020,
             index_cache_dir=index_cache_dir,
             use_rtree_index=use_rtree_index,
+            use_bigquery=use_bigquery,
         )
 
     @pytest.mark.parametrize("use_rtree_index", [False, True])
@@ -192,7 +201,7 @@ def test_search_intersecting_product_with_missing_xml(
         tzinfo=timezone.utc,
     )
     time_range = (sense_day, sense_day + timedelta(days=1))
-    cell_bounds = get_sentinel2_tile_index()[cell_id]
+    cell_bounds = get_sentinel2_tile_index()[cell_id][0]
     center = (
         (cell_bounds[0] + cell_bounds[2]) / 2,
         (cell_bounds[1] + cell_bounds[3]) / 2,

--- a/tests/unit/data_sources/test_copernicus.py
+++ b/tests/unit/data_sources/test_copernicus.py
@@ -1,0 +1,40 @@
+import pathlib
+from datetime import datetime, timezone
+
+import shapely
+from upath import UPath
+
+from rslearn.const import WGS84_PROJECTION
+from rslearn.data_sources.copernicus import get_sentinel2_tiles
+from rslearn.utils.geometry import STGeometry
+
+
+class TestGetSentinel2Tiles:
+    """Tests for get_sentinel2_tiles."""
+
+    def test_antimeridian_handling(self, tmp_path: pathlib.Path) -> None:
+        """Make sure that get_sentinel2_tiles handles the antimeridian correctly.
+
+        Previously we returned tiles that spanned the antimeridian for any geometry
+        that had a matching latitude.
+        """
+        # We use a 1x1 degree geometry that should match with these tiles:
+        # - 10UFU
+        # - 10TFT
+        # - 10UEU
+        # - 10TET
+        geom = STGeometry(
+            WGS84_PROJECTION,
+            shapely.box(-122, 47, -121, 48),
+            (
+                datetime(2024, 1, 1, tzinfo=timezone.utc),
+                datetime(2024, 2, 1, tzinfo=timezone.utc),
+            ),
+        )
+        tiles = get_sentinel2_tiles(geom, UPath(tmp_path))
+        assert set(tiles) == {
+            "10UFU",
+            "10TFT",
+            "10UEU",
+            "10TET",
+        }, f"Got incorrect tile list {tiles}"


### PR DESCRIPTION
Improve performance of GCP Sentinel-2 data source get_items:

- Support using BigQuery table to do get_items without building rtree index.
- Improve debug logging so it's more transparent what work the prepare step is doing.
- Fix antimeridian issue in the sentinel2 tile index to avoid matching with tiles that are at same latitude but wrong longitude and just cross antimeridian.