### PR TITLE
Model deletion fails nondeterministically because we have parallel test workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,4 @@ testpaths = [
 addopts = [
     "--import-mode=importlib",
 ]
+tmp_path_retention_policy = "failed"

--- a/tests/unit/models/test_clip.py
+++ b/tests/unit/models/test_clip.py
@@ -7,7 +7,7 @@ from rslearn.models.clip import CLIP
 @pytest.mark.parametrize(
     "model_name", ["openai/clip-vit-base-patch32", "openai/clip-vit-large-patch14-336"]
 )
-def test_molmo(model_name: str) -> None:
+def test_clip(model_name: str) -> None:
     # Make sure the forward pass works.
     clip = CLIP(model_name=model_name)
     inputs = [

--- a/tests/unit/models/test_terramind.py
+++ b/tests/unit/models/test_terramind.py
@@ -1,16 +1,19 @@
 """Test the Terramind model."""
 
-import os
-import shutil
-from pathlib import Path
+import pathlib
+from typing import Any
 
+import huggingface_hub.constants
 import torch
 
 from rslearn.models.terramind import Terramind, TerramindNormalize, TerramindSize
 
 
-def test_terramind() -> None:
+def test_terramind(tmp_path: pathlib.Path, monkeypatch: Any) -> None:
+    # Use monkeypatch to set HF_HUB_CACHE so we can store the weights in a temp dir.
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
     terramind = Terramind(model_size=TerramindSize.BASE, modalities=["RGB"])
+
     inputs = [
         {
             "RGB": torch.zeros((3, 256, 256), dtype=torch.float32),
@@ -30,8 +33,3 @@ def test_terramind() -> None:
     assert features.shape[0] == 1
     assert features.shape[2] == 16
     assert features.shape[3] == 16
-
-    # Delete any cached models if running in CI.
-    cache_dir = Path.home() / ".cache" / "huggingface" / "hub"
-    if cache_dir.exists() and os.environ.get("CI") == "true":
-        shutil.rmtree(cache_dir)


### PR DESCRIPTION
Model deletion fails nondeterministically because we have parallel test workers. For example, TerraMind and CLIP test both use HuggingFace so the deletion will conflict.

This PR changes it to use temporary directory instead by monkeypatching the relevant attributes. I updated pyproject.toml to direct pytest to only keep temp dirs from failing tests as well, since otherwise they would be retained which would defeat the point of this (to delete checkpoints immediately after the test is done in github action workers).