### PR TITLE
Speed up detection metric speed to reduce how long validation step takes

### DIFF
--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -247,11 +247,9 @@ class RslearnLightningModule(L.LightningModule):
             sync_dist=True,
         )
         self.val_metrics.update(outputs, targets)
-
-    def on_validation_epoch_end(self) -> None:
-        """Log test metrics on epoch end."""
-        self.log_dict(self.val_metrics.compute(), sync_dist=True)
-        self.val_metrics.reset()
+        self.log_dict(
+            self.val_metrics, batch_size=batch_size, on_epoch=True, sync_dist=True
+        )
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
@@ -281,6 +279,9 @@ class RslearnLightningModule(L.LightningModule):
             sync_dist=True,
         )
         self.test_metrics.update(outputs, targets)
+        self.log_dict(
+            self.test_metrics, batch_size=batch_size, on_epoch=True, sync_dist=True
+        )
 
         if self.visualize_dir:
             for idx, (inp, target, output, metadata) in enumerate(
@@ -293,11 +294,6 @@ class RslearnLightningModule(L.LightningModule):
                         f'{metadata["window_name"]}_{metadata["bounds"][0]}_{metadata["bounds"][1]}_{image_suffix}.png',
                     )
                     Image.fromarray(image).save(out_fname)
-
-    def on_test_epoch_end(self) -> None:
-        """Log test metrics on epoch end."""
-        self.log_dict(self.test_metrics.compute(), sync_dist=True)
-        self.test_metrics.reset()
 
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -247,9 +247,11 @@ class RslearnLightningModule(L.LightningModule):
             sync_dist=True,
         )
         self.val_metrics.update(outputs, targets)
-        self.log_dict(
-            self.val_metrics, batch_size=batch_size, on_epoch=True, sync_dist=True
-        )
+
+    def on_validation_epoch_end(self) -> None:
+        """Log test metrics on epoch end."""
+        self.log_dict(self.val_metrics.compute(), sync_dist=True)
+        self.val_metrics.reset()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
@@ -279,9 +281,6 @@ class RslearnLightningModule(L.LightningModule):
             sync_dist=True,
         )
         self.test_metrics.update(outputs, targets)
-        self.log_dict(
-            self.test_metrics, batch_size=batch_size, on_epoch=True, sync_dist=True
-        )
 
         if self.visualize_dir:
             for idx, (inp, target, output, metadata) in enumerate(
@@ -294,6 +293,11 @@ class RslearnLightningModule(L.LightningModule):
                         f'{metadata["window_name"]}_{metadata["bounds"][0]}_{metadata["bounds"][1]}_{image_suffix}.png',
                     )
                     Image.fromarray(image).save(out_fname)
+
+    def on_test_epoch_end(self) -> None:
+        """Log test metrics on epoch end."""
+        self.log_dict(self.test_metrics.compute(), sync_dist=True)
+        self.test_metrics.reset()
 
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0


### PR DESCRIPTION
Speed up detection metric speed to reduce validation duration.
    
We speed up in two ways:
- Add enable_precision_recall option so that by default we support only logging F1 score. Each one does redundant computation so far and metric can only return one scalar with lightning, so disabling precision/recall logging makes it much faster.
- Currently the speed gets slower and slower. I don't know the exact reason, but the part that gets slower is logging the metric, even though we pass on_epoch=True. Moving to epoch end and manually resetting the metric avoids this slowdown. UPDATE: I reverted this because it was causing errors relating to distributed sync. It seems only mAP metric gets slower, our implementation works fine since we don't store list that gets longer and longer, disabling mAP metric should work assuming user is happy with F1 metric.

Depends on #181.