### PR TITLE
Supporting building and saving an index over windows to speed up window loading

### DIFF
--- a/docs/examples/WindowsFromGeojson.md
+++ b/docs/examples/WindowsFromGeojson.md
@@ -61,7 +61,7 @@ with open(os.path.join(ds_path, "source_data/subset/latest.geojson"), "w") as f:
 Now we can use the `dataset add_windows` command to create the windows.
 
 ```
-rslearn dataset add_windows --group default --fname $DATASET_PATH/source_data/subset/latest.geojson --grid_size 256 --utm --resolution 10 --start 2024-01-01T00:00:00+00:00 --end 2024-07-01T00:00:00+00:00 --root dataset/
+rslearn dataset add_windows --group default --fname $DATASET_PATH/source_data/subset/latest.geojson --grid_size 256 --utm --resolution 10 --start 2024-01-01T00:00:00+00:00 --end 2024-07-01T00:00:00+00:00 --root $DATASET_PATH
 ```
 
 Here, we create windows along a 256x256 grid by passing `--grid_size 256`; windows are

--- a/rslearn/dataset/dataset.py
+++ b/rslearn/dataset/dataset.py
@@ -97,6 +97,10 @@ class Dataset:
             if dataset_index is not None:
                 return dataset_index.get_windows(groups=groups, names=names)
 
+        # Avoid directory does not exist errors later.
+        if not (self.path / "windows").exists():
+            return []
+
         window_dirs = []
         if not groups:
             groups = []
@@ -104,6 +108,11 @@ class Dataset:
                 groups.append(p.name)
         for group in groups:
             group_dir = self.path / "windows" / group
+            if not group_dir.exists():
+                logger.warning(
+                    f"Skipping group directory {group_dir} since it does not exist"
+                )
+                continue
             if names:
                 cur_names = names
             else:

--- a/rslearn/dataset/dataset.py
+++ b/rslearn/dataset/dataset.py
@@ -78,6 +78,7 @@ class Dataset:
         names: list[str] | None = None,
         show_progress: bool = False,
         workers: int = 0,
+        no_index: bool = False,
     ) -> list[Window]:
         """Load the windows in the dataset.
 
@@ -86,11 +87,15 @@ class Dataset:
             names: an optional list of window names to filter loading
             show_progress: whether to show tqdm progress bar
             workers: number of parallel workers, default 0 (use main thread only to load windows)
+            no_index: don't use the dataset index even if it exists.
         """
         # Load from index if it exists.
-        dataset_index = self._get_index()
-        if dataset_index is not None:
-            return dataset_index.get_windows(groups=groups, names=names)
+        # We never use the index if names is set since loading the index will likely be
+        # slower than loading a few windows.
+        if not no_index and names is None:
+            dataset_index = self._get_index()
+            if dataset_index is not None:
+                return dataset_index.get_windows(groups=groups, names=names)
 
         window_dirs = []
         if not groups:

--- a/rslearn/dataset/index.py
+++ b/rslearn/dataset/index.py
@@ -178,6 +178,7 @@ class DatasetIndex:
         completed_layers = {}  # window name -> list of (layer name, group idx)
         for window, cur_completed_layers in zip(windows, completed_layer_outputs):
             completed_layers[window.name] = cur_completed_layers
+        p.close()
 
         return DatasetIndex(
             windows=windows,

--- a/rslearn/dataset/index.py
+++ b/rslearn/dataset/index.py
@@ -1,0 +1,182 @@
+"""Index about windows in the dataset."""
+
+import json
+import multiprocessing
+from typing import TYPE_CHECKING
+
+import tqdm
+from upath import UPath
+
+from .window import (
+    LAYERS_DIRECTORY_NAME,
+    Window,
+    WindowLayerData,
+    get_layer_and_group_from_dir_name,
+)
+
+if TYPE_CHECKING:
+    from .dataset import Dataset
+
+
+def get_window_layer_datas(window: Window) -> list[WindowLayerData]:
+    """Helper function for multiprocessing to load window layer datas."""
+    return list(window.load_layer_datas().values())
+
+
+def get_window_completed_layers(window: Window) -> list[tuple[str, int]]:
+    """Helper function for multiprocessing to load window completed layers."""
+    # We don't know the range of possible groups a priori, so we instead look in the
+    # layers directory.
+    completed_layers = []
+    for layer_dir in (window.path / LAYERS_DIRECTORY_NAME).iterdir():
+        layer_name, group_idx = get_layer_and_group_from_dir_name(layer_dir.name)
+        if not window.is_layer_completed(layer_name, group_idx):
+            continue
+        completed_layers.append((layer_name, group_idx))
+    return completed_layers
+
+
+class DatasetIndex:
+    """Manage an index about windows in the dataset.
+
+    The index is just a single file containing information about all windows in the
+    dataset, so that this information does not need to be loaded from per-window files.
+
+    The information includes the window metadata, the window layer datas (matching data
+    source items), and the completed layers.
+
+    Currently the index must be manually maintained. It can be created for relatively
+    static datasets, and updated each time the dataset is modified.
+    """
+
+    FNAME = "dataset_index.json"
+
+    def __init__(
+        self,
+        windows: list[Window],
+        layer_datas: dict[str, list[WindowLayerData]],
+        completed_layers: dict[str, list[tuple[str, int]]],
+    ):
+        """Create a new DatasetIndex.
+
+        Args:
+            windows: the windows in the dataset.
+            layer_datas: map from window name to the layer datas for that window.
+            completed_layers: map from window name to its list of completed layers.
+                Each element is (layer_name, group_idx).
+        """
+        self.windows = windows
+        self.layer_datas = layer_datas
+        self.completed_layers = completed_layers
+
+        for window in self.windows:
+            window.index = self
+
+    def get_windows(
+        self,
+        groups: list[str] | None = None,
+        names: list[str] | None = None,
+    ) -> list[Window]:
+        """Get the windows in the dataset.
+
+        Args:
+            groups: an optional list of groups to filter by
+            names: an optional list of window names to filter by
+        """
+        windows = self.windows
+        if groups is not None:
+            group_set = set(groups)
+            windows = [window for window in windows if window.group in group_set]
+        if names is not None:
+            name_set = set(names)
+            windows = [window for window in windows if window.name in name_set]
+        return windows
+
+    def save_index(self, ds_path: UPath) -> None:
+        """Save the index to the specified file."""
+        encoded_windows = [window.get_metadata() for window in self.windows]
+
+        encoded_layer_datas = {}
+        for window_name, layer_data_list in self.layer_datas.items():
+            encoded_layer_datas[window_name] = [
+                layer_data.serialize() for layer_data in layer_data_list
+            ]
+
+        encoded_index = {
+            "windows": encoded_windows,
+            "layer_datas": encoded_layer_datas,
+            "completed_layers": self.completed_layers,
+        }
+        with (ds_path / self.FNAME).open("w") as f:
+            json.dump(encoded_index, f)
+
+    @staticmethod
+    def load_index(ds_path: UPath) -> "DatasetIndex":
+        """Load the DatasetIndex for the specified dataset."""
+        with (ds_path / DatasetIndex.FNAME).open() as f:
+            encoded_index = json.load(f)
+
+        windows = []
+        for encoded_window in encoded_index["windows"]:
+            window = Window.from_metadata(
+                path=Window.get_window_root(
+                    ds_path, encoded_window["group"], encoded_window["name"]
+                ),
+                metadata=encoded_window,
+            )
+            windows.append(window)
+
+        layer_datas = {}
+        for window_name, encoded_layer_data_list in encoded_index[
+            "layer_datas"
+        ].items():
+            layer_datas[window_name] = [
+                WindowLayerData.deserialize(encoded_layer_data)
+                for encoded_layer_data in encoded_layer_data_list
+            ]
+
+        completed_layers = {}
+        for window_name, encoded_layer_list in encoded_index[
+            "completed_layers"
+        ].items():
+            completed_layers[window_name] = [
+                (layer_name, group_idx)
+                for (layer_name, group_idx) in encoded_layer_list
+            ]
+
+        return DatasetIndex(
+            windows=windows,
+            layer_datas=layer_datas,
+            completed_layers=completed_layers,
+        )
+
+    @staticmethod
+    def build_index(dataset: "Dataset", workers: int) -> "DatasetIndex":
+        """Build a new DatasetIndex for the specified dataset."""
+        # Load windows.
+        windows = dataset.load_windows(workers=workers)
+
+        # Load layer datas.
+        p = multiprocessing.Pool(workers)
+        layer_data_outputs = p.imap(get_window_layer_datas, windows)
+        layer_data_outputs = tqdm.tqdm(
+            layer_data_outputs, total=len(windows), desc="Loading window layer datas"
+        )
+        layer_datas = {}
+        for window, cur_layer_datas in zip(windows, layer_data_outputs):
+            layer_datas[window.name] = cur_layer_datas
+
+        # Load completed layers.
+        completed_layer_outputs = p.imap(get_window_completed_layers, windows)
+        completed_layer_outputs = tqdm.tqdm(
+            completed_layer_outputs, total=len(windows), desc="Loading completed layers"
+        )
+        completed_layers = {}  # window name -> list of (layer name, group idx)
+        for window, cur_completed_layers in zip(windows, completed_layer_outputs):
+            completed_layers[window.name] = cur_completed_layers
+
+        return DatasetIndex(
+            windows=windows,
+            layer_datas=layer_datas,
+            completed_layers=completed_layers,
+        )

--- a/rslearn/dataset/index.py
+++ b/rslearn/dataset/index.py
@@ -27,8 +27,12 @@ def get_window_completed_layers(window: Window) -> list[tuple[str, int]]:
     """Helper function for multiprocessing to load window completed layers."""
     # We don't know the range of possible groups a priori, so we instead look in the
     # layers directory.
+    layers_directory = window.path / LAYERS_DIRECTORY_NAME
+    if not layers_directory.exists():
+        return []
+
     completed_layers = []
-    for layer_dir in (window.path / LAYERS_DIRECTORY_NAME).iterdir():
+    for layer_dir in layers_directory.iterdir():
         layer_name, group_idx = get_layer_and_group_from_dir_name(layer_dir.name)
         if not window.is_layer_completed(layer_name, group_idx):
             continue
@@ -154,7 +158,7 @@ class DatasetIndex:
     def build_index(dataset: "Dataset", workers: int) -> "DatasetIndex":
         """Build a new DatasetIndex for the specified dataset."""
         # Load windows.
-        windows = dataset.load_windows(workers=workers)
+        windows = dataset.load_windows(workers=workers, no_index=True)
 
         # Load layer datas.
         p = multiprocessing.Pool(workers)

--- a/rslearn/dataset/window.py
+++ b/rslearn/dataset/window.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import shapely
 from upath import UPath
@@ -10,6 +10,9 @@ from upath import UPath
 from rslearn.log_utils import get_logger
 from rslearn.utils import Projection, STGeometry
 from rslearn.utils.fsspec import open_atomic
+
+if TYPE_CHECKING:
+    from .index import DatasetIndex
 
 logger = get_logger(__name__)
 
@@ -35,6 +38,26 @@ def get_window_layer_dir(
     else:
         folder_name = f"{layer_name}.{group_idx}"
     return window_path / LAYERS_DIRECTORY_NAME / folder_name
+
+
+def get_layer_and_group_from_dir_name(layer_dir_name: str) -> tuple[str, int]:
+    """Get the layer name and group index from the layer directory name.
+
+    Args:
+        layer_dir_name: the name of the layer folder.
+
+    Returns:
+        a tuple (layer_name, group_idx)
+    """
+    if "." in layer_dir_name:
+        parts = layer_dir_name.split(".")
+        if len(parts) != 2:
+            raise ValueError(
+                f"expected layer directory name {layer_dir_name} to only contain one '.'"
+            )
+        return (parts[0], int(parts[1]))
+    else:
+        return (layer_dir_name, 0)
 
 
 def get_window_raster_dir(
@@ -120,6 +143,7 @@ class Window:
         bounds: tuple[int, int, int, int],
         time_range: tuple[datetime, datetime] | None,
         options: dict[str, Any] = {},
+        index: "DatasetIndex | None" = None,
     ) -> None:
         """Creates a new Window instance.
 
@@ -134,6 +158,7 @@ class Window:
             bounds: the bounds of the window in pixel coordinates
             time_range: optional time range of the window
             options: additional options (?)
+            index: DatasetIndex if it is available
         """
         self.path = path
         self.group = group
@@ -142,26 +167,7 @@ class Window:
         self.bounds = bounds
         self.time_range = time_range
         self.options = options
-
-    def save(self) -> None:
-        """Save the window metadata to its root directory."""
-        self.path.mkdir(parents=True, exist_ok=True)
-        metadata = {
-            "group": self.group,
-            "name": self.name,
-            "projection": self.projection.serialize(),
-            "bounds": self.bounds,
-            "time_range": (
-                [self.time_range[0].isoformat(), self.time_range[1].isoformat()]
-                if self.time_range
-                else None
-            ),
-            "options": self.options,
-        }
-        metadata_path = self.path / "metadata.json"
-        logger.debug(f"Saving window metadata to {metadata_path}")
-        with open_atomic(metadata_path, "w") as f:
-            json.dump(metadata, f)
+        self.index = index
 
     def get_geometry(self) -> STGeometry:
         """Computes the STGeometry corresponding to this window."""
@@ -173,13 +179,20 @@ class Window:
 
     def load_layer_datas(self) -> dict[str, WindowLayerData]:
         """Load layer datas describing items in retrieved layers from items.json."""
-        items_fname = self.path / "items.json"
-        if not items_fname.exists():
-            return {}
-        with items_fname.open("r") as f:
-            layer_datas = [
-                WindowLayerData.deserialize(layer_data) for layer_data in json.load(f)
-            ]
+        # Load from index if it is available.
+        if self.index is not None:
+            layer_datas = self.index.layer_datas.get(self.name, [])
+
+        else:
+            items_fname = self.path / "items.json"
+            if not items_fname.exists():
+                return {}
+            with items_fname.open("r") as f:
+                layer_datas = [
+                    WindowLayerData.deserialize(layer_data)
+                    for layer_data in json.load(f)
+                ]
+
         return {layer_data.layer_name: layer_data for layer_data in layer_datas}
 
     def save_layer_datas(self, layer_datas: dict[str, WindowLayerData]) -> None:
@@ -216,6 +229,12 @@ class Window:
         Returns:
             whether the layer is completed
         """
+        # Use the index to speed up the completed check if it is available.
+        if self.index is not None:
+            return (layer_name, group_idx) in self.index.completed_layers.get(
+                self.name, []
+            )
+
         layer_dir = self.get_layer_dir(layer_name, group_idx)
         return (layer_dir / "completed").exists()
 
@@ -251,19 +270,40 @@ class Window:
         """
         return get_window_raster_dir(self.path, layer_name, bands, group_idx)
 
+    def get_metadata(self) -> dict[str, Any]:
+        """Returns the window metadata dictionary."""
+        return {
+            "group": self.group,
+            "name": self.name,
+            "projection": self.projection.serialize(),
+            "bounds": self.bounds,
+            "time_range": (
+                [self.time_range[0].isoformat(), self.time_range[1].isoformat()]
+                if self.time_range
+                else None
+            ),
+            "options": self.options,
+        }
+
+    def save(self) -> None:
+        """Save the window metadata to its root directory."""
+        self.path.mkdir(parents=True, exist_ok=True)
+        metadata_path = self.path / "metadata.json"
+        logger.debug(f"Saving window metadata to {metadata_path}")
+        with open_atomic(metadata_path, "w") as f:
+            json.dump(self.get_metadata(), f)
+
     @staticmethod
-    def load(path: UPath) -> "Window":
-        """Load a Window from a UPath.
+    def from_metadata(path: UPath, metadata: dict[str, Any]) -> "Window":
+        """Create a Window from its path and metadata dictionary.
 
         Args:
-            path: the root directory of the window
+            path: the root directory of the window.
+            metadata: the window metadata.
 
         Returns:
             the Window
         """
-        metadata_fname = path / "metadata.json"
-        with metadata_fname.open("r") as f:
-            metadata = json.load(f)
         return Window(
             path=path,
             group=metadata["group"],
@@ -280,6 +320,21 @@ class Window:
             ),
             options=metadata["options"],
         )
+
+    @staticmethod
+    def load(path: UPath) -> "Window":
+        """Load a Window from a UPath.
+
+        Args:
+            path: the root directory of the window
+
+        Returns:
+            the Window
+        """
+        metadata_fname = path / "metadata.json"
+        with metadata_fname.open("r") as f:
+            metadata = json.load(f)
+        return Window.from_metadata(path, metadata)
 
     @staticmethod
     def get_window_root(ds_path: UPath, group: str, name: str) -> UPath:

--- a/rslearn/dataset/window.py
+++ b/rslearn/dataset/window.py
@@ -304,12 +304,19 @@ class Window:
         Returns:
             the Window
         """
+        # Ensure bounds is converted from list to tuple.
+        bounds = (
+            metadata["bounds"][0],
+            metadata["bounds"][1],
+            metadata["bounds"][2],
+            metadata["bounds"][3],
+        )
         return Window(
             path=path,
             group=metadata["group"],
             name=metadata["name"],
             projection=Projection.deserialize(metadata["projection"]),
-            bounds=metadata["bounds"],
+            bounds=bounds,
             time_range=(
                 (
                     datetime.fromisoformat(metadata["time_range"][0]),

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -748,7 +748,7 @@ def dataset_build_index() -> None:
         description=("rslearn dataset build_index: " + "create a dataset index file"),
     )
     parser.add_argument(
-        "--ds_path",
+        "--root",
         type=str,
         required=True,
         help="Dataset path",
@@ -760,11 +760,13 @@ def dataset_build_index() -> None:
         help="Number of workers",
     )
     args = parser.parse_args(args=sys.argv[3:])
-    dataset = Dataset(UPath(args.ds_path))
-    DatasetIndex.build_index(
+    ds_path = UPath(args.root)
+    dataset = Dataset(ds_path)
+    index = DatasetIndex.build_index(
         dataset=dataset,
         workers=args.workers,
     )
+    index.save_index(ds_path)
 
 
 class RslearnLightningCLI(LightningCLI):

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -18,6 +18,7 @@ from rslearn.const import WGS84_EPSG
 from rslearn.data_sources import Item, data_source_from_config
 from rslearn.dataset import Dataset, Window, WindowLayerData
 from rslearn.dataset.add_windows import add_windows_from_box, add_windows_from_file
+from rslearn.dataset.index import DatasetIndex
 from rslearn.dataset.manage import (
     materialize_dataset_windows,
     prepare_dataset_windows,
@@ -737,6 +738,33 @@ def dataset_materialize() -> None:
         retry_backoff=timedelta(seconds=args.retry_backoff_seconds),
     )
     apply_on_windows_args(fn, args)
+
+
+@register_handler("dataset", "build_index")
+def dataset_build_index() -> None:
+    """Handler for the rslearn dataset build_index command."""
+    parser = argparse.ArgumentParser(
+        prog="rslearn dataset build_index",
+        description=("rslearn dataset build_index: " + "create a dataset index file"),
+    )
+    parser.add_argument(
+        "--ds_path",
+        type=str,
+        required=True,
+        help="Dataset path",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=16,
+        help="Number of workers",
+    )
+    args = parser.parse_args(args=sys.argv[3:])
+    dataset = Dataset(UPath(args.ds_path))
+    DatasetIndex.build_index(
+        dataset=dataset,
+        workers=args.workers,
+    )
 
 
 class RslearnLightningCLI(LightningCLI):

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -416,7 +416,7 @@ class ModelDataset(torch.utils.data.Dataset):
                 if split_config.overlap_ratio
                 else 0
             )
-            for window in self.windows:
+            for window in dataset_examples:
                 cur_patches = []
                 if window is None:
                     raise ValueError("Window is None in load_all_patches")

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -1,10 +1,13 @@
 """Default Dataset for rslearn."""
 
 import hashlib
+import json
 import multiprocessing
 import os
 import random
+import tempfile
 import time
+import uuid
 from typing import Any
 
 import torch
@@ -353,11 +356,17 @@ class ModelDataset(torch.utils.data.Dataset):
 
         # Eliminate windows that are missing either a requisite input layer, or missing
         # all target layers.
+        # We use only main thread if the index is set, since that can take a long time
+        # to send to the worker threads, it may get serialized for each window.
         new_windows = []
-        if workers == 0:
+        if workers == 0 or windows[0].index is not None:
             for window in windows:
                 if check_window(self.inputs, window) is None:
                     continue
+                # The index may be set, but now that this check is done, from here on
+                # we no longer need it. We set it None so that we don't end up passing
+                # it later to the dataloader workers.
+                window.index = None
                 new_windows.append(window)
         else:
             p = multiprocessing.Pool(workers)
@@ -396,9 +405,10 @@ class ModelDataset(torch.utils.data.Dataset):
             # be representative of the population.
             windows = windows[0 : split_config.num_samples]
 
-        self.windows: list = windows
+        dataset_examples: list = windows
 
         # If we're loading all patches, we need to include the patch details.
+        # In this case, dataset_examples is a list of (window, bounds, (patch_idx, # patches)).
         if split_config.get_load_all_patches() and self.patch_size is not None:
             patches = []
             overlap_size = int(
@@ -430,11 +440,68 @@ class ModelDataset(torch.utils.data.Dataset):
                         )
                 for i, patch_bounds in enumerate(cur_patches):
                     patches.append((window, patch_bounds, (i, len(cur_patches))))
-            self.windows = patches
+            dataset_examples = patches
+
+        # Write dataset_examples to a file so that we can load it lazily in the worker
+        # processes. Otherwise it takes a long time to transmit it when spawning each
+        # process.
+        self.dataset_examples_fname = os.path.join(
+            tempfile.gettempdir(),
+            "rslearn_dataset_examples",
+            f"{os.getpid()}_{uuid.uuid4()}.json",
+        )
+        self.num_dataset_examples = len(dataset_examples)
+        self.dataset_examples: list | None = None
+        logger.info(
+            f"Writing {len(dataset_examples)} dataset examples to {self.dataset_examples_fname}"
+        )
+        os.makedirs(os.path.dirname(self.dataset_examples_fname), exist_ok=True)
+        with open(self.dataset_examples_fname, "w") as f:
+            json.dump(
+                [self._serialize_item(example) for example in dataset_examples], f
+            )
+
+    def _serialize_item(self, example: Window | tuple) -> dict[str, Any]:
+        if isinstance(example, Window):
+            return {
+                "window": example.get_metadata(),
+            }
+        else:
+            window, patch_bounds, indices = example
+            return {
+                "window": window.get_metadata(),
+                "patch_bounds": patch_bounds,
+                "indices": indices,
+            }
+
+    def _deserialize_item(self, d: dict[str, Any]) -> Window | tuple:
+        window_metadata = d["window"]
+        window = Window.from_metadata(
+            Window.get_window_root(
+                self.dataset.path, window_metadata["group"], window_metadata["name"]
+            ),
+            window_metadata,
+        )
+        if "patch_bounds" in d:
+            return (window, tuple(d["patch_bounds"]), tuple(d["indices"]))
+        else:
+            return window
+
+    def _get_dataset_examples(self) -> list:
+        if self.dataset_examples is None:
+            logger.info(
+                f"Loading dataset examples from {self.dataset_examples_fname} in process {os.getpid()}"
+            )
+            with open(self.dataset_examples_fname) as f:
+                self.dataset_examples = [
+                    self._deserialize_item(d) for d in json.load(f)
+                ]
+            logger.info(f"Finished loading dataset examples in process {os.getpid()}")
+        return self.dataset_examples
 
     def __len__(self) -> int:
         """Returns the dataset length."""
-        return len(self.windows)
+        return self.num_dataset_examples
 
     def __getitem__(
         self, idx: int
@@ -447,13 +514,16 @@ class ModelDataset(torch.utils.data.Dataset):
         Returns:
             a tuple (input_dict, target_dict)
         """
+        dataset_examples = self._get_dataset_examples()
         logger.debug("__getitem__ start pid=%d item_idx=%d", os.getpid(), idx)
-        window = self.windows[idx]
+        example = dataset_examples[idx]
 
         # Select bounds to read.
         if self.split_config.get_load_all_patches():
-            window, bounds, (patch_idx, num_patches) = window
+            window, bounds, (patch_idx, num_patches) = example
+
         elif self.patch_size:
+            window = example
 
             def get_patch_range(n_patch: int, n_window: int) -> list[int]:
                 if n_patch > n_window:
@@ -481,7 +551,9 @@ class ModelDataset(torch.utils.data.Dataset):
                 window.bounds[0] + patch_ranges[0][1],
                 window.bounds[1] + patch_ranges[1][1],
             ]
+
         else:
+            window = example
             bounds = window.bounds
 
         # Read the inputs and targets.

--- a/tests/integration/train/test_dataset.py
+++ b/tests/integration/train/test_dataset.py
@@ -55,5 +55,5 @@ class TestDataset:
             workers=4,
         )
         assert len(dataset) == 2
-        window_names = {window.name for window in dataset.get_windows()}
+        window_names = {window.name for window in dataset.get_dataset_examples()}
         assert window_names == {"window3", "window4"}

--- a/tests/unit/dataset/test_index.py
+++ b/tests/unit/dataset/test_index.py
@@ -1,0 +1,91 @@
+import json
+import pathlib
+
+import pytest
+from upath import UPath
+
+from rslearn.const import WGS84_PROJECTION
+from rslearn.dataset.dataset import Dataset
+from rslearn.dataset.index import DatasetIndex
+from rslearn.dataset.window import Window, WindowLayerData
+
+
+@pytest.fixture
+def dummy_dataset(tmp_path: pathlib.Path) -> Dataset:
+    """An empty dataset with one layer called layer."""
+    ds_path = UPath(tmp_path)
+    with (ds_path / "config.json").open("w") as f:
+        json.dump({"layers": {"layer": {"type": "vector"}}}, f)
+    return Dataset(ds_path)
+
+
+def make_window(dataset: Dataset, name: str) -> Window:
+    """Add a window to the dataset with the given name."""
+    window = Window(
+        path=Window.get_window_root(dataset.path, "group", name),
+        group="group",
+        name=name,
+        projection=WGS84_PROJECTION,
+        bounds=(0, 0, 1, 1),
+        time_range=None,
+    )
+    window.save()
+    return window
+
+
+def test_build_index_one_window(dummy_dataset: Dataset) -> None:
+    """Ensure that the index is built correctly with one window.
+
+    We check the window, but also the layer datas and completed layers.
+    """
+    window = make_window(dummy_dataset, "name")
+    layer_data = WindowLayerData("layer", [[{"name": "x"}]])
+    window.save_layer_datas({"layer": layer_data})
+    layer_dir = window.get_layer_dir("layer")
+    layer_dir.mkdir(parents=True)
+    window.mark_layer_completed("layer")
+
+    index = DatasetIndex.build_index(dummy_dataset, workers=1)
+
+    assert len(index.windows) == 1
+    assert index.windows[0].get_metadata() == window.get_metadata()
+    assert len(index.layer_datas[window.name]) == 1
+    assert index.layer_datas[window.name][0].serialize() == layer_data.serialize()
+    assert index.completed_layers[window.name] == [("layer", 0)]
+
+
+def test_index_used_for_loading_windows(dummy_dataset: Dataset) -> None:
+    """Verify that the index is used to load windows, when it exists.
+
+    To do so, we create a window, build the index, and then create another window, but
+    verify only the first window is returned in a call to
+    """
+    window1 = make_window(dummy_dataset, "window1")
+    DatasetIndex.build_index(dummy_dataset, workers=1).save_index(dummy_dataset.path)
+    make_window(dummy_dataset, "window2")
+    windows = dummy_dataset.load_windows()
+    assert len(windows) == 1
+    assert windows[0].get_metadata() == window1.get_metadata()
+
+
+def test_no_index_when_loading_windows(dummy_dataset: Dataset) -> None:
+    """Verify that the no_index argument to loading windows works.
+
+    It should not use the outdated index.
+    """
+    DatasetIndex.build_index(dummy_dataset, workers=1).save_index(dummy_dataset.path)
+    make_window(dummy_dataset, "window")
+    assert len(dummy_dataset.load_windows()) == 0
+    assert len(dummy_dataset.load_windows(no_index=True)) == 1
+
+
+def test_index_used_for_completed_layers(dummy_dataset: Dataset) -> None:
+    """Verify that the index is used for checking completed layers."""
+    window = make_window(dummy_dataset, "name")
+    DatasetIndex.build_index(dummy_dataset, workers=1).save_index(dummy_dataset.path)
+    layer_dir = window.get_layer_dir("layer")
+    layer_dir.mkdir(parents=True)
+    window.mark_layer_completed("layer")
+
+    windows = dummy_dataset.load_windows()
+    assert not windows[0].is_layer_completed("layer")


### PR DESCRIPTION
Resolves #161.

Currently, loading windows can take several minutes or even hours, depending on the number of windows and where the dataset is stored. This is especially annoying when we need to wait for the loading to complete before the model starts training.

This PR adds a DatasetIndex. The index is stored in a single file/object, so it can be retrieved relatively quickly; it isn't compressed, so we read about the same number of bytes, but reading a single file is much faster than reading hundreds of thousands of files. The index enumerates the windows and their metadata (metadata.json), along with the layer datas (items.json) and which layers are "completed".

A new `rslearn dataset build_index` command is added, and we check if the index exists when calling Dataset.load_windows. If it does exist, then the index is passed to the returned Window objects so that they can continue to use the index to satisfy calls to load_layer_datas / is_layer_completed.

Additionally, I updated `rslearn.train.dataset.ModelDataset` to save the list of Windows to a file rather than keeping it as a field. The list is then loaded from the file lazily after the dataloader workers are started. Keeping it as a field means pytorch sends it to each worker when it spawns it sequentially, which is much slower. This further speeds up the initialization time for training jobs on rslearn datasets with many windows.