### PR TITLE
Fix bug in ModelDataset when dataset has no windows

### DIFF
--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -367,7 +367,7 @@ class ModelDataset(torch.utils.data.Dataset):
         # We use only main thread if the index is set, since that can take a long time
         # to send to the worker threads, it may get serialized for each window.
         new_windows = []
-        if workers == 0 or windows[0].index is not None:
+        if workers == 0 or (len(windows) >= 1 and windows[0].index is not None):
             for window in windows:
                 if check_window(self.inputs, window) is None:
                     continue

--- a/tests/integration/train/test_dataset.py
+++ b/tests/integration/train/test_dataset.py
@@ -57,3 +57,17 @@ class TestDataset:
         assert len(dataset) == 2
         window_names = {window.name for window in dataset.get_dataset_examples()}
         assert window_names == {"window3", "window4"}
+
+    def test_empty_dataset(self, tmp_path: pathlib.Path) -> None:
+        """Ensure ModelDataset works with no windows."""
+        ds_path = UPath(tmp_path)
+        with (ds_path / "config.json").open("w") as f:
+            json.dump({"layers": {}}, f)
+        dataset = ModelDataset(
+            dataset=Dataset(ds_path),
+            split_config=SplitConfig(),
+            inputs={},
+            task=ClassificationTask(property_name="prop_name", classes=[]),
+            workers=4,
+        )
+        assert len(dataset) == 0


### PR DESCRIPTION
Fix bug in ModelDataset when dataset has no windows.

This bug was introduced with the DatasetIndex. It causes issues for some tests in rslearn_projects using dataset with no windows. I added a new test here to make sure ModelDataset works with no windows.