### PR TITLE
Better time series support in the model configuration

### DIFF
--- a/rslearn/data_sources/aws_sentinel1.py
+++ b/rslearn/data_sources/aws_sentinel1.py
@@ -1,0 +1,142 @@
+"""Data source for Sentinel-1 on AWS."""
+
+import os
+import tempfile
+from typing import Any
+
+import boto3
+from upath import UPath
+
+from rslearn.config import RasterLayerConfig
+from rslearn.data_sources.copernicus import (
+    CopernicusItem,
+    Sentinel1OrbitDirection,
+    Sentinel1Polarisation,
+    Sentinel1ProductType,
+)
+from rslearn.data_sources.copernicus import Sentinel1 as CopernicusSentinel1
+from rslearn.log_utils import get_logger
+from rslearn.tile_stores import TileStore, TileStoreWithLayer
+from rslearn.utils.geometry import STGeometry
+
+from .data_source import DataSource, QueryConfig
+
+WRS2_GRID_SIZE = 1.0
+
+logger = get_logger(__name__)
+
+
+class Sentinel1(DataSource, TileStore):
+    """A data source for Sentinel-1 GRD imagery on AWS.
+
+    Specifically, uses the sentinel-s1-l1c S3 bucket maintained by Sinergise. See
+    https://aws.amazon.com/marketplace/pp/prodview-uxrsbvhd35ifw for details about the
+    bucket.
+
+    We use the Copernicus API for metadata search. So the bucket is only used for
+    downloading the images.
+
+    Currently, it only supports GRD IW DV scenes.
+    """
+
+    bucket_name = "sentinel-s1-l1c"
+    bands = ["vv", "vh"]
+
+    def __init__(
+        self,
+        orbit_direction: Sentinel1OrbitDirection | None = None,
+    ) -> None:
+        """Initialize a new Sentinel1 instance.
+
+        Args:
+            orbit_direction: optional orbit direction to filter by.
+        """
+        self.client = boto3.client("s3")
+        self.bucket = boto3.resource("s3").Bucket(self.bucket_name)
+        self.sentinel1 = CopernicusSentinel1(
+            product_type=Sentinel1ProductType.IW_GRDH,
+            polarisation=Sentinel1Polarisation.VV_VH,
+            orbit_direction=orbit_direction,
+        )
+
+    @staticmethod
+    def from_config(config: RasterLayerConfig, ds_path: UPath) -> "Sentinel1":
+        """Creates a new Sentinel1 instance from a configuration dictionary."""
+        if config.data_source is None:
+            raise ValueError(f"data_source is required for config dict {config}")
+        d = config.data_source.config_dict
+        kwargs: dict[str, Any] = {}
+        if "orbit_direction" in d:
+            d["orbit_direction"] = Sentinel1OrbitDirection[d["orbit_direction"]]
+
+        return Sentinel1(**kwargs)
+
+    def get_items(
+        self, geometries: list[STGeometry], query_config: QueryConfig
+    ) -> list[list[list[CopernicusItem]]]:
+        """Get a list of items in the data source intersecting the given geometries.
+
+        Args:
+            geometries: the spatiotemporal geometries
+            query_config: the query configuration
+
+        Returns:
+            List of groups of items that should be retrieved for each geometry.
+        """
+        return self.sentinel1.get_items(geometries, query_config)
+
+    def get_item_by_name(self, name: str) -> CopernicusItem:
+        """Gets an item by name."""
+        return self.sentinel1.get_item_by_name(name)
+
+    def deserialize_item(self, serialized_item: Any) -> CopernicusItem:
+        """Deserializes an item from JSON-decoded data."""
+        assert isinstance(serialized_item, dict)
+        return CopernicusItem.deserialize(serialized_item)
+
+    def ingest(
+        self,
+        tile_store: TileStoreWithLayer,
+        items: list[CopernicusItem],
+        geometries: list[list[STGeometry]],
+    ) -> None:
+        """Ingest items into the given tile store.
+
+        Args:
+            tile_store: the tile store to ingest into
+            items: the items to ingest
+            geometries: a list of geometries needed for each item
+        """
+        for item in items:
+            for band in self.bands:
+                band_names = [band]
+                if tile_store.is_raster_ready(item.name, band_names):
+                    continue
+
+                # Item name is like "S1C_IW_GRDH_1SDV_20250528T172106_20250528T172131_002534_00545C_B433.SAFE".
+                item_name_prefix = item.name.split(".")[0]
+                time_str = item_name_prefix.split("_")[4]
+                if len(time_str) != 15:
+                    raise ValueError(
+                        f"expected 15-character time string but got {time_str}"
+                    )
+                # We convert to int here since path in bucket isn't padded with leading 0s.
+                year = int(time_str[0:4])
+                month = int(time_str[4:6])
+                day = int(time_str[6:8])
+                blob_path = f"GRD/{year}/{month}/{day}/IW/DV/{item_name_prefix}/measurement/iw-{band}.tiff"
+
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    fname = os.path.join(tmp_dir, f"{band}.tif")
+                    try:
+                        self.bucket.download_file(
+                            blob_path,
+                            fname,
+                            ExtraArgs={"RequestPayer": "requester"},
+                        )
+                    except:
+                        logger.error(
+                            f"encountered error while downloading s3://{self.bucket_name}/{blob_path}"
+                        )
+                        raise
+                    tile_store.write_raster_file(item.name, band_names, UPath(fname))

--- a/rslearn/data_sources/copernicus.py
+++ b/rslearn/data_sources/copernicus.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
 from typing import Any
+from urllib.parse import quote
 from zipfile import ZipFile
 
 import numpy as np
@@ -24,7 +25,7 @@ from upath import UPath
 
 from rslearn.config import QueryConfig, RasterLayerConfig
 from rslearn.const import WGS84_PROJECTION
-from rslearn.data_sources.data_source import Item
+from rslearn.data_sources.data_source import DataSource, Item
 from rslearn.data_sources.utils import match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
@@ -254,7 +255,7 @@ class CopernicusItem(Item):
         )
 
 
-class Copernicus:
+class Copernicus(DataSource):
     """Scenes from the ESA Copernicus OData API.
 
     See https://documentation.dataspace.copernicus.eu/APIs/OData.html for details about
@@ -358,6 +359,11 @@ class Copernicus:
 
         return Copernicus(**kwargs)
 
+    def deserialize_item(self, serialized_item: Any) -> CopernicusItem:
+        """Deserializes an item from JSON-decoded data."""
+        assert isinstance(serialized_item, dict)
+        return CopernicusItem.deserialize(serialized_item)
+
     def _get(self, path: str) -> dict[str, Any]:
         """Get the API path and return JSON content."""
         url = self.BASE_URL + path
@@ -449,7 +455,7 @@ class Copernicus:
         """
         if "'" in name:
             raise ValueError('product name cannot contain "\'"')
-        filter_string = self._build_filter_string(f"Name eq '{name}")
+        filter_string = self._build_filter_string(f"Name eq '{quote(name)}'")
         path = f"/Products?$filter={filter_string}"
         response = self._get(path)
         products = response["value"]
@@ -745,7 +751,7 @@ class Sentinel2(Copernicus):
             glob_to_bands[glob_pattern] = band_names
 
         # Create query filter based on the product type.
-        query_filter = f"Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{product_type.value}')"
+        query_filter = f"Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{quote(product_type.value)}')"
 
         super().__init__(
             glob_to_bands=glob_to_bands,
@@ -844,3 +850,92 @@ class Sentinel2(Copernicus):
                         tile_store.write_raster(
                             item.name, band_names, projection, bounds, array
                         )
+
+
+class Sentinel1ProductType(str, Enum):
+    """The Sentinel-1 product type."""
+
+    IW_GRDH = "IW_GRDH_1S"
+
+
+class Sentinel1Polarisation(str, Enum):
+    """The Sentinel-1 polarisation."""
+
+    VV_VH = "VV&VH"
+
+
+class Sentinel1OrbitDirection(str, Enum):
+    """The Sentinel-1 orbit direction."""
+
+    ASCENDING = "ASCENDING"
+    DESCENDING = "DESCENDING"
+
+
+class Sentinel1(Copernicus):
+    """A data source for Sentinel-1 data from the Copernicus API."""
+
+    GLOB_TO_BANDS = {
+        Sentinel1Polarisation.VV_VH: {
+            "*/measurement/*-vh-*.tiff": ["vh"],
+            "*/measurement/*-vv-*.tiff": ["vv"],
+        }
+    }
+
+    # Pattern of XML file within the product zip file.
+    METADATA_PATTERN = "*/MTD_MSIL*.xml"
+
+    def __init__(
+        self,
+        product_type: Sentinel1ProductType,
+        polarisation: Sentinel1Polarisation,
+        orbit_direction: Sentinel1OrbitDirection | None = None,
+        **kwargs: Any,
+    ):
+        """Create a new Sentinel1.
+
+        Args:
+            product_type: desired product type.
+            polarisation: desired polarisation(s).
+            orbit_direction: optional orbit direction to filter by.
+            kwargs: additional arguments to pass to Copernicus.
+        """
+        # Create query filter based on the product type.
+        query_filter = (
+            f"Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{quote(product_type.value)}')"
+            + f" and Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{quote(polarisation.value)}')"
+        )
+        if orbit_direction:
+            query_filter += f" and Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{quote(orbit_direction.value)}')"
+
+        super().__init__(
+            glob_to_bands=self.GLOB_TO_BANDS[polarisation],
+            query_filter=query_filter,
+            **kwargs,
+        )
+
+    @staticmethod
+    def from_config(config: RasterLayerConfig, ds_path: UPath) -> "Sentinel1":
+        """Creates a new Sentinel1 instance from a configuration dictionary."""
+        if config.data_source is None:
+            raise ValueError("config.data_source is required")
+        d = config.data_source.config_dict
+
+        kwargs: dict[str, Any] = dict(
+            product_type=Sentinel1ProductType[d["product_type"]],
+            polarisation=Sentinel1Polarisation[d["polarisation"]],
+        )
+
+        if "orbit_direction" in d:
+            kwargs["orbit_direction"] = Sentinel1OrbitDirection[d["orbit_direction"]]
+
+        simple_optionals = [
+            "access_token",
+            "order_by",
+            "sort_by",
+            "sort_desc",
+        ]
+        for k in simple_optionals:
+            if k in d:
+                kwargs[k] = d[k]
+
+        return Sentinel1(**kwargs)

--- a/rslearn/data_sources/google_earth_engine.py
+++ b/rslearn/data_sources/google_earth_engine.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import ee
+import ee.ee_types
 import rasterio
 import rasterio.merge
 import shapely
@@ -19,6 +20,7 @@ from upath import UPath
 import rslearn.data_sources.utils
 from rslearn.config import DType, RasterLayerConfig
 from rslearn.const import WGS84_PROJECTION
+from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
 from rslearn.utils import STGeometry
 from rslearn.utils.fsspec import join_upath
@@ -27,15 +29,17 @@ from rslearn.utils.rtree_index import RtreeIndex, get_cached_rtree
 
 from .data_source import DataSource, Item, QueryConfig
 
+logger = get_logger(__name__)
+
 
 class GEE(DataSource):
     """A data source for ingesting images from Google Earth Engine."""
 
     def __init__(
         self,
-        config: RasterLayerConfig,
         collection_name: str,
         gcs_bucket_name: str,
+        bands: list[str],
         index_cache_dir: UPath,
         service_account_name: str,
         service_account_credentials: str,
@@ -45,9 +49,9 @@ class GEE(DataSource):
         """Initialize a new GEE instance.
 
         Args:
-            config: configuration for this layer.
-            collection_name: the Earth Engine collection to ingest images from
+            collection_name: the Earth Engine ImageCollection to ingest images from
             gcs_bucket_name: the Cloud Storage bucket to export GEE images to
+            bands: the list of bands to ingest
             index_cache_dir: cache directory to store rtree index
             service_account_name: name of the service account to use for authentication
             service_account_credentials: service account credentials filename
@@ -56,9 +60,9 @@ class GEE(DataSource):
             dtype: optional desired array data type. If the data obtained from GEE does
                 not match this type, then it is converted.
         """
-        self.config = config
         self.collection_name = collection_name
         self.gcs_bucket_name = gcs_bucket_name
+        self.bands = bands
         self.index_cache_dir = index_cache_dir
         self.filters = filters
         self.dtype = dtype
@@ -70,6 +74,7 @@ class GEE(DataSource):
         )
         ee.Initialize(credentials)
 
+        self.index_cache_dir.mkdir(parents=True, exist_ok=True)
         self.rtree_index = get_cached_rtree(self.index_cache_dir, self._build_index)
 
     @staticmethod
@@ -78,10 +83,11 @@ class GEE(DataSource):
         if config.data_source is None:
             raise ValueError("data_source is required in config")
         d = config.data_source.config_dict
+        bands = [band for band_set in config.band_sets for band in band_set.bands]
         kwargs = {
-            "config": config,
             "collection_name": d["collection_name"],
             "gcs_bucket_name": d["gcs_bucket_name"],
+            "bands": bands,
             "service_account_name": d["service_account_name"],
             "service_account_credentials": d["service_account_credentials"],
             "filters": d.get("filters"),
@@ -109,7 +115,7 @@ class GEE(DataSource):
         if not csv_blob.exists():
             # Export feature collection of image metadata to GCS.
             def image_to_feature(image: ee.Image) -> ee.Feature:
-                geometry = image.geometry().transform(proj="EPSG:4326")
+                geometry = image.geometry().transform(proj="EPSG:4326", maxError=0.001)
                 return ee.Feature(geometry, {"time": image.date().format()})
 
             fc = self.get_collection().map(image_to_feature)
@@ -121,14 +127,17 @@ class GEE(DataSource):
                 fileFormat="CSV",
             )
             task.start()
-            print(
-                "started task to export GEE index "
-                + f"for image collection {self.collection_name}"
+            logger.info(
+                "Started task to export GEE index for image collection %s",
+                self.collection_name,
             )
             while True:
                 time.sleep(10)
                 status_dict = task.status()
-                print(status_dict)
+                logger.debug(
+                    "Waiting for export task to complete, current status is %s",
+                    status_dict,
+                )
                 if status_dict["state"] in ["UNSUBMITTED", "READY", "RUNNING"]:
                     continue
                 assert status_dict["state"] == "COMPLETED"
@@ -190,6 +199,51 @@ class GEE(DataSource):
         assert isinstance(serialized_item, dict)
         return Item.deserialize(serialized_item)
 
+    def item_to_image(self, item: Item) -> ee.image.Image:
+        """Get the Image corresponding to the Item.
+
+        This function is separated so it can be overriden if subclasses want to add
+        modifications to the image.
+        """
+        filtered = self.get_collection().filter(ee.Filter.eq("system:index", item.name))
+        image = filtered.first()
+        image = image.select(self.bands)
+        return image
+
+    def export_item(self, item: Item, blob_prefix: str) -> None:
+        """Export the item to the specified folder.
+
+        Args:
+            item: the item to export.
+            blob_prefix: the prefix (folder) to use.
+        """
+        # Use the native projection of the image to obtain the raster.
+        # We pass scale instead of crsTransform since some images have positive y
+        # resolution which means they are upside down and rasterio cannot merge
+        # them.
+        image = self.item_to_image(item)
+        projection = image.select(self.bands[0]).projection().getInfo()
+        logger.info("Starting task to retrieve image %s", item.name)
+        task = ee.batch.Export.image.toCloudStorage(
+            image=image,
+            description=item.name,
+            bucket=self.gcs_bucket_name,
+            fileNamePrefix=blob_prefix,
+            crs=projection["crs"],
+            scale=projection["transform"][0],
+            maxPixels=10000000000,
+            fileFormat="GeoTIFF",
+            skipEmptyTiles=True,
+        )
+        task.start()
+        while True:
+            time.sleep(10)
+            status_dict = task.status()
+            if status_dict["state"] in ["UNSUBMITTED", "READY", "RUNNING"]:
+                continue
+            assert status_dict["state"] == "COMPLETED"
+            break
+
     def ingest(
         self,
         tile_store: TileStoreWithLayer,
@@ -203,52 +257,18 @@ class GEE(DataSource):
             items: the items to ingest
             geometries: a list of geometries needed for each item
         """
-        bands = []
-        for band_set in self.config.band_sets:
-            if band_set.bands is None:
-                continue
-            for band in band_set.bands:
-                if band in bands:
-                    continue
-                bands.append(band)
-
         for item in items:
-            if tile_store.is_raster_ready(item.name, bands):
+            if tile_store.is_raster_ready(item.name, self.bands):
                 continue
 
-            filtered = self.get_collection().filter(
-                ee.Filter.eq("system:index", item.name)
-            )
-            image = filtered.first()
-            image = image.select(bands)
-
-            # Use the native projection of the image to obtain the raster.
-            projection = image.select(bands[0]).projection().getInfo()
-            print(f"starting task to retrieve image {item.name}")
-            blob_path = f"{self.collection_name}/{item.name}.{os.getpid()}/"
-            task = ee.batch.Export.image.toCloudStorage(
-                image=image,
-                description=item.name,
-                bucket=self.gcs_bucket_name,
-                fileNamePrefix=blob_path,
-                fileFormat="GeoTIFF",
-                crs=projection["crs"],
-                crsTransform=projection["transform"],
-                maxPixels=10000000000,
-            )
-            task.start()
-            while True:
-                time.sleep(10)
-                status_dict = task.status()
-                if status_dict["state"] in ["UNSUBMITTED", "READY", "RUNNING"]:
-                    continue
-                assert status_dict["state"] == "COMPLETED"
-                break
+            # Export the item to GCS.
+            blob_prefix = f"{self.collection_name}/{item.name}.{os.getpid()}/"
+            self.export_item(item, blob_prefix)
 
             # See what files the export produced.
             # If there are multiple, then we merge them into one file since that's the
             # simplest way to handle it.
-            blobs = list(self.bucket.list_blobs(prefix=blob_path))
+            blobs = list(self.bucket.list_blobs(prefix=blob_prefix))
 
             with tempfile.TemporaryDirectory() as tmp_dir_name:
                 if len(blobs) == 1:
@@ -256,7 +276,9 @@ class GEE(DataSource):
                         tmp_dir_name, blobs[0].name.split("/")[-1]
                     )
                     blobs[0].download_to_filename(local_fname)
-                    tile_store.write_raster_file(item.name, bands, UPath(local_fname))
+                    tile_store.write_raster_file(
+                        item.name, self.bands, UPath(local_fname)
+                    )
 
                 else:
                     rasterio_datasets = []
@@ -284,7 +306,58 @@ class GEE(DataSource):
                     for ds in rasterio_datasets:
                         ds.close()
 
-                    tile_store.write_raster(item.name, bands, projection, bounds, array)
+                    tile_store.write_raster(
+                        item.name, self.bands, projection, bounds, array
+                    )
 
             for blob in blobs:
                 blob.delete()
+
+
+class GoogleSatelliteEmbeddings(GEE):
+    """GEE data source for the Google Satellite Embeddings.
+
+    See here for details:
+    https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_SATELLITE_EMBEDDING_V1_ANNUAL
+    """
+
+    COLLECTION_NAME = "GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL"
+
+    def __init__(
+        self,
+        gcs_bucket_name: str,
+        index_cache_dir: UPath,
+        service_account_name: str,
+        service_account_credentials: str,
+    ):
+        """Create a new GoogleSatelliteEmbeddings. See GEE for the arguments."""
+        super().__init__(
+            bands=[f"A{idx:02d}" for idx in range(64)],
+            collection_name=self.COLLECTION_NAME,
+            gcs_bucket_name=gcs_bucket_name,
+            index_cache_dir=index_cache_dir,
+            service_account_name=service_account_name,
+            service_account_credentials=service_account_credentials,
+        )
+
+    @staticmethod
+    def from_config(config: RasterLayerConfig, ds_path: UPath) -> "GEE":
+        """Creates a new GEE instance from a configuration dictionary."""
+        if config.data_source is None:
+            raise ValueError("data_source is required in config")
+        d = config.data_source.config_dict
+        kwargs = {
+            "gcs_bucket_name": d["gcs_bucket_name"],
+            "index_cache_dir": join_upath(ds_path, d["index_cache_dir"]),
+            "service_account_name": d["service_account_name"],
+            "service_account_credentials": d["service_account_credentials"],
+        }
+        return GoogleSatelliteEmbeddings(**kwargs)
+
+    # Override to add conversion to uint16.
+    def item_to_image(self, item: Item) -> ee.image.Image:
+        """Get the Image corresponding to the Item."""
+        filtered = self.get_collection().filter(ee.Filter.eq("system:index", item.name))
+        image = filtered.first()
+        image = image.select(self.bands)
+        return image.multiply(8192).add(8192).toUint16()

--- a/rslearn/data_sources/google_earth_engine.py
+++ b/rslearn/data_sources/google_earth_engine.py
@@ -1,6 +1,7 @@
 """Data source for raster or vector data in local files."""
 
 import csv
+import io
 import json
 import os
 import tempfile
@@ -9,7 +10,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 import ee
-import ee.ee_types
+import numpy as np
+import numpy.typing as npt
 import rasterio
 import rasterio.merge
 import shapely
@@ -18,13 +20,20 @@ from google.cloud import storage
 from upath import UPath
 
 import rslearn.data_sources.utils
-from rslearn.config import DType, RasterLayerConfig
+from rslearn.config import DType, LayerConfig, RasterLayerConfig
 from rslearn.const import WGS84_PROJECTION
+from rslearn.dataset.materialize import RasterMaterializer
+from rslearn.dataset.window import Window
 from rslearn.log_utils import get_logger
-from rslearn.tile_stores import TileStoreWithLayer
-from rslearn.utils import STGeometry
+from rslearn.tile_stores import TileStore, TileStoreWithLayer
+from rslearn.utils.array import copy_spatial_array
 from rslearn.utils.fsspec import join_upath
-from rslearn.utils.raster_format import get_raster_projection_and_bounds_from_transform
+from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
+from rslearn.utils.raster_format import (
+    Resampling,
+    get_raster_projection_and_bounds_from_transform,
+    get_transform_from_projection_and_bounds,
+)
 from rslearn.utils.rtree_index import RtreeIndex, get_cached_rtree
 
 from .data_source import DataSource, Item, QueryConfig
@@ -32,7 +41,7 @@ from .data_source import DataSource, Item, QueryConfig
 logger = get_logger(__name__)
 
 
-class GEE(DataSource):
+class GEE(DataSource, TileStore):
     """A data source for ingesting images from Google Earth Engine."""
 
     def __init__(
@@ -159,6 +168,26 @@ class GEE(DataSource):
                 item = Item(row["system:index"], geometry)
                 rtree_index.insert(shp.bounds, json.dumps(item.serialize()))
 
+    def get_item_by_name(self, name: str) -> Item:
+        """Gets an item by name.
+
+        Args:
+            name: the name of the item to get
+
+        Returns:
+            the item object
+        """
+        filtered = self.get_collection().filter(ee.Filter.eq("system:index", name))
+        image = filtered.first()
+        shp = shapely.geometry.shape(
+            image.geometry().transform(proj="EPSG:4326", maxError=0.001).getInfo()
+        )
+        ts = datetime.fromisoformat(image.date().format().getInfo()).replace(
+            tzinfo=timezone.utc
+        )
+        geometry = STGeometry(WGS84_PROJECTION, shp, (ts, ts))
+        return Item(name, geometry)
+
     def get_items(
         self, geometries: list[STGeometry], query_config: QueryConfig
     ) -> list[list[list[Item]]]:
@@ -210,30 +239,61 @@ class GEE(DataSource):
         image = image.select(self.bands)
         return image
 
-    def export_item(self, item: Item, blob_prefix: str) -> None:
+    def export_item(
+        self,
+        item: Item,
+        blob_prefix: str,
+        projection_and_bounds: tuple[Projection, PixelBounds] | None = None,
+    ) -> None:
         """Export the item to the specified folder.
 
         Args:
             item: the item to export.
             blob_prefix: the prefix (folder) to use.
+            projection_and_bounds: optionally use this projection and bounds instead of
+                the extent of the image.
         """
-        # Use the native projection of the image to obtain the raster.
-        # We pass scale instead of crsTransform since some images have positive y
-        # resolution which means they are upside down and rasterio cannot merge
-        # them.
         image = self.item_to_image(item)
         projection = image.select(self.bands[0]).projection().getInfo()
         logger.info("Starting task to retrieve image %s", item.name)
+
+        extent_kwargs: dict[str, Any]
+        if projection_and_bounds is not None:
+            projection, bounds = projection_and_bounds
+            transform = get_transform_from_projection_and_bounds(projection, bounds)
+            width = bounds[2] - bounds[0]
+            height = bounds[3] - bounds[1]
+            extent_kwargs = dict(
+                crs=str(projection.crs),
+                crsTransform=[
+                    transform.a,
+                    transform.b,
+                    transform.c,
+                    transform.d,
+                    transform.e,
+                    transform.f,
+                ],
+                dimensions=f"{width}x{height}",
+            )
+        else:
+            # Use the native projection of the image.
+            # We pass scale instead of crsTransform since some images have positive y
+            # resolution which means they are upside down and rasterio cannot merge
+            # them.
+            extent_kwargs = dict(
+                crs=projection["crs"],
+                scale=projection["transform"][0],
+            )
+
         task = ee.batch.Export.image.toCloudStorage(
             image=image,
             description=item.name,
             bucket=self.gcs_bucket_name,
             fileNamePrefix=blob_prefix,
-            crs=projection["crs"],
-            scale=projection["transform"][0],
             maxPixels=10000000000,
             fileFormat="GeoTIFF",
             skipEmptyTiles=True,
+            **extent_kwargs,
         )
         task.start()
         while True:
@@ -243,6 +303,55 @@ class GEE(DataSource):
                 continue
             assert status_dict["state"] == "COMPLETED"
             break
+
+    def _merge_rasters(
+        self,
+        blobs: list[storage.Blob],
+        crs_bounds: tuple[float, float, float, float] | None = None,
+        res: float | None = None,
+    ) -> tuple[npt.NDArray, Projection, PixelBounds]:
+        """Merge multiple rasters split up during export by GEE.
+
+        GEE can produce multiple rasters if it determines the file size exceeds its
+        internal limit. So in this case we stitch them back together.
+
+        Args:
+            blobs: the list of GCS blobs where the rasters were written.
+            crs_bounds: generate merged output under this bounds, in CRS coordinates
+                (not pixel units).
+            res: generate merged output under this resolution.
+
+        Returns:
+            a tuple (array, projection, bounds) where the projection and bounds
+                indicate the extent of the array.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            rasterio_datasets = []
+            for blob in blobs:
+                local_fname = os.path.join(tmp_dir_name, blob.name.split("/")[-1])
+                blob.download_to_filename(local_fname)
+                src = rasterio.open(local_fname)
+                rasterio_datasets.append(src)
+
+            merge_kwargs: dict[str, Any] = dict(
+                sources=rasterio_datasets,
+                bounds=crs_bounds,
+                res=res,
+            )
+            if self.dtype:
+                merge_kwargs["dtype"] = self.dtype.value
+            array, transform = rasterio.merge.merge(**merge_kwargs)
+            projection, bounds = get_raster_projection_and_bounds_from_transform(
+                rasterio_datasets[0].crs,
+                transform,
+                array.shape[2],
+                array.shape[1],
+            )
+
+            for ds in rasterio_datasets:
+                ds.close()
+
+        return array, projection, bounds
 
     def ingest(
         self,
@@ -281,37 +390,168 @@ class GEE(DataSource):
                     )
 
                 else:
-                    rasterio_datasets = []
-                    for blob in blobs:
-                        local_fname = os.path.join(
-                            tmp_dir_name, blob.name.split("/")[-1]
-                        )
-                        blob.download_to_filename(local_fname)
-                        src = rasterio.open(local_fname)
-                        rasterio_datasets.append(src)
-
-                    merge_kwargs: dict[str, Any] = {"sources": rasterio_datasets}
-                    if self.dtype:
-                        merge_kwargs["dtype"] = self.dtype.value
-                    array, transform = rasterio.merge.merge(**merge_kwargs)
-                    projection, bounds = (
-                        get_raster_projection_and_bounds_from_transform(
-                            rasterio_datasets[0].crs,
-                            transform,
-                            array.shape[2],
-                            array.shape[1],
-                        )
-                    )
-
-                    for ds in rasterio_datasets:
-                        ds.close()
-
+                    array, projection, bounds = self._merge_rasters(blobs)
                     tile_store.write_raster(
                         item.name, self.bands, projection, bounds, array
                     )
 
             for blob in blobs:
                 blob.delete()
+
+    def is_raster_ready(
+        self, layer_name: str, item_name: str, bands: list[str]
+    ) -> bool:
+        """Checks if this raster has been written to the store.
+
+        Args:
+            layer_name: the layer name or alias.
+            item_name: the item.
+            bands: the list of bands identifying which specific raster to read.
+
+        Returns:
+            whether there is a raster in the store matching the source, item, and
+                bands.
+        """
+        # Always ready since we wrap accesses to Planetary Computer.
+        return True
+
+    def get_raster_bands(self, layer_name: str, item_name: str) -> list[list[str]]:
+        """Get the sets of bands that have been stored for the specified item.
+
+        Args:
+            layer_name: the layer name or alias.
+            item_name: the item.
+
+        Returns:
+            a list of lists of bands that are in the tile store (with one raster
+                stored corresponding to each inner list). If no rasters are ready for
+                this item, returns empty list.
+        """
+        return [self.bands]
+
+    def get_raster_bounds(
+        self, layer_name: str, item_name: str, bands: list[str], projection: Projection
+    ) -> PixelBounds:
+        """Get the bounds of the raster in the specified projection.
+
+        Args:
+            layer_name: the layer name or alias.
+            item_name: the item to check.
+            bands: the list of bands identifying which specific raster to read. These
+                bands must match the bands of a stored raster.
+            projection: the projection to get the raster's bounds in.
+
+        Returns:
+            the bounds of the raster in the projection.
+        """
+        item = self.get_item_by_name(item_name)
+        geom = item.geometry.to_projection(projection)
+        return (
+            int(geom.shp.bounds[0]),
+            int(geom.shp.bounds[1]),
+            int(geom.shp.bounds[2]),
+            int(geom.shp.bounds[3]),
+        )
+
+    def read_raster(
+        self,
+        layer_name: str,
+        item_name: str,
+        bands: list[str],
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+    ) -> npt.NDArray[Any]:
+        """Read raster data from the store.
+
+        Args:
+            layer_name: the layer name or alias.
+            item_name: the item to read.
+            bands: the list of bands identifying which specific raster to read. These
+                bands must match the bands of a stored raster.
+            projection: the projection to read in.
+            bounds: the bounds to read.
+            resampling: the resampling method to use in case reprojection is needed.
+
+        Returns:
+            the raster data
+        """
+        # Extract the requested extent and export to GCS.
+        bounds_str = f"{bounds[0]}_{bounds[1]}_{bounds[2]}_{bounds[3]}"
+        item = self.get_item_by_name(item_name)
+        blob_prefix = f"{self.collection_name}/{item.name}.{bounds_str}.{os.getpid()}/"
+        self.export_item(item, blob_prefix, projection_and_bounds=(projection, bounds))
+
+        wanted_transform = get_transform_from_projection_and_bounds(projection, bounds)
+        crs_bounds = (
+            bounds[0] * projection.x_resolution,
+            bounds[3] * projection.y_resolution,
+            bounds[2] * projection.x_resolution,
+            bounds[1] * projection.y_resolution,
+        )
+
+        blobs = list(self.bucket.list_blobs(prefix=blob_prefix))
+
+        if len(blobs) == 1:
+            # With a single output, we can simply read it with vrt.
+            buf = io.BytesIO()
+            blobs[0].download_to_file(buf)
+            buf.seek(0)
+            with rasterio.open(buf) as src:
+                with rasterio.vrt.WarpedVRT(
+                    src,
+                    crs=projection.crs,
+                    transform=wanted_transform,
+                    width=bounds[2] - bounds[0],
+                    height=bounds[3] - bounds[1],
+                    resampling=resampling,
+                ) as vrt:
+                    return vrt.read()
+
+        else:
+            # With multiple outputs, we need to merge them together.
+            # We can set the bounds in CRS coordinates when we do the merging.
+            if projection.x_resolution != -projection.y_resolution:
+                raise NotImplementedError(
+                    "Only projection with x_res=-y_res is supported for GEE direct materialization"
+                )
+            src_array, _, src_bounds = self._merge_rasters(
+                blobs, crs_bounds=crs_bounds, res=projection.x_resolution
+            )
+
+            # We copy the array if its bounds don't match exactly.
+            if src_bounds == bounds:
+                return src_array
+            dst_array = np.zeros(
+                (src_array.shape[0], bounds[3] - bounds[1], bounds[2] - bounds[0]),
+                dtype=src_array.dtype,
+            )
+            copy_spatial_array(src_array, dst_array, src_bounds[0:2], bounds[0:2])
+            return dst_array
+
+    def materialize(
+        self,
+        window: Window,
+        item_groups: list[list[Item]],
+        layer_name: str,
+        layer_cfg: LayerConfig,
+    ) -> None:
+        """Materialize data for the window.
+
+        Args:
+            window: the window to materialize
+            item_groups: the items from get_items
+            layer_name: the name of this layer
+            layer_cfg: the config of this layer
+        """
+        assert isinstance(layer_cfg, RasterLayerConfig)
+        RasterMaterializer().materialize(
+            TileStoreWithLayer(self, layer_name),
+            window,
+            layer_name,
+            layer_cfg,
+            item_groups,
+        )
 
 
 class GoogleSatelliteEmbeddings(GEE):

--- a/rslearn/dataset/index.py
+++ b/rslearn/dataset/index.py
@@ -8,10 +8,8 @@ import tqdm
 from upath import UPath
 
 from .window import (
-    LAYERS_DIRECTORY_NAME,
     Window,
     WindowLayerData,
-    get_layer_and_group_from_dir_name,
 )
 
 if TYPE_CHECKING:
@@ -25,19 +23,7 @@ def get_window_layer_datas(window: Window) -> list[WindowLayerData]:
 
 def get_window_completed_layers(window: Window) -> list[tuple[str, int]]:
     """Helper function for multiprocessing to load window completed layers."""
-    # We don't know the range of possible groups a priori, so we instead look in the
-    # layers directory.
-    layers_directory = window.path / LAYERS_DIRECTORY_NAME
-    if not layers_directory.exists():
-        return []
-
-    completed_layers = []
-    for layer_dir in layers_directory.iterdir():
-        layer_name, group_idx = get_layer_and_group_from_dir_name(layer_dir.name)
-        if not window.is_layer_completed(layer_name, group_idx):
-            continue
-        completed_layers.append((layer_name, group_idx))
-    return completed_layers
+    return window.list_completed_layers()
 
 
 class DatasetIndex:

--- a/rslearn/dataset/manage.py
+++ b/rslearn/dataset/manage.py
@@ -42,7 +42,7 @@ def retry(fn: Callable, retry_max_attempts: int, retry_backoff: timedelta) -> An
         try:
             return fn()
         except Exception as e:
-            logger.debug(f"Retrying after catching error in retry loop: {e}")
+            logger.warning(f"Retrying after catching error in retry loop: {e}")
             sleep_base_seconds = retry_backoff.total_seconds() * (attempt_idx + 1)
             time.sleep(sleep_base_seconds * (1 + random.random()))
 

--- a/rslearn/dataset/window.py
+++ b/rslearn/dataset/window.py
@@ -205,6 +205,25 @@ class Window:
         with open_atomic(items_fname, "w") as f:
             json.dump(json_data, f)
 
+    def list_completed_layers(self) -> list[tuple[str, int]]:
+        """List the layers available for this window that are completed.
+
+        Returns:
+            a list of (layer_name, group_idx) completed layers.
+        """
+        layers_directory = self.path / LAYERS_DIRECTORY_NAME
+        if not layers_directory.exists():
+            return []
+
+        completed_layers = []
+        for layer_dir in layers_directory.iterdir():
+            layer_name, group_idx = get_layer_and_group_from_dir_name(layer_dir.name)
+            if not self.is_layer_completed(layer_name, group_idx):
+                continue
+            completed_layers.append((layer_name, group_idx))
+
+        return completed_layers
+
     def get_layer_dir(self, layer_name: str, group_idx: int = 0) -> UPath:
         """Get the directory containing materialized data for the specified layer.
 

--- a/rslearn/dataset/window.py
+++ b/rslearn/dataset/window.py
@@ -10,6 +10,7 @@ from upath import UPath
 from rslearn.log_utils import get_logger
 from rslearn.utils import Projection, STGeometry
 from rslearn.utils.fsspec import open_atomic
+from rslearn.utils.raster_format import get_bandset_dirname
 
 logger = get_logger(__name__)
 
@@ -52,7 +53,8 @@ def get_window_raster_dir(
     Returns:
         the directory containing the raster.
     """
-    return get_window_layer_dir(window_path, layer_name, group_idx) / "_".join(bands)
+    dirname = get_bandset_dirname(bands)
+    return get_window_layer_dir(window_path, layer_name, group_idx) / dirname
 
 
 class WindowLayerData:

--- a/rslearn/main.py
+++ b/rslearn/main.py
@@ -243,7 +243,11 @@ def add_apply_on_windows_args(parser: argparse.ArgumentParser) -> None:
         "--root", type=str, required=True, help="Dataset root directory"
     )
     parser.add_argument(
-        "--group", type=str, default=None, help="Only prepare windows in this group"
+        "--group",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Only prepare windows in these groups",
     )
     parser.add_argument(
         "--window", type=str, nargs="*", default=None, help="Only prepare these windows"
@@ -283,7 +287,7 @@ def add_apply_on_windows_args(parser: argparse.ArgumentParser) -> None:
 def apply_on_windows(
     f: Callable[[list[Window]], None],
     dataset: Dataset,
-    group: str | None = None,
+    group: str | list[str] | None = None,
     names: list[str] | None = None,
     workers: int = 0,
     load_workers: int | None = None,
@@ -315,9 +319,14 @@ def apply_on_windows(
     if hasattr(f, "set_dataset"):
         f.set_dataset(dataset)
 
-    groups = None
-    if group:
+    # Handle group. It can be None (load all groups) or list of groups. But it can also
+    # just be group name, in which case we must convert to list.
+    groups: list[str] | None
+    if isinstance(group, str):
         groups = [group]
+    else:
+        groups = group
+
     if load_workers is None:
         load_workers = workers
     windows = dataset.load_windows(

--- a/rslearn/models/simple_time_series.py
+++ b/rslearn/models/simple_time_series.py
@@ -25,12 +25,14 @@ class SimpleTimeSeries(torch.nn.Module):
         groups: list[list[int]] | None = None,
         num_layers: int | None = None,
         image_key: str = "image",
+        backbone_channels: list[tuple[int, int]] | None = None,
     ) -> None:
         """Create a new SimpleTimeSeries.
 
         Args:
             encoder: the underlying encoder. It must provide get_backbone_channels
-                function that returns the output channels.
+                function that returns the output channels, or backbone_channels must be
+                set.
             image_channels: the number of channels per image of the time series. The
                 input should have multiple images concatenated on the channel axis, so
                 this parameter is used to distinguish the different images.
@@ -44,6 +46,8 @@ class SimpleTimeSeries(torch.nn.Module):
                 list of sets, and each set is a list of image indices.
             num_layers: the number of layers for convrnn, conv3d, and conv1d ops.
             image_key: the key to access the images.
+            backbone_channels: manually specify the backbone channels. Can be set if
+                the encoder does not provide get_backbone_channels function.
         """
         super().__init__()
         self.encoder = encoder
@@ -52,7 +56,10 @@ class SimpleTimeSeries(torch.nn.Module):
         self.groups = groups
         self.image_key = image_key
 
-        out_channels = self.encoder.get_backbone_channels()
+        if backbone_channels is not None:
+            out_channels = backbone_channels
+        else:
+            out_channels = self.encoder.get_backbone_channels()
         if self.groups:
             self.num_groups = len(self.groups)
         else:

--- a/rslearn/tile_stores/default.py
+++ b/rslearn/tile_stores/default.py
@@ -23,6 +23,7 @@ from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
 from rslearn.utils.get_utm_ups_crs import get_utm_ups_crs
 from rslearn.utils.raster_format import (
     GeotiffRasterFormat,
+    get_bandset_dirname,
 )
 from rslearn.utils.vector_format import (
     GeojsonVectorFormat,
@@ -96,9 +97,7 @@ class DefaultTileStore(TileStore):
             the UPath directory where the raster should be stored.
         """
         assert self.path is not None
-        if any(["_" in band for band in bands]):
-            raise ValueError("band names must not contain '_'")
-        return self.path / layer_name / item_name / "_".join(bands)
+        return self.path / layer_name / item_name / get_bandset_dirname(bands)
 
     def _get_raster_fname(
         self, layer_name: str, item_name: str, bands: list[str]

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -20,14 +20,19 @@ from rslearn.config import (
     RasterLayerConfig,
     VectorLayerConfig,
 )
-from rslearn.dataset import Dataset, Window
+from rslearn.dataset.dataset import Dataset
+from rslearn.dataset.window import Window, get_layer_and_group_from_dir_name
+from rslearn.log_utils import get_logger
 from rslearn.train.tasks import Task
-from rslearn.utils import logger
+from rslearn.utils.feature import Feature
+from rslearn.utils.geometry import PixelBounds
 from rslearn.utils.mp import star_imap_unordered
 from rslearn.utils.raster_format import load_raster_format
 from rslearn.utils.vector_format import load_vector_format
 
 from .transforms import Sequential
+
+logger = get_logger(__name__)
 
 
 class SamplerFactory:
@@ -127,6 +132,8 @@ class DataInput:
         passthrough: bool = False,
         is_target: bool = False,
         dtype: DType = DType.FLOAT32,
+        load_all_layers: bool = False,
+        load_all_item_groups: bool = False,
     ) -> None:
         """Initialize a new DataInput.
 
@@ -140,6 +147,14 @@ class DataInput:
             is_target: whether this DataInput represents a target for the task. Targets
                 are not read during prediction phase.
             dtype: data type to load the raster as
+            load_all_layers: whether to load all of the layers specified in the list of
+                layer names. By default, we randomly pick one layer to read. When
+                reading multiple layers, the images are stacked on the channel
+                dimension.
+            load_all_item_groups: whether to load all item groups in the layer(s) we
+                are reading from. By default, we assume the specified layer name is of
+                the form "{layer_name}.{group_idx}" and read that item group only. With
+                this option enabled, we ignore the group_idx and read all item groups.
         """
         self.data_type = data_type
         self.layers = layers
@@ -148,6 +163,175 @@ class DataInput:
         self.passthrough = passthrough
         self.is_target = is_target
         self.dtype = dtype
+        self.load_all_layers = load_all_layers
+        self.load_all_item_groups = load_all_item_groups
+
+
+def read_raster_layer_for_data_input(
+    window: Window,
+    bounds: PixelBounds,
+    layer_name: str,
+    group_idx: int,
+    layer_config: RasterLayerConfig,
+    data_input: DataInput,
+) -> torch.Tensor:
+    """Read a raster layer for a DataInput.
+
+    This scans the available rasters for the layer at the window to determine which
+    ones are needed to get all of the configured bands.
+
+    Args:
+        window: the window to read from.
+        bounds: the bounds to read.
+        layer_name: the layer.
+        group_idx: the item group.
+        layer_config: the layer configuration.
+        data_input: the DataInput that specifies the bands and dtype.
+
+    Returns:
+        tensor containing raster data.
+    """
+    # See what different sets of bands we need to read to get all the
+    # configured bands.
+    needed_bands = data_input.bands
+    if needed_bands is None:
+        raise ValueError(f"No bands specified for {layer_name}")
+    needed_band_indexes = {}
+    for i, band in enumerate(needed_bands):
+        needed_band_indexes[band] = i
+    needed_sets_and_indexes = []
+    for band_set in layer_config.band_sets:
+        needed_src_indexes = []
+        needed_dst_indexes = []
+        if band_set.bands is None:
+            continue
+        for i, band in enumerate(band_set.bands):
+            if band not in needed_band_indexes:
+                continue
+            needed_src_indexes.append(i)
+            needed_dst_indexes.append(needed_band_indexes[band])
+            del needed_band_indexes[band]
+        if len(needed_src_indexes) == 0:
+            continue
+        needed_sets_and_indexes.append(
+            (band_set, needed_src_indexes, needed_dst_indexes)
+        )
+    if len(needed_band_indexes) > 0:
+        raise ValueError(
+            "could not get all the needed bands from "
+            + f"window {window.name} layer {layer_name} group {group_idx}"
+        )
+
+    image = torch.zeros(
+        (len(needed_bands), bounds[3] - bounds[1], bounds[2] - bounds[0]),
+        dtype=data_input.dtype.get_torch_dtype(),
+    )
+
+    for band_set, src_indexes, dst_indexes in needed_sets_and_indexes:
+        final_projection, final_bounds = band_set.get_final_projection_and_bounds(
+            window.projection, bounds
+        )
+        if band_set.format is None:
+            raise ValueError(f"No format specified for {layer_name}")
+        raster_format = load_raster_format(
+            RasterFormatConfig(band_set.format["name"], band_set.format)
+        )
+        raster_dir = window.get_raster_dir(
+            layer_name, band_set.bands, group_idx=group_idx
+        )
+        src = raster_format.decode_raster(raster_dir, final_projection, final_bounds)
+        if src is None:
+            raise ValueError(f"Source is None for {data_input}")
+        # Resize to patch size if needed.
+        # This is for band sets that are stored at a lower resolution.
+        # Here we assume that it is a multiple.
+        if src.shape[1:3] != image.shape[1:3]:
+            if src.shape[1] < image.shape[1]:
+                factor = image.shape[1] // src.shape[1]
+                src = src.repeat(repeats=factor, axis=1).repeat(repeats=factor, axis=2)
+            else:
+                factor = src.shape[1] // image.shape[1]
+                src = src[:, ::factor, ::factor]
+
+        image[dst_indexes, :, :] = torch.as_tensor(
+            src[src_indexes, :, :].astype(data_input.dtype.get_numpy_dtype())
+        )
+
+    return image
+
+
+def read_data_input(
+    dataset: Dataset, window: Window, bounds: PixelBounds, data_input: DataInput
+) -> torch.Tensor | list[Feature]:
+    """Read the data specified by the DataInput from the window.
+
+    Args:
+        dataset: the dataset, to get layer configs.
+        window: the window to read from.
+        bounds: the bounds of the patch we are reading.
+        data_input: the DataInput that specifies what layers to read.
+
+    Returns:
+        the raster or vector data.
+    """
+    # We first enumerate which layers are available.
+    # If load_all_item_groups is set, we need to check each item group within the
+    # layer.
+    layer_options: list[tuple[str, int]] = []
+    if data_input.load_all_item_groups:
+        wanted_layers = set(data_input.layers)
+        for layer_name, group_idx in window.list_completed_layers():
+            if layer_name not in wanted_layers:
+                continue
+            layer_options.append((layer_name, group_idx))
+    else:
+        for option in data_input.layers:
+            layer_name, group_idx = get_layer_and_group_from_dir_name(option)
+            if not window.is_layer_completed(layer_name, group_idx):
+                continue
+            layer_options.append((layer_name, group_idx))
+
+    # Now determine the layers that we should actually read.
+    # We randomly pick one, unless load_all_layers is set, in which case we read all of
+    # them.
+    layers_to_read: list[tuple[str, int]]
+    if data_input.load_all_layers:
+        # We assume that the user has ensured the layers are compatible, e.g. raster
+        # layers will need to have the same number of bands.
+        layers_to_read = layer_options
+    else:
+        layers_to_read = [random.choice(layer_options)]
+
+    if data_input.data_type == "raster":
+        images: list[torch.Tensor] = []
+        for layer_name, group_idx in layers_to_read:
+            layer_config = dataset.layers[layer_name]
+            assert isinstance(layer_config, RasterLayerConfig)
+            images.append(
+                read_raster_layer_for_data_input(
+                    window, bounds, layer_name, group_idx, layer_config, data_input
+                )
+            )
+        return torch.cat(images, dim=0)
+
+    elif data_input.data_type == "vector":
+        # We don't really support time series for vector data currently, we just
+        # concatenate the features together.
+        features: list[Feature] = []
+        for layer_name, group_idx in layers_to_read:
+            layer_config = dataset.layers[layer_name]
+            assert isinstance(layer_config, VectorLayerConfig)
+            vector_format = load_vector_format(layer_config.format)
+            layer_dir = window.get_layer_dir(layer_name, group_idx=group_idx)
+            cur_features = vector_format.decode_vector(
+                layer_dir, window.projection, window.bounds
+            )
+            features.extend(cur_features)
+
+        return features
+
+    else:
+        raise ValueError(f"unknown data type {data_input.data_type}")
 
 
 class SplitConfig:
@@ -575,121 +759,10 @@ class ModelDataset(torch.utils.data.Dataset):
 
         assert isinstance(window, Window)
 
-        # Read the inputs and targets.
-        def read_input(data_input: DataInput) -> torch.Tensor:
-            # First enumerate all options of individual layers to read.
-            layer_options = []
-            for layer_name in data_input.layers:
-                layer_dir = window.get_layer_dir(layer_name)
-                if not (layer_dir / "completed").exists():
-                    continue
-                layer_options.append(layer_name)
-
-            # For now we just randomly pick one option.
-            # In the future we need to support different configuration for how to pick
-            # the options, as well as picking multiple for series inputs.
-            layer = random.choice(layer_options)
-
-            # The model config may reference a specific group within a layer, like
-            # "image.2" in a dataset that has a layer "image" with max_matches > 1.
-            # So we need to split off the period. Layer names should not contain
-            # period.
-            layer_ds_key = layer.split(".")[0]
-            layer_config = self.dataset.layers[layer_ds_key]
-
-            if data_input.data_type == "raster":
-                assert isinstance(layer_config, RasterLayerConfig)
-
-                # See what different sets of bands we need to read to get all the
-                # configured bands.
-                needed_bands = data_input.bands
-                if needed_bands is None:
-                    raise ValueError(f"No bands specified for {layer}")
-                needed_band_indexes = {}
-                for i, band in enumerate(needed_bands):
-                    needed_band_indexes[band] = i
-                needed_sets_and_indexes = []
-                for band_set in layer_config.band_sets:
-                    needed_src_indexes = []
-                    needed_dst_indexes = []
-                    if band_set.bands is None:
-                        continue
-                    for i, band in enumerate(band_set.bands):
-                        if band not in needed_band_indexes:
-                            continue
-                        needed_src_indexes.append(i)
-                        needed_dst_indexes.append(needed_band_indexes[band])
-                        del needed_band_indexes[band]
-                    if len(needed_src_indexes) == 0:
-                        continue
-                    needed_sets_and_indexes.append(
-                        (band_set, needed_src_indexes, needed_dst_indexes)
-                    )
-                if len(needed_band_indexes) > 0:
-                    raise Exception(
-                        "could not get all the needed bands from "
-                        + f"window {window.name} layer {layer}"
-                    )
-
-                image = torch.zeros(
-                    (len(needed_bands), bounds[3] - bounds[1], bounds[2] - bounds[0]),
-                    dtype=data_input.dtype.get_torch_dtype(),
-                )
-
-                for band_set, src_indexes, dst_indexes in needed_sets_and_indexes:
-                    final_projection, final_bounds = (
-                        band_set.get_final_projection_and_bounds(
-                            window.projection, bounds
-                        )
-                    )
-                    if band_set.format is None:
-                        raise ValueError(f"No format specified for {layer}")
-                    raster_format = load_raster_format(
-                        RasterFormatConfig(band_set.format["name"], band_set.format)
-                    )
-                    raster_dir = window.get_raster_dir(layer, band_set.bands)
-                    src = raster_format.decode_raster(
-                        raster_dir, final_projection, final_bounds
-                    )
-                    if src is None:
-                        raise ValueError(f"Source is None for {data_input}")
-                    # Resize to patch size if needed.
-                    # This is for band sets that are stored at a lower resolution.
-                    # Here we assume that it is a multiple.
-                    if src.shape[1:3] != image.shape[1:3]:
-                        if src.shape[1] < image.shape[1]:
-                            factor = image.shape[1] // src.shape[1]
-                            src = src.repeat(repeats=factor, axis=1).repeat(
-                                repeats=factor, axis=2
-                            )
-                        else:
-                            factor = src.shape[1] // image.shape[1]
-                            src = src[:, ::factor, ::factor]
-
-                    image[dst_indexes, :, :] = torch.as_tensor(
-                        src[src_indexes, :, :].astype(
-                            data_input.dtype.get_numpy_dtype()
-                        )
-                    )
-
-                return image
-
-            elif data_input.data_type == "vector":
-                assert isinstance(layer_config, VectorLayerConfig)
-                vector_format = load_vector_format(layer_config.format)
-                layer_dir = window.get_layer_dir(layer)
-                features = vector_format.decode_vector(
-                    layer_dir, window.projection, window.bounds
-                )
-                return features
-
-            else:
-                raise Exception(f"unknown data type {data_input.data_type}")
-
         raw_inputs = {}
         passthrough_inputs = {}
         for name, data_input in self.inputs.items():
-            raw_inputs[name] = read_input(data_input)
+            raw_inputs[name] = read_data_input(self.dataset, window, bounds, data_input)
             if data_input.passthrough:
                 passthrough_inputs[name] = raw_inputs[name]
 

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -1,5 +1,6 @@
 """Abstract RasterFormat class."""
 
+import hashlib
 import json
 from typing import Any, BinaryIO
 
@@ -22,6 +23,18 @@ from .geometry import PixelBounds, Projection
 
 RasterFormats = ClassRegistry()
 logger = get_logger(__name__)
+
+
+def get_bandset_dirname(bands: list[str]) -> str:
+    """Get the directory name that should be used to store the given group of bands."""
+    if any(["_" in band for band in bands]):
+        raise ValueError("band names must not contain '_'")
+    dirname = "_".join(bands)
+    if len(dirname) > 64:
+        # Previously we simply joined the bands, but this can result in directory name
+        # that is too long. In this case, now we use hash instead.
+        dirname = hashlib.sha256(dirname.encode()).hexdigest()
+    return dirname
 
 
 def get_raster_projection_and_bounds_from_transform(

--- a/tests/integration/data_sources/test_copernicus.py
+++ b/tests/integration/data_sources/test_copernicus.py
@@ -126,7 +126,6 @@ class TestSentinel1:
 
     def test_ingest(self, tmp_path: pathlib.Path, seattle2020: STGeometry) -> None:
         """Test ingesting a Sentinel-1 scene corresponding to seattle2020."""
-        band_names = ["vv", "vh"]
         data_source = Sentinel1(
             Sentinel1ProductType.IW_GRDH, Sentinel1Polarisation.VV_VH
         )
@@ -145,4 +144,5 @@ class TestSentinel1:
         data_source.ingest(
             TileStoreWithLayer(tile_store, layer_name), item_groups[0], [[seattle2020]]
         )
-        assert tile_store.is_raster_ready(layer_name, item.name, band_names)
+        assert tile_store.is_raster_ready(layer_name, item.name, ["vv"])
+        assert tile_store.is_raster_ready(layer_name, item.name, ["vh"])

--- a/tests/integration/data_sources/test_google_earth_engine.py
+++ b/tests/integration/data_sources/test_google_earth_engine.py
@@ -7,11 +7,7 @@ import pytest
 from upath import UPath
 
 from rslearn.config import (
-    BandSetConfig,
-    DType,
-    LayerType,
     QueryConfig,
-    RasterLayerConfig,
     SpaceMode,
 )
 from rslearn.data_sources.google_earth_engine import GEE
@@ -37,15 +33,11 @@ class TestGEE:
 
         Here we use Sentinel-1.
         """
-        layer_config = RasterLayerConfig(
-            LayerType.RASTER,
-            [BandSetConfig(config_dict={}, dtype=DType.UINT8, bands=[self.TEST_BAND])],
-        )
         query_config = QueryConfig(space_mode=SpaceMode.INTERSECTS)
         data_source = GEE(
-            config=layer_config,
             collection_name="COPERNICUS/S1_GRD",
             gcs_bucket_name=os.environ["TEST_BUCKET"],
+            bands=[self.TEST_BAND],
             service_account_name=os.environ["TEST_SERVICE_ACCOUNT_NAME"],
             service_account_credentials=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
             filters=[


### PR DESCRIPTION
Improve time series support in the model configuration file.

Previously, if we have a layer that is an image time series (contains multiple sub-layers over time), then in the model config we would need to have one DataInput per timestep. This PR adds two options in DataInput, load_all_item_groups and load_all_layers.

- load_all_item_groups: this adds all item groups under the specified layer as options of layers to load.
- load_all_layers: this reads all of the layer options concatenated on channel axis instead of randomly picking one option to read.

So the two options can be combined to read image time series. They are still treated as tensors with time concatenated over channel axis (T*CxHxW).

Resolves #174. Depends on #200.