### PR TITLE
Finetuning on concatenated datasets

### DIFF
--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any, TypeVar
 
-import lightning as L
 import tqdm
 from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 from rasterio.crs import CRS
@@ -26,6 +25,8 @@ from rslearn.dataset.manage import (
 )
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import get_tile_store_with_layer
+from rslearn.train.data_module import RslearnDataModule
+from rslearn.train.lightning_module import RslearnLightningModule
 from rslearn.utils import Projection, STGeometry
 
 logger = get_logger(__name__)
@@ -778,11 +779,9 @@ class RslearnLightningCLI(LightningCLI):
 
 def model_handler() -> None:
     """Handler for any rslearn model X commands."""
-    # Decreased strictness of type checking for model and datamodule classes
-    # to allow for multiple dataset training tasks
     RslearnLightningCLI(
-        model_class=L.LightningModule,
-        datamodule_class=L.LightningDataModule,
+        model_class=RslearnLightningModule,
+        datamodule_class=RslearnDataModule,
         args=sys.argv[2:],
         subclass_mode_model=True,
         subclass_mode_data=True,

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -8,8 +8,8 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any, TypeVar
 
-import tqdm
 import lightning as L
+import tqdm
 from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 from rasterio.crs import CRS
 from upath import UPath

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, TypeVar
 
 import tqdm
+import lightning as L
 from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 from rasterio.crs import CRS
 from upath import UPath
@@ -25,8 +26,6 @@ from rslearn.dataset.manage import (
 )
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import get_tile_store_with_layer
-from rslearn.train.data_module import RslearnDataModule
-from rslearn.train.lightning_module import RslearnLightningModule
 from rslearn.utils import Projection, STGeometry
 
 logger = get_logger(__name__)
@@ -775,9 +774,11 @@ class RslearnLightningCLI(LightningCLI):
 
 def model_handler() -> None:
     """Handler for any rslearn model X commands."""
+    # Decreased strictness of type checking for model and datamodule classes
+    # to allow for multiple dataset training tasks
     RslearnLightningCLI(
-        model_class=RslearnLightningModule,
-        datamodule_class=RslearnDataModule,
+        model_class=L.LightningModule,
+        datamodule_class=L.LightningDataModule,
         args=sys.argv[2:],
         subclass_mode_model=True,
         subclass_mode_data=True,

--- a/rslearn/models/multitask.py
+++ b/rslearn/models/multitask.py
@@ -89,11 +89,15 @@ class MultiTaskModel(torch.nn.Module):
             print(f"INFO: loading full model weights from {checkpoint_path}")
             restore_config = RestoreConfig(
                 restore_path=checkpoint_path,
-                selector=["model."],
+                selector=["state_dict"],
                 remap_prefixes=[("model.", "")],
             )
             state_dict = restore_config.get_state_dict()
-            self.load_state_dict(state_dict, strict=False)
+            result = self.load_state_dict(state_dict, strict=False)
+            if result.missing_keys:
+                print(f"WARNING: missing keys: {result.missing_keys}")
+            if result.unexpected_keys:
+                print(f"WARNING: unexpected keys: {result.unexpected_keys}")
 
     def forward(
         self,

--- a/rslearn/models/multitask.py
+++ b/rslearn/models/multitask.py
@@ -87,7 +87,8 @@ class MultiTaskModel(torch.nn.Module):
             print(f"INFO: loading full model weights from {checkpoint_path}")
             state_dict = torch.load(checkpoint_path)["state_dict"]
             self.load_state_dict(
-                {k.replace("model.", "", 1): v for k, v in state_dict.items()}
+                {k.replace("model.", "", 1): v for k, v in state_dict.items()},
+                strict=False,
             )
 
     def forward(

--- a/rslearn/models/multitask.py
+++ b/rslearn/models/multitask.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import torch
 
+from rslearn.train.lightning_module import RestoreConfig
+
 
 def apply_decoder(
     features: list[torch.Tensor],
@@ -85,11 +87,13 @@ class MultiTaskModel(torch.nn.Module):
 
         if checkpoint_path is not None:
             print(f"INFO: loading full model weights from {checkpoint_path}")
-            state_dict = torch.load(checkpoint_path)["state_dict"]
-            self.load_state_dict(
-                {k.replace("model.", "", 1): v for k, v in state_dict.items()},
-                strict=False,
+            restore_config = RestoreConfig(
+                restore_path=checkpoint_path,
+                selector=["model."],
+                remap_prefixes=[("model.", "")],
             )
+            state_dict = restore_config.get_state_dict()
+            self.load_state_dict(state_dict, strict=False)
 
     def forward(
         self,

--- a/rslearn/train/callbacks/peft.py
+++ b/rslearn/train/callbacks/peft.py
@@ -1,0 +1,76 @@
+"""Parameter-efficient finetuning callbacks."""
+
+import torch
+import torch.nn.functional as F
+from lightning.pytorch import LightningModule
+from lightning.pytorch.callbacks import BaseFinetuning
+from torch.optim.optimizer import Optimizer
+from helios.nn.attention import Attention
+
+
+class SplitProjection(torch.nn.Module):
+
+    def __init__(self, dim, r=8):
+        super().__init__()
+        self.dim = dim
+        self.r = r
+
+        # Register indices as buffers so they move to the correct device automatically
+        indices = torch.randperm(dim)
+        self.register_buffer('trainable_inds', indices[:r])
+        self.register_buffer('frozen_inds', indices[r:])
+
+        # Create parameter modules directly
+        self.trainable_w = torch.nn.Parameter(torch.empty(dim, r), requires_grad=True)
+        self.frozen_w = torch.nn.Parameter(torch.empty(dim, dim - r), requires_grad=False)
+        self.trainable_b = torch.nn.Parameter(torch.empty(r), requires_grad=True)
+        self.frozen_b = torch.nn.Parameter(torch.empty(dim - r), requires_grad=False)
+
+    def forward(self, x):
+        trainable_out = F.linear(x, self.trainable_w, self.trainable_b)
+        frozen_out = F.linear(x, self.frozen_w, self.frozen_b)
+        
+        output = torch.zeros(x.shape, device=x.device, dtype=trainable_out.dtype)
+        output[..., self.trainable_inds] = trainable_out
+        output[..., self.frozen_inds] = frozen_out
+        
+        return output
+
+
+class APLA(BaseFinetuning):
+    """APLA (https://arxiv.org/pdf/2503.11335v2) finetuning callback."""
+
+    def __init__(self, r: int = 8) -> None:
+        super().__init__()
+        self.r = r
+
+    def freeze_before_training(self, pl_module: LightningModule) -> None:
+        print(f"splitting projection weights by monkeypatching")
+        model = pl_module.model
+        self.freeze(model.encoder[0])
+        n_trainable = 0
+        for layer in model.encoder[0].model.blocks:
+            if hasattr(layer, 'attn'):
+                alpa_proj = SplitProjection(layer.attn.proj.weight.shape[0], r=self.r)
+                proj_weight = layer.attn.proj.weight.data.clone()
+                proj_bias = layer.attn.proj.bias.data.clone()
+
+                alpa_proj.trainable_w.data = proj_weight[alpa_proj.trainable_inds, :]
+                alpa_proj.frozen_w.data = proj_weight[alpa_proj.frozen_inds, :]
+
+                alpa_proj.trainable_b.data = proj_bias[alpa_proj.trainable_inds]
+                alpa_proj.frozen_b.data = proj_bias[alpa_proj.frozen_inds]
+
+                alpa_proj.trainable_w.requires_grad = True
+                alpa_proj.trainable_b.requires_grad = True
+                n_trainable += alpa_proj.trainable_w.numel() + alpa_proj.trainable_b.numel()
+
+                layer.attn.proj = alpa_proj
+
+        print(f"n_trainable: {n_trainable / int(1e6)}M")
+
+    def finetune_function(
+        self, pl_module: LightningModule, current_epoch: int, optimizer: Optimizer
+    ) -> None:
+        # Maybe worth unfreezing down the line?
+        pass

--- a/rslearn/train/callbacks/peft.py
+++ b/rslearn/train/callbacks/peft.py
@@ -5,35 +5,56 @@ import torch.nn.functional as F
 from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks import BaseFinetuning
 from torch.optim.optimizer import Optimizer
-from helios.nn.attention import Attention
 
 
 class SplitProjection(torch.nn.Module):
+    """Split projection weights into trainable and frozen parts.
 
-    def __init__(self, dim, r=8):
+    This module is used to split the projection weights into trainable and frozen parts.
+    The trainable part is used to compute the output, and the frozen part is used to
+    compute the output without gradients.
+    """
+
+    def __init__(self, dim: int, r: int = 8) -> None:
+        """Initialize the SplitProjection module.
+
+        Args:
+            dim: the dimension of the input and output
+            r: the number of trainable parameters
+        """
         super().__init__()
         self.dim = dim
         self.r = r
 
         # Register indices as buffers so they move to the correct device automatically
         indices = torch.randperm(dim)
-        self.register_buffer('trainable_inds', indices[:r])
-        self.register_buffer('frozen_inds', indices[r:])
+        self.register_buffer("trainable_inds", indices[:r])
+        self.register_buffer("frozen_inds", indices[r:])
 
         # Create parameter modules directly
         self.trainable_w = torch.nn.Parameter(torch.empty(dim, r), requires_grad=True)
-        self.frozen_w = torch.nn.Parameter(torch.empty(dim, dim - r), requires_grad=False)
+        self.frozen_w = torch.nn.Parameter(
+            torch.empty(dim, dim - r), requires_grad=False
+        )
         self.trainable_b = torch.nn.Parameter(torch.empty(r), requires_grad=True)
         self.frozen_b = torch.nn.Parameter(torch.empty(dim - r), requires_grad=False)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the SplitProjection module.
+
+        Args:
+            x: the input tensor
+
+        Returns:
+            the output tensor
+        """
         trainable_out = F.linear(x, self.trainable_w, self.trainable_b)
         frozen_out = F.linear(x, self.frozen_w, self.frozen_b)
-        
+
         output = torch.zeros(x.shape, device=x.device, dtype=trainable_out.dtype)
-        output[..., self.trainable_inds] = trainable_out
-        output[..., self.frozen_inds] = frozen_out
-        
+        output[..., self.trainable_inds] = trainable_out  # type: ignore
+        output[..., self.frozen_inds] = frozen_out  # type: ignore
+
         return output
 
 
@@ -41,16 +62,26 @@ class APLA(BaseFinetuning):
     """APLA (https://arxiv.org/pdf/2503.11335v2) finetuning callback."""
 
     def __init__(self, r: int = 8) -> None:
+        """Initialize the APLA finetuning callback.
+
+        Args:
+            r: the number of trainable parameters
+        """
         super().__init__()
         self.r = r
 
     def freeze_before_training(self, pl_module: LightningModule) -> None:
-        print(f"splitting projection weights by monkeypatching")
+        """Freeze the model before training.
+
+        Args:
+            pl_module: the LightningModule
+        """
+        print("splitting projection weights by monkeypatching")
         model = pl_module.model
         self.freeze(model.encoder[0])
         n_trainable = 0
         for layer in model.encoder[0].model.blocks:
-            if hasattr(layer, 'attn'):
+            if hasattr(layer, "attn"):
                 alpa_proj = SplitProjection(layer.attn.proj.weight.shape[0], r=self.r)
                 proj_weight = layer.attn.proj.weight.data.clone()
                 proj_bias = layer.attn.proj.bias.data.clone()
@@ -63,7 +94,9 @@ class APLA(BaseFinetuning):
 
                 alpa_proj.trainable_w.requires_grad = True
                 alpa_proj.trainable_b.requires_grad = True
-                n_trainable += alpa_proj.trainable_w.numel() + alpa_proj.trainable_b.numel()
+                n_trainable += (
+                    alpa_proj.trainable_w.numel() + alpa_proj.trainable_b.numel()
+                )
 
                 layer.attn.proj = alpa_proj
 
@@ -72,5 +105,12 @@ class APLA(BaseFinetuning):
     def finetune_function(
         self, pl_module: LightningModule, current_epoch: int, optimizer: Optimizer
     ) -> None:
+        """Do nothing here.
+
+        Args:
+            pl_module: the LightningModule
+            current_epoch: the current epoch
+            optimizer: the optimizer
+        """
         # Maybe worth unfreezing down the line?
         pass

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -268,7 +268,7 @@ class MultiDatasetDataModule(L.LightningDataModule):
                 multi_dataset=dataset,
                 batch_size=batch_size,
                 shuffle=(split == "train"),
-                drop_last=True,  # should already be handled but in case
+                drop_last=True,
                 num_replicas=self.trainer.world_size,  # type: ignore
                 rank=self.trainer.global_rank,  # type: ignore
             ),
@@ -322,7 +322,7 @@ class DistributedPerDatasetBatchSampler(torch.utils.data.Sampler[list[int]]):
             num_replicas=num_replicas,
             rank=rank,
             shuffle=shuffle,
-            drop_last=False,  # we handle drop_last in our own sampler
+            drop_last=True,  # should already be handled but in case
         )
         self.buckets = list(multi_dataset.buckets.items())
         self.batch_size = batch_size

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -1,5 +1,6 @@
 """Default LightningDataModule for rslearn."""
 
+import random
 from typing import Any
 
 import lightning as L
@@ -10,6 +11,9 @@ from upath import UPath
 from rslearn.dataset import Dataset
 from rslearn.train.tasks import Task
 
+from typing import Dict, Optional, List
+from torch.utils.data import DataLoader, IterableDataset
+from rslearn.train.tasks.multi_task import MultiTask
 from .dataset import DataInput, ModelDataset, RetryDataset, SplitConfig
 
 
@@ -167,4 +171,114 @@ class RslearnDataModule(L.LightningDataModule):
             MisconfigurationException: If :meth:`setup` does not define a
                 dataset or sampler, or if the dataset or sampler has length 0.
         """
+        return self._get_dataloader("predict")
+
+
+class MultiWrapperDataset(IterableDataset):
+    """
+    Multi-dataset data module for training on multiple datasets with different modalities.
+    Basic data flow:
+    1. Build individual RslearnDataModule instances from dataset configs
+    2. Build a MultiWrapperDataset from the DataLoaders of these RslearnDataModule instances
+    3. Wrap the MultiWrapperDataset in a DataLoader shell
+    4. Pass the DataLoader to the LightningDataModule and use as normal
+    """
+
+    def __init__(self, dataloaders: List[DataLoader], tasks: List[str], strategy: str = "random"):
+        """
+        dataloaders: list of DataLoader objects
+        tasks: list of task names, one for each dataloader
+        strategy: "random" or "round_robin"
+        """
+        assert len(dataloaders) == len(tasks), "number of dataloaders and tasks must match"
+        self.dataloaders = dataloaders
+        self.strategy = strategy
+        self.tasks = tasks.copy()
+
+    def __iter__(self):
+        self.iterators = [iter(dl) for dl in self.dataloaders]
+        while True:
+            if self.strategy == "random":
+                idx = random.randint(0, len(self.iterators) - 1)
+            elif self.strategy == "round_robin":
+                idx = getattr(self, 'last_idx', -1) + 1
+                idx %= len(self.iterators)
+                self.last_idx = idx
+            else:
+                raise ValueError("Unknown strategy")
+
+            try:
+                batch = next(self.iterators[idx])
+                for instance in batch[0]:
+                    instance["dataset_source"] = self.tasks[idx]
+                yield batch
+            except StopIteration:
+                self.iterators.pop(idx)
+                self.tasks.pop(idx)
+                if len(self.iterators) == 0:
+                    break
+                if self.strategy == "round_robin":
+                    self.last_idx -= 1
+
+
+class MultiDatasetDataModule(L.LightningDataModule):
+    """Data module that manages multiple RslearnDataModule instances.
+    
+    This module creates and manages multiple RslearnDataModule instances, each handling
+    a different dataset. It provides a unified interface for training on multiple datasets
+    with different modalities and labels.
+    
+    Each dataset can have different:
+    - Input modalities (e.g., Sentinel-2 vs Landsat)
+    - Label schemas (e.g., different classification classes)
+    - Task types (e.g., classification vs detection)
+    - Transforms and preprocessing
+    """
+
+    def __init__(
+        self,
+        dataset_configs: Dict[str, RslearnDataModule],
+        task: MultiTask,
+        batch_size: int = 16,
+        num_workers: int = 32,
+        **kwargs
+    ):
+        super().__init__()
+        
+        self.tasks = list(dataset_configs.keys())
+        self.data_modules = dataset_configs
+        self.global_batch_size = batch_size
+        self.global_num_workers = num_workers
+
+    def setup(self, stage: Optional[str] = None):
+        """Set up the datasets for the given stage.
+        
+        Args:
+            stage: The stage to set up ('fit', 'validate', 'test', 'predict')
+        """
+        for data_module in self.data_modules.values():
+            data_module.setup(stage)
+
+    def _get_dataloader(self, split: str) -> DataLoader[dict[str, torch.Tensor]]:
+        dataloaders = []
+        for data_module in self.data_modules.values():
+            dataloaders.append(data_module._get_dataloader(split))
+        return DataLoader(
+            MultiWrapperDataset(dataloaders, self.tasks),
+            batch_size=None,
+            num_workers=0,    # handle splitting and multiprocessing in the 
+            shuffle=False,    # individual dataloaders spawned by rslearn
+            pin_memory=True,  # unclear if we need this, haven't checked properly
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        return self._get_dataloader("train")
+
+    def val_dataloader(self) -> DataLoader:
+        return self._get_dataloader("val")
+
+    def test_dataloader(self) -> DataLoader:
+        return self._get_dataloader("test")
+
+    def predict_dataloader(self) -> DataLoader:
         return self._get_dataloader("predict")

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -130,7 +130,14 @@ class RslearnDataModule(L.LightningDataModule):
         should_shuffle = split == "train"
         if sampler_factory:
             kwargs["sampler"] = sampler_factory.get_sampler(dataset)
-        elif self.trainer.world_size is not None and self.trainer.world_size > 1:
+        elif (
+            self.trainer is not None
+            and self.trainer.world_size is not None
+            and self.trainer.world_size > 1
+        ):
+            # NOTE: when doing single-gpu multi-dataset training, self.trainer is None
+            # unsure if this is only for single-gpu setting or multi-dataset
+            # is broken for distributed traning
             # Use distributed sampler in case ddp is enabled.
             kwargs["sampler"] = DistributedSampler(
                 dataset,

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -226,7 +226,7 @@ class MultiDatasetDataModule(L.LightningDataModule):
         self,
         dataset_configs: dict[str, RslearnDataModule],
         task: MultiTask,
-        max_num_workers: int = 32,
+        num_workers: int = 32,
         **kwargs: Any,
     ) -> None:
         """Initialize a new MultiDatasetDataModule.
@@ -234,12 +234,12 @@ class MultiDatasetDataModule(L.LightningDataModule):
         Args:
             dataset_configs: dict mapping dataset names to RslearnDataModule objects
             task: the task to train on
-            max_num_workers: the maximum number of workers to use for the dataloader
+            num_workers: the maximum number of workers to use for the dataloader
             kwargs: additional keyword arguments
         """
         super().__init__()
         self.data_modules = dataset_configs
-        self.max_num_workers = max_num_workers
+        self.num_workers = num_workers
 
     def setup(self, stage: str | None = None) -> None:
         """Set up the datasets for the given stage. Also assign dataset-specific names.
@@ -261,7 +261,7 @@ class MultiDatasetDataModule(L.LightningDataModule):
         return DataLoader(
             dataset=dataset,
             pin_memory=True,
-            num_workers=self.max_num_workers,
+            num_workers=self.num_workers,
             persistent_workers=True,
             collate_fn=collate_fn,
             batch_sampler=DistributedPerDatasetBatchSampler(

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -1,20 +1,19 @@
 """Default LightningDataModule for rslearn."""
 
-import os
 import random
 from collections.abc import Iterator
 from typing import Any
 
 import lightning as L
 import torch
-from torch.utils.data import DataLoader, DistributedSampler, IterableDataset
+from torch.utils.data import DataLoader, DistributedSampler
 from upath import UPath
 
 from rslearn.dataset import Dataset
 from rslearn.train.tasks import Task
 from rslearn.train.tasks.multi_task import MultiTask
 
-from .dataset import DataInput, ModelDataset, RetryDataset, SplitConfig
+from .dataset import DataInput, ModelDataset, MultiDataset, RetryDataset, SplitConfig
 
 
 def collate_fn(
@@ -124,23 +123,12 @@ class RslearnDataModule(L.LightningDataModule):
     def _get_dataloader(
         self,
         split: str,
-        is_inner_process: bool = False,
-        generator: torch.Generator | None = None,
     ) -> DataLoader[dict[str, torch.Tensor]]:
         """Get a dataloader for the given split.
 
-        If is_inner_process is True, then this dataloader is in an inner process, and we
-        don't want to spawn nested processes. In this case, we use a generator to shuffle
-        the data, and we don't use a sampler. We need a generator to ensure that each
-        child dataloader gets the same shuffle, otherwise rank/processes won't synch.
-
         Args:
             split: the split to get a dataloader for
-            is_inner_process: whether this dataloader is in an inner process
-            generator: a generator to use for shuffling (only used if is_inner_process is True)
         """
-        # is_inner_process is used if we are in a multi dataset setting, and this dataloader
-        # is one of a set instantiated PER process (so we don't want to spawn nested processes)
         dataset = self.datasets[split]
         persistent_workers = self.num_workers > 0
         kwargs = dict(
@@ -150,16 +138,7 @@ class RslearnDataModule(L.LightningDataModule):
             collate_fn=collate_fn,
             persistent_workers=persistent_workers,
         )
-        # Can still shuffle in inner process since we rebuild dataloaders
         should_shuffle = split == "train"
-        if is_inner_process:
-            assert generator is not None, "generator must be provided for inner process"
-            kwargs["num_workers"] = 0
-            kwargs["persistent_workers"] = False
-            kwargs["shuffle"] = should_shuffle
-            kwargs["pin_memory"] = False
-            kwargs["generator"] = generator  # type: ignore
-            return DataLoader(**kwargs)  # type: ignore
 
         sampler_factory = self.split_configs[split].sampler
         if sampler_factory:
@@ -229,143 +208,6 @@ class RslearnDataModule(L.LightningDataModule):
         return self._get_dataloader("predict")
 
 
-class MultiWrapperDataset(IterableDataset):
-    """IterableDataset that wraps several RslearnDataModule DataLoaders.
-
-    Wraps several RslearnDataModule DataLoaders and emits batches in random order
-    with correct sharding across DDP ranks (GPU) and DataLoader workers (CPU).
-    Manual sharding only (seems to be faster).
-
-    Basic data flow:
-    1. Build individual RslearnDataModule instances from dataset configs
-    2. Build a MultiWrapperDataset from the DataLoaders of these RslearnDataModule instances
-    3. Wrap the MultiWrapperDataset in a DataLoader shell
-    4. Pass the DataLoader to the LightningDataModule and use as normal
-    """
-
-    def __init__(
-        self,
-        data_modules: dict[str, "RslearnDataModule"],
-        rank: int,
-        world_size: int,
-        split: str = "train",
-        epoch: int = 0,
-    ) -> None:
-        """Initialize a new MultiWrapperDataset.
-
-        Args:
-            data_modules: dict mapping dataset names to RslearnDataModule objects
-            rank: the rank of the current process
-            world_size: the total number of processes
-            split: "train", "val", "test", or "predict"
-            epoch: the current epoch
-        """
-        super().__init__()
-        self.data_modules = data_modules
-        self.split = split
-        self.rank = rank
-        self.world_size = world_size
-        self.epoch = epoch
-
-    def _build_dataloaders(self, seed: int = 0) -> list[DataLoader]:
-        """Build the dataloaders for the given split.
-
-        Lightning will call this every epoch when it re‑creates the DataLoaders.
-        Note that the base seed should be consistent across all ranks/processes,
-        but is modified for each spawn's dataloader.
-
-        The seed argument is only used for shuffling (needs to be identical across
-        all the child dataloaders), but is not used to seed transforms.
-
-        Args:
-            seed: a seed to use for shuffling across all dataloaders
-
-        Returns:
-            A list of DataLoaders for the given split.
-        """
-        dataloaders = []
-        for i, dm in enumerate(self.data_modules.values()):
-            generator = torch.Generator()
-            generator.manual_seed(seed + i)
-            dataloaders.append(
-                dm._get_dataloader(
-                    self.split,
-                    is_inner_process=True,
-                    generator=generator,
-                )
-            )
-        return dataloaders
-
-    def _worker(self) -> tuple[int, int]:
-        """Get the worker id and number of workers for the current process."""
-        w = torch.utils.data.get_worker_info()
-        return (w.id, w.num_workers) if w else (0, 1)
-
-    def __len__(self) -> int:
-        """Get the length of the dataset.
-
-        This information is per rank, after sharding. It's not exact (may be off
-        due to uneven splits - see docs in __iter__) but is okay for logging.
-
-        Do NOT use this for operations that require exact counts (e.g. anything
-        with distributed training)!
-
-        Returns:
-            The length of the dataset.
-        """
-        total_batches = sum(
-            int(len(dm.datasets[self.split]) / dm.batch_size)
-            for dm in self.data_modules.values()
-        )
-        return int(total_batches / self.world_size)
-
-    def __iter__(self) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
-        """Iterate over the dataset.
-
-        For each GPU rank (process), we have a pool of workers. For each worker in each
-        rank, we have a disjoint set of batches we will route to the data queue.
-        We need to ensure that 1) each worker per rank gets a unique set of batches, and
-        2) all batches are routed, 3) shuffling is consistent across workers in all ranks.
-
-        NOTE: Condition 2 is not really satisfied, since we need to enforce exact batch
-        counts across ranks/workers to prevent hangs. There might be a few dropped batches.
-
-        Returns:
-            An iterator over the dataset for this particular rank/worker.
-        """
-        # Set a consistent seed across all ranks and all workers
-        rng = random.Random(self.epoch)
-        loaders = self._build_dataloaders(self.epoch)
-        total_raw_batches = sum(len(dl) for dl in loaders)
-
-        # Compute this rank/worker's id compared to the global batch counter
-        wid, num_w = self._worker()
-        my_id = self.rank * num_w + wid
-        parts = self.world_size * num_w
-        iters = [iter(dl) for dl in loaders]
-        local_yielded = 0
-        max_local = total_raw_batches // parts
-        self.epoch += 1
-
-        # Only yield batches that belong to this rank/worker
-        for global_idx in range(total_raw_batches):
-            if not iters or local_yielded >= max_local:
-                # Ensure that all ranks/workers yield the same number of batches
-                # Otherwise, NCCL hangs waiting for an all-reduce (gather?) even
-                # though some dataloaders have already quit the yield loop
-                break
-            batch = None
-            while batch is None and iters:
-                child_i = rng.randrange(len(iters))
-                try:
-                    batch = next(iters[child_i])
-                except StopIteration:
-                    iters.pop(child_i)
-            if batch is not None and global_idx % parts == my_id:
-                yield batch
-                local_yielded += 1
-
-
 class MultiDatasetDataModule(L.LightningDataModule):
     """Data module that manages multiple RslearnDataModule instances.
 
@@ -410,22 +252,26 @@ class MultiDatasetDataModule(L.LightningDataModule):
             data_module.set_name(name)
 
     def _get_dataloader(self, split: str) -> DataLoader[dict[str, torch.Tensor]]:
-        num_workers = min(len(os.sched_getaffinity(0)), self.max_num_workers)
-        print(f"INFO: using num_workers={num_workers} for {split} split")
-        print(f"INFO: restarting shuffling from epoch {self.trainer.current_epoch}")  # type: ignore
+        datasets = {name: dm.datasets[split] for name, dm in self.data_modules.items()}
+        batch_size = max(
+            self.data_modules.values(), key=lambda dm: dm.batch_size
+        ).batch_size
+        print(f"INFO: using batch_size {batch_size} for split {split}")
+        dataset = MultiDataset(datasets)
         return DataLoader(
-            dataset=MultiWrapperDataset(
-                self.data_modules,
-                split=split,
-                rank=self.trainer.global_rank,  # type: ignore
-                world_size=self.trainer.world_size,  # type: ignore
-                epoch=self.trainer.current_epoch,  # type: ignore
-            ),
-            batch_size=None,
+            dataset=dataset,
             pin_memory=True,
-            num_workers=num_workers,
-            shuffle=False,  # already randomly chose next dataloader + per-dataloader shuffler
-            persistent_workers=True,  # won't do much since we rebuild dataloaders on each epoch
+            num_workers=self.max_num_workers,
+            persistent_workers=True,
+            collate_fn=collate_fn,
+            batch_sampler=DistributedPerDatasetBatchSampler(
+                multi_dataset=dataset,
+                batch_size=batch_size,
+                shuffle=(split == "train"),
+                drop_last=False,
+                num_replicas=self.trainer.world_size,  # type: ignore
+                rank=self.trainer.global_rank,  # type: ignore
+            ),
         )
 
     def train_dataloader(self) -> DataLoader:
@@ -443,3 +289,101 @@ class MultiDatasetDataModule(L.LightningDataModule):
     def predict_dataloader(self) -> DataLoader:
         """Get the predict dataloader."""
         return self._get_dataloader("predict")
+
+
+class DistributedPerDatasetBatchSampler(torch.utils.data.Sampler[list[int]]):
+    """Distributed batch sampler yielding batches from one sub-dataset per rank.
+
+    Wraps torch DistributedSampler to first split indices across ranks,
+    then does "one-subdataset-per-batch" sampling in each process.
+    """
+
+    def __init__(
+        self,
+        multi_dataset: MultiDataset,
+        batch_size: int,
+        shuffle: bool = True,
+        drop_last: bool = True,
+        num_replicas: int | None = None,
+        rank: int | None = None,
+    ) -> None:
+        """Initialize a new DistributedPerDatasetBatchSampler.
+
+        Args:
+            multi_dataset: the MultiDataset to sample from
+            batch_size: the batch size
+            shuffle: whether to shuffle the indices
+            drop_last: whether to drop the last batch if it's not full
+            num_replicas: the number of replicas
+            rank: the rank
+        """
+        self.dist_sampler = DistributedSampler(
+            multi_dataset,  # get indices across all datasets, flattened
+            num_replicas=num_replicas,
+            rank=rank,
+            shuffle=shuffle,
+            drop_last=False,  # we handle drop_last in our own sampler
+        )
+        self.buckets = list(multi_dataset.buckets.items())
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the epoch for the distributed sampler.
+
+        Args:
+            epoch: the epoch to set
+        """
+        self.dist_sampler.set_epoch(epoch)
+
+    def __iter__(self) -> Iterator[list[int]]:
+        """Iterate over the batches."""
+        # Get the per-rank, per-epoch list of (shuffled) indices
+        all_idxs = list(iter(self.dist_sampler))
+
+        # Partition this rank's indices into sub-dataset buckets
+        partitioned: dict[str, list[int]] = {name: [] for name, _ in self.buckets}
+        for idx in all_idxs:
+            for name, rng in self.buckets:
+                if idx in rng:
+                    partitioned[name].append(idx)
+                    break
+
+        # Pick a non-empty bucket each time
+        while True:
+            # Which buckets can still yield at least 1 (or a full batch if drop_last)?
+            available = [
+                name
+                for name, idxs in partitioned.items()
+                if len(idxs) >= (self.batch_size if self.drop_last else 1)
+            ]
+            if not available:
+                break
+
+            name = random.choice(available)
+            idxs = partitioned[name]
+
+            if len(idxs) >= self.batch_size:
+                batch, partitioned[name] = (
+                    idxs[: self.batch_size],
+                    idxs[self.batch_size :],
+                )
+            else:
+                batch, partitioned[name] = idxs[:], []
+
+            yield batch
+
+    def __len__(self) -> int:
+        """Return the number of batches."""
+        total = 0
+        world_size = self.dist_sampler.num_replicas
+        for _, rng in self.buckets:
+            size = rng.stop - rng.start
+            per_rank = size // world_size
+            if not self.drop_last and size % world_size != 0:
+                per_rank += 1
+            if self.drop_last:
+                total += per_rank // self.batch_size
+            else:
+                total += (per_rank + self.batch_size - 1) // self.batch_size
+        return total

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -78,7 +78,6 @@ class RslearnDataModule(L.LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.name = name
-
         self.split_configs = {
             "train": default_config.update(train_config),
             "val": default_config.update(val_config),
@@ -115,7 +114,7 @@ class RslearnDataModule(L.LightningDataModule):
     def set_name(self, name: str) -> None:
         self.name = name
         for dataset in self.datasets.values():
-            dataset.dataset.name = name
+            dataset.set_name(name)
 
     def _get_dataloader(self, split: str) -> DataLoader[dict[str, torch.Tensor]]:
         dataset = self.datasets[split]
@@ -251,15 +250,11 @@ class MultiDatasetDataModule(L.LightningDataModule):
         self,
         dataset_configs: Dict[str, RslearnDataModule],
         task: MultiTask,
-        batch_size: int = 16,
-        num_workers: int = 32,
         **kwargs
     ):
         super().__init__()
         self.tasks = list(dataset_configs.keys())
         self.data_modules = dataset_configs
-        self.global_batch_size = batch_size
-        self.global_num_workers = num_workers
 
     def setup(self, stage: Optional[str] = None):
         """Set up the datasets for the given stage. Also assign dataset-specific names.

--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -268,7 +268,7 @@ class MultiDatasetDataModule(L.LightningDataModule):
                 multi_dataset=dataset,
                 batch_size=batch_size,
                 shuffle=(split == "train"),
-                drop_last=False,
+                drop_last=True,  # should already be handled but in case
                 num_replicas=self.trainer.world_size,  # type: ignore
                 rank=self.trainer.global_rank,  # type: ignore
             ),

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -619,7 +619,7 @@ class ModelDataset(torch.utils.data.Dataset):
             "bounds": bounds,
             "time_range": window.time_range,
             "projection": window.projection,
-            "task": self.name,
+            "dataset_source": self.name,
         }
         if self.split_config.get_load_all_patches():
             metadata["patch_idx"] = patch_idx
@@ -635,6 +635,7 @@ class ModelDataset(torch.utils.data.Dataset):
         )
         input_dict.update(passthrough_inputs)
         input_dict, target_dict = self.transforms(input_dict, target_dict)
+        input_dict["dataset_source"] = self.name
 
         logger.debug("__getitem__ finish pid=%d item_idx=%d", os.getpid(), idx)
 
@@ -645,6 +646,11 @@ class ModelDataset(torch.utils.data.Dataset):
         return self.windows
 
     def set_name(self, name: str) -> None:
+        """Set the name of the dataset.
+
+        Args:
+            name: the name to set.
+        """
         self.name = name
 
 
@@ -666,8 +672,13 @@ class RetryDataset(torch.utils.data.Dataset):
         self.delay = delay
 
     def set_name(self, name: str) -> None:
+        """Set the name of the dataset.
+
+        Args:
+            name: the name to set.
+        """
         self.dataset.set_name(name)
- 
+
     def __len__(self) -> int:
         """Return length of the dataset."""
         return len(self.dataset)

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -740,13 +740,13 @@ class MultiDataset(torch.utils.data.Dataset):
             the item data.
         """
         dataset_name = None
-        bucket = None
+        found_bucket = None
         for name, bucket in self.buckets.items():
             if idx in bucket:
                 dataset_name = name
-                bucket = bucket
+                found_bucket = bucket
                 break
         else:
             raise IndexError(f"Index {idx} out of range (len={len(self)})")
-        dataset_idx = idx - bucket.start
+        dataset_idx = idx - found_bucket.start
         return self.datasets[dataset_name][dataset_idx]

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -739,14 +739,7 @@ class MultiDataset(torch.utils.data.Dataset):
         Returns:
             the item data.
         """
-        dataset_name = None
-        found_bucket = None
         for name, bucket in self.buckets.items():
             if idx in bucket:
-                dataset_name = name
-                found_bucket = bucket
-                break
-        else:
-            raise IndexError(f"Index {idx} out of range (len={len(self)})")
-        dataset_idx = idx - found_bucket.start
-        return self.datasets[dataset_name][dataset_idx]
+                return self.datasets[name][idx - bucket.start]
+        raise IndexError(f"Index {idx} out of range (len={len(self)})")

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -289,6 +289,7 @@ class ModelDataset(torch.utils.data.Dataset):
         inputs: dict[str, DataInput],
         task: Task,
         workers: int,
+        name: str | None = None,
     ) -> None:
         """Instantiate a new ModelDataset.
 
@@ -298,12 +299,13 @@ class ModelDataset(torch.utils.data.Dataset):
             inputs: data to read from the dataset for training
             task: the task to train on
             workers: number of workers to use for initializing the dataset
+            name: name of the dataset (default: None)
         """
         self.dataset = dataset
         self.split_config = split_config
         self.inputs = inputs
         self.task = task
-
+        self.name = name
         if split_config.transforms:
             self.transforms = Sequential(*split_config.transforms)
         else:
@@ -609,6 +611,7 @@ class ModelDataset(torch.utils.data.Dataset):
             "bounds": bounds,
             "time_range": window.time_range,
             "projection": window.projection,
+            "task": self.name,
         }
         if self.split_config.get_load_all_patches():
             metadata["patch_idx"] = patch_idx
@@ -671,6 +674,7 @@ class RetryDataset(torch.utils.data.Dataset):
             try:
                 return self.dataset[idx]
             except Exception as e:
+                raise e
                 logger.warning("warning: caught exception loading item %d: %s", idx, e)
             time.sleep(self.delay)
 

--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -185,6 +185,14 @@ class RslearnLightningModule(L.LightningModule):
             self.schedulers["plateau"] = scheduler
         return d
 
+    def on_train_epoch_start(self) -> None:
+        """If we are in a multi-dataset distributed strategy, set the epoch."""
+        try:
+            self.trainer.train_dataloader.batch_sampler.set_epoch(self.current_epoch)
+        except AttributeError:
+            # Fail silently for single-dataset case, which is okay
+            pass
+
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> torch.Tensor:

--- a/rslearn/train/lightning_module.py
+++ b/rslearn/train/lightning_module.py
@@ -37,7 +37,7 @@ class RestoreConfig:
             restore_path_options: additional options for the restore_path to pass to
                 fsspec.
             selector: path in the torch dict containing the model parameters.
-            ignore_prefixes: prefixes to restore.
+            ignore_prefixes: prefixes to ignore from the state dict.
             remap_prefixes: list of (old_prefix, new_prefix) to rename parameters
                 starting with old_prefix to start with new_prefix instead.
         """
@@ -258,7 +258,7 @@ class RslearnLightningModule(L.LightningModule):
     def on_test_epoch_end(self) -> None:
         """Optionally save the test metrics to a file."""
         if self.metrics_file:
-            with open(self.metrics_file, "w+") as f:
+            with open(self.metrics_file, "w") as f:
                 metrics = self.test_metrics.compute()
                 metrics_dict = {k: v.item() for k, v in metrics.items()}
                 json.dump(metrics_dict, f, indent=4)

--- a/rslearn/train/tasks/multi_task.py
+++ b/rslearn/train/tasks/multi_task.py
@@ -46,12 +46,14 @@ class MultiTask(Task):
         """
         input_dict = {}
         target_dict = {}
-        if metadata["task"] is None:
+        if metadata["dataset_source"] is None:
             # No multi-dataset, so always compute across all tasks
             task_iter = list(self.tasks.items())
         else:
             # Multi-dataset, so only compute for the task in this dataset
-            task_iter = [(metadata["task"], self.tasks[metadata["task"]])]
+            task_iter = [
+                (metadata["dataset_source"], self.tasks[metadata["dataset_source"]])
+            ]
 
         for task_name, task in task_iter:
             cur_raw_inputs = {}

--- a/rslearn/train/tasks/multi_task.py
+++ b/rslearn/train/tasks/multi_task.py
@@ -166,8 +166,11 @@ class MetricWrapper(Metric):
                 [target[self.task_name] for target in targets],
             )
         except KeyError:
-            # this happens if during multi-task training, all tasks are not
+            # This happens if during multi-task training, all tasks are not
             # represented in the batch (which is expected)
+            # NOTE: This causes a warning about computing update on no data
+            # if the number of sanity steps at the start of training is less than
+            # the number of datasets we're training on
             pass
 
     def compute(self) -> Any:

--- a/rslearn/train/tasks/multi_task.py
+++ b/rslearn/train/tasks/multi_task.py
@@ -84,14 +84,12 @@ class MultiTask(Task):
         """
         processed_output = {}
         for task_name, task in self.tasks.items():
-            try:
+            if task_name in raw_output:
                 processed_output[task_name] = task.process_output(
                     raw_output[task_name], metadata
                 )
-            except KeyError:
-                # this happens if during multi-task training, all tasks are not
+                # will fail during multi-task training, all tasks are not
                 # represented in the batch (which is expected)
-                pass
         return processed_output
 
     def visualize(
@@ -160,18 +158,13 @@ class MetricWrapper(Metric):
             preds: the predictions
             targets: the targets
         """
-        try:
+        if self.task_name in preds:
             self.metric.update(
                 [pred[self.task_name] for pred in preds],
                 [target[self.task_name] for target in targets],
             )
-        except KeyError:
-            # This happens if during multi-task training, all tasks are not
+            # Will fail if during multi-task training, all tasks are not
             # represented in the batch (which is expected)
-            # NOTE: This causes a warning about computing update on no data
-            # if the number of sanity steps at the start of training is less than
-            # the number of datasets we're training on
-            pass
 
     def compute(self) -> Any:
         """Returns the computed metric."""

--- a/rslearn/train/tasks/multi_task.py
+++ b/rslearn/train/tasks/multi_task.py
@@ -48,7 +48,7 @@ class MultiTask(Task):
         target_dict = {}
         if metadata["task"] is None:
             # No multi-dataset, so always compute across all tasks
-            task_iter = self.tasks.items()
+            task_iter = list(self.tasks.items())
         else:
             # Multi-dataset, so only compute for the task in this dataset
             task_iter = [(metadata["task"], self.tasks[metadata["task"]])]
@@ -88,7 +88,7 @@ class MultiTask(Task):
                 )
             except KeyError:
                 # this happens if during multi-task training, all tasks are not
-                # represented in the batch (which is expected) 
+                # represented in the batch (which is expected)
                 pass
         return processed_output
 
@@ -165,7 +165,7 @@ class MetricWrapper(Metric):
             )
         except KeyError:
             # this happens if during multi-task training, all tasks are not
-            # represented in the batch (which is expected) 
+            # represented in the batch (which is expected)
             pass
 
     def compute(self) -> Any:


### PR DESCRIPTION
Finetuning on multiple datasets in memory at once.

- [X]  Collect test metrics at the end of a model test run
- [X]  Metrics, logging, checkpointing across different dataset heads
- [X]  Training/evaluation across different datasets
- [X]  Alternating batches between datasets
- [X] Fast distributed data loader that works across multiple ranks/processes
- [ ]  Mixed-dataset in a single batch
- [ ]  Multiple tasks within a single dataset

Currently only allows one task per dataset - this is the highest priority next fix, since some datasets (ex: v2_pastis) have ambiguous task names like detect or classify that collide with other datasets.

Occasionally there are NCCL hangs at the end of validation loops, this has been hard to reproduce/debug in isolation so unclear if this is due to multi-dataset training or a larger issue.

Also adds support for [ALPA](https://arxiv.org/html/2503.11335v2), but this isn't recommended as the performance gains during backward are quite small. Unclear why this is, maybe something to do with switching off gradients at such a finegrained parameter level?