### PR TITLE
Changes to support crop type application

### DIFF
--- a/rslearn/models/module_wrapper.py
+++ b/rslearn/models/module_wrapper.py
@@ -54,15 +54,25 @@ class EncoderModuleWrapper(torch.nn.Module):
 
     def __init__(
         self,
-        modules: list[torch.nn.Module],
+        module: torch.nn.Module | None = None,
+        modules: list[torch.nn.Module] = [],
     ):
         """Initialize an EncoderModuleWrapper.
 
         Args:
+            module: the encoder module to wrap. Exactly one one of module or modules
+                must be set.
             modules: list of modules to wrap
         """
         super().__init__()
-        self.encoder_modules = torch.nn.ModuleList(modules)
+        if module is not None and len(modules) > 0:
+            raise ValueError("only one of module or modules should be set")
+        if module is not None:
+            self.encoder_modules = torch.nn.ModuleList([module])
+        elif len(modules) > 0:
+            self.encoder_modules = torch.nn.ModuleList(modules)
+        else:
+            raise ValueError("one of module or modules must be set")
 
     def forward(
         self,

--- a/rslearn/models/module_wrapper.py
+++ b/rslearn/models/module_wrapper.py
@@ -54,15 +54,15 @@ class EncoderModuleWrapper(torch.nn.Module):
 
     def __init__(
         self,
-        module: torch.nn.Module,
+        modules: list[torch.nn.Module],
     ):
         """Initialize an EncoderModuleWrapper.
 
         Args:
-            module: the module to wrap
+            modules: list of modules to wrap
         """
         super().__init__()
-        self.module = module
+        self.encoder_modules = torch.nn.ModuleList(modules)
 
     def forward(
         self,
@@ -75,4 +75,7 @@ class EncoderModuleWrapper(torch.nn.Module):
                 process.
         """
         images = torch.stack([inp["image"] for inp in inputs], dim=0)
-        return self.module([images], inputs)
+        cur = [images]
+        for m in self.encoder_modules:
+            cur = m(cur, inputs)
+        return cur

--- a/rslearn/models/pick_features.py
+++ b/rslearn/models/pick_features.py
@@ -8,14 +8,20 @@ import torch
 class PickFeatures(torch.nn.Module):
     """Picks a subset of feature maps in a multi-scale feature map list."""
 
-    def __init__(self, indexes: list[int]):
+    def __init__(self, indexes: list[int], collapse: bool = False):
         """Create a new PickFeatures.
 
         Args:
             indexes: the indexes of the input feature map list to select.
+            collapse: return one feature map instead of list. If enabled, indexes must
+                consist of one index.
         """
         super().__init__()
         self.indexes = indexes
+        self.collapse = collapse
+
+        if self.collapse and len(self.indexes) != 1:
+            raise ValueError("if collapse is enabled, must get exactly one index")
 
     def forward(
         self,
@@ -30,4 +36,9 @@ class PickFeatures(torch.nn.Module):
             inputs: raw inputs, not used
             targets: targets, not used
         """
-        return [features[idx] for idx in self.indexes]
+        new_features = [features[idx] for idx in self.indexes]
+        if self.collapse:
+            assert len(new_features) == 1
+            return new_features[0]
+        else:
+            return new_features

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -912,6 +912,9 @@ class AllPatchesDataset(torch.utils.data.IterableDataset):
         # Now we pad our own patches as necessary.
         # We copy from patches assigned to other workers starting from the previous
         # worker.
+        # This ensures that all workers have the same number of samples. This is needed
+        # because the batches must be consistent across ranks, since processing will
+        # stop once any rank has exhausted its batches with DDP.
         my_patches = patches_by_worker[global_worker_id]
         cur_worker_to_pad_from = (global_worker_id - 1) % global_num_workers
         while (

--- a/rslearn/train/dataset.py
+++ b/rslearn/train/dataset.py
@@ -8,8 +8,10 @@ import random
 import tempfile
 import time
 import uuid
+from collections.abc import Iterable, Iterator
 from typing import Any
 
+import shapely
 import torch
 import tqdm
 
@@ -25,7 +27,7 @@ from rslearn.dataset.window import Window, get_layer_and_group_from_dir_name
 from rslearn.log_utils import get_logger
 from rslearn.train.tasks import Task
 from rslearn.utils.feature import Feature
-from rslearn.utils.geometry import PixelBounds
+from rslearn.utils.geometry import PixelBounds, STGeometry
 from rslearn.utils.mp import star_imap_unordered
 from rslearn.utils.raster_format import load_raster_format
 from rslearn.utils.vector_format import load_vector_format
@@ -381,12 +383,15 @@ class SplitConfig:
         self.transforms = transforms
         self.sampler = sampler
         self.patch_size = patch_size
-        self.load_all_patches = load_all_patches
         self.skip_targets = skip_targets
+
+        # Note that load_all_patches are handled by the RslearnDataModule rather than
+        # the ModelDataset.
+        self.load_all_patches = load_all_patches
         self.overlap_ratio = overlap_ratio
-        if self.overlap_ratio is not None:
-            if not (0 < self.overlap_ratio < 1):
-                raise ValueError("overlap_ratio must be between 0 and 1 (exclusive)")
+
+        if self.overlap_ratio is not None and not (0 < self.overlap_ratio < 1):
+            raise ValueError("overlap_ratio must be between 0 and 1 (exclusive)")
 
     def update(self, other: "SplitConfig") -> "SplitConfig":
         """Override settings in this SplitConfig with those in another.
@@ -430,6 +435,18 @@ class SplitConfig:
         if other.skip_targets is not None:
             result.skip_targets = other.skip_targets
         return result
+
+    def get_patch_size(self) -> tuple[int, int] | None:
+        """Get patch size normalized to int tuple."""
+        if self.patch_size is None:
+            return None
+        if isinstance(self.patch_size, int):
+            return (self.patch_size, self.patch_size)
+        return self.patch_size
+
+    def get_overlap_ratio(self) -> float:
+        """Get the overlap ratio (default 0)."""
+        return self.overlap_ratio if self.overlap_ratio is not None else 0.0
 
     def get_load_all_patches(self) -> bool:
         """Returns whether loading all patches is enabled (default False)."""
@@ -504,13 +521,13 @@ class ModelDataset(torch.utils.data.Dataset):
         else:
             self.transforms = rslearn.train.transforms.transform.Identity()
 
-        # Convert patch size to (width, height) format if needed.
-        if not split_config.patch_size:
+        # Get normalized patch size from the SplitConfig.
+        # But if load all patches is enabled, this is handled by AllPatchesDataset, so
+        # here we instead load the entire windows.
+        if split_config.get_load_all_patches():
             self.patch_size = None
-        elif isinstance(split_config.patch_size, int):
-            self.patch_size = (split_config.patch_size, split_config.patch_size)
         else:
-            self.patch_size = split_config.patch_size
+            self.patch_size = split_config.get_patch_size()
 
         if split_config.names:
             windows = self.dataset.load_windows(
@@ -601,47 +618,6 @@ class ModelDataset(torch.utils.data.Dataset):
             # be representative of the population.
             windows = windows[0 : split_config.num_samples]
 
-        dataset_examples: list = windows
-
-        # If we're loading all patches, we need to include the patch details.
-        # In this case, dataset_examples is a list of (window, bounds, (patch_idx, # patches)).
-        if split_config.get_load_all_patches() and self.patch_size is not None:
-            patches = []
-            overlap_size = int(
-                self.patch_size[0] * split_config.overlap_ratio
-                if split_config.overlap_ratio
-                else 0
-            )
-            for window in dataset_examples:
-                cur_patches = []
-                if window is None:
-                    raise ValueError("Window is None in load_all_patches")
-                for col in range(
-                    window.bounds[0],
-                    window.bounds[2],
-                    self.patch_size[0] - overlap_size,
-                ):
-                    for row in range(
-                        window.bounds[1],
-                        window.bounds[3],
-                        self.patch_size[1] - overlap_size,
-                    ):
-                        cur_patches.append(
-                            (
-                                col,
-                                row,
-                                col + self.patch_size[0],
-                                row + self.patch_size[1],
-                            )
-                        )
-                for i, patch_bounds in enumerate(cur_patches):
-                    patches.append((window, patch_bounds, (i, len(cur_patches))))
-
-            if split_config.num_patches:
-                patches = patches[0 : split_config.num_patches]
-
-            dataset_examples = patches
-
         # Write dataset_examples to a file so that we can load it lazily in the worker
         # processes. Otherwise it takes a long time to transmit it when spawning each
         # process.
@@ -650,44 +626,25 @@ class ModelDataset(torch.utils.data.Dataset):
             "rslearn_dataset_examples",
             f"{os.getpid()}_{uuid.uuid4()}.json",
         )
-        self.num_dataset_examples = len(dataset_examples)
-        self.dataset_examples: list | None = None
+        self.num_dataset_examples = len(windows)
+        self.dataset_examples: list[Window] | None = None
         logger.info(
-            f"Writing {len(dataset_examples)} dataset examples to {self.dataset_examples_fname}"
+            f"Writing {len(windows)} dataset examples to {self.dataset_examples_fname}"
         )
         os.makedirs(os.path.dirname(self.dataset_examples_fname), exist_ok=True)
         with open(self.dataset_examples_fname, "w") as f:
-            json.dump(
-                [self._serialize_item(example) for example in dataset_examples], f
-            )
+            json.dump([self._serialize_item(example) for example in windows], f)
 
-    def _serialize_item(self, example: Window | tuple) -> dict[str, Any]:
-        if isinstance(example, Window):
-            return {
-                "window": example.get_metadata(),
-            }
-        else:
-            window, patch_bounds, indices = example
-            return {
-                "window": window.get_metadata(),
-                "patch_bounds": patch_bounds,
-                "indices": indices,
-            }
+    def _serialize_item(self, example: Window) -> dict[str, Any]:
+        return example.get_metadata()
 
-    def _deserialize_item(self, d: dict[str, Any]) -> Window | tuple:
-        window_metadata = d["window"]
-        window = Window.from_metadata(
-            Window.get_window_root(
-                self.dataset.path, window_metadata["group"], window_metadata["name"]
-            ),
-            window_metadata,
+    def _deserialize_item(self, d: dict[str, Any]) -> Window:
+        return Window.from_metadata(
+            Window.get_window_root(self.dataset.path, d["group"], d["name"]),
+            d,
         )
-        if "patch_bounds" in d:
-            return (window, tuple(d["patch_bounds"]), tuple(d["indices"]))
-        else:
-            return window
 
-    def get_dataset_examples(self) -> list:
+    def get_dataset_examples(self) -> list[Window]:
         """Get a list of examples in the dataset.
 
         If load_all_patches is False, this is a list of Windows. Otherwise, this is a
@@ -708,26 +665,25 @@ class ModelDataset(torch.utils.data.Dataset):
         """Returns the dataset length."""
         return self.num_dataset_examples
 
-    def __getitem__(
+    def get_raw_inputs(
         self, idx: int
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-        """Read one training example.
+        """Get the raw inputs and base metadata for this example.
+
+        This is the raster or vector data before being processed by the Task. So it
+        should be a Tensor for raster and list[Feature] for vector.
 
         Args:
             idx: the index in the dataset.
 
         Returns:
-            a tuple (input_dict, target_dict)
+            a tuple (raw_inputs, passthrough_inputs, metadata).
         """
         dataset_examples = self.get_dataset_examples()
-        logger.debug("__getitem__ start pid=%d item_idx=%d", os.getpid(), idx)
         example = dataset_examples[idx]
 
         # Select bounds to read.
-        if self.split_config.get_load_all_patches():
-            window, bounds, (patch_idx, num_patches) = example
-
-        elif self.patch_size:
+        if self.patch_size:
             window = example
 
             def get_patch_range(n_patch: int, n_window: int) -> list[int]:
@@ -750,12 +706,12 @@ class ModelDataset(torch.utils.data.Dataset):
                 get_patch_range(self.patch_size[0], window_size[0]),
                 get_patch_range(self.patch_size[1], window_size[1]),
             ]
-            bounds = [
+            bounds = (
                 window.bounds[0] + patch_ranges[0][0],
                 window.bounds[1] + patch_ranges[1][0],
                 window.bounds[0] + patch_ranges[0][1],
                 window.bounds[1] + patch_ranges[1][1],
-            ]
+            )
 
         else:
             window = example
@@ -779,12 +735,25 @@ class ModelDataset(torch.utils.data.Dataset):
             "projection": window.projection,
             "dataset_source": self.name,
         }
-        if self.split_config.get_load_all_patches():
-            metadata["patch_idx"] = patch_idx
-            metadata["num_patches"] = num_patches
-        else:
-            metadata["patch_idx"] = 0
-            metadata["num_patches"] = 1
+
+        return raw_inputs, passthrough_inputs, metadata
+
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Read one training example.
+
+        Args:
+            idx: the index in the dataset.
+
+        Returns:
+            a tuple (input_dict, target_dict, metadata)
+        """
+        logger.debug("__getitem__ start pid=%d item_idx=%d", os.getpid(), idx)
+
+        raw_inputs, passthrough_inputs, metadata = self.get_raw_inputs(idx)
+        metadata["patch_idx"] = 0
+        metadata["num_patches"] = 1
 
         input_dict, target_dict = self.task.process_inputs(
             raw_inputs,
@@ -806,6 +775,198 @@ class ModelDataset(torch.utils.data.Dataset):
             name: the name to set.
         """
         self.name = name
+
+
+class AllPatchesDataset(torch.utils.data.IterableDataset):
+    """This wraps a ModelDataset to iterate over all patches in that dataset.
+
+    This should be used when SplitConfig.load_all_patches is enabled. The ModelDataset
+    is configured with no patch size (load entire windows), and the dataset is wrapped
+    in an AllPatchesDataset.
+    """
+
+    def __init__(
+        self,
+        dataset: ModelDataset,
+        patch_size: tuple[int, int],
+        overlap_ratio: float = 0.0,
+        rank: int = 0,
+        world_size: int = 1,
+    ):
+        """Create a new AllPatchesDataset.
+
+        Args:
+            dataset: the ModelDataset to wrap.
+            patch_size: the size of the patches to extract.
+            overlap_ratio: whether to include overlap between the patches. Note that
+                the right/bottom-most patches may still overlap since we ensure that
+                all patches are contained in the window bounds.
+            rank: the global rank of this train worker process.
+            world_size: the total number of train worker processes.
+        """
+        super().__init__()
+        self.dataset = dataset
+        self.patch_size = patch_size
+        self.overlap_size = (
+            round(self.patch_size[0] * overlap_ratio),
+            round(self.patch_size[1] * overlap_ratio),
+        )
+        self.rank = rank
+        self.world_size = world_size
+
+    def get_patch_options(self, bounds: PixelBounds) -> list[PixelBounds]:
+        """Get the bounds of each patch within the overall bounds.
+
+        Args:
+            bounds: the window bounds to divide up into smaller patches.
+
+        Returns:
+            a list of patch bounds within the overall bounds. The rightmost and
+                bottommost patches may extend beyond the provided bounds.
+        """
+        # We stride the patches by patch_size - overlap_size until the last patch.
+        # We handle the last patch with a special case to ensure it does not exceed the
+        # window bounds. Instead, it may overlap the previous patch.
+        cols = list(
+            range(
+                bounds[0],
+                bounds[2] - self.patch_size[0],
+                self.patch_size[0] - self.overlap_size[0],
+            )
+        ) + [bounds[2] - self.patch_size[0]]
+        rows = list(
+            range(
+                bounds[1],
+                bounds[3] - self.patch_size[1],
+                self.patch_size[1] - self.overlap_size[1],
+            )
+        ) + [bounds[3] - self.patch_size[1]]
+
+        patch_bounds: list[PixelBounds] = []
+        for col in cols:
+            for row in rows:
+                patch_bounds.append(
+                    (
+                        col,
+                        row,
+                        col + self.patch_size[0],
+                        row + self.patch_size[1],
+                    )
+                )
+        return patch_bounds
+
+    def _get_idx_subset(self) -> Iterable[int]:
+        """Get subset of indices in the underlying dataset that we should iterate over.
+
+        This is split both by training worker (self.rank) and data loader worker (via
+        get_worker_info).
+        """
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            worker_id = 0
+            num_workers = 1
+        else:
+            worker_id = worker_info.id
+            num_workers = worker_info.num_workers
+        global_worker_id = self.rank * num_workers + worker_id
+        global_num_workers = self.world_size * num_workers
+
+        return range(global_worker_id, len(self.dataset), global_num_workers)
+
+    def __len__(self) -> int:
+        """Compute the total number of patches across all windows for this worker."""
+        total_num_patches = 0
+        windows = self.dataset.get_dataset_examples()
+        for idx in self._get_idx_subset():
+            patch_options = self.get_patch_options(windows[idx].bounds)
+            total_num_patches += len(patch_options)
+        return total_num_patches
+
+    def __iter__(
+        self,
+    ) -> Iterator[tuple[dict[str, Any], dict[str, Any], dict[str, Any]]]:
+        """Iterate over all patches in each element of the underlying ModelDataset."""
+        for idx in self._get_idx_subset():
+            raw_inputs, passthrough_inputs, metadata = self.dataset.get_raw_inputs(idx)
+            bounds = metadata["bounds"]
+
+            # For simplicity, pad tensors by patch size to ensure that any patch bounds
+            # extending outside the window bounds will not have issues when we slice
+            # the tensors later.
+            for d in [raw_inputs, passthrough_inputs]:
+                for input_name, value in list(d.items()):
+                    if not isinstance(value, torch.Tensor):
+                        continue
+                    d[input_name] = torch.nn.functional.pad(
+                        value, pad=(0, self.patch_size[0], 0, self.patch_size[1])
+                    )
+
+            # Now iterate over the patches and extract/yield the crops.
+            # Note that, in case user is leveraging RslearnWriter, it is important that
+            # the patch_idx be increasing (as we iterate) within one window.
+            patch_options = self.get_patch_options(bounds)
+            for patch_idx, cur_bounds in enumerate(patch_options):
+                cur_geom = STGeometry(
+                    metadata["projection"], shapely.box(*cur_bounds), None
+                )
+                start_offset = (
+                    cur_bounds[0] - bounds[0],
+                    cur_bounds[1] - bounds[1],
+                )
+                end_offset = (
+                    cur_bounds[2] - bounds[0],
+                    cur_bounds[3] - bounds[1],
+                )
+
+                # Define a helper function to handle each input dict.
+                def crop_input_dict(d: dict[str, Any]) -> dict[str, Any]:
+                    cropped = {}
+                    for input_name, value in d.items():
+                        if isinstance(value, torch.Tensor):
+                            # Crop the CHW tensor.
+                            cropped[input_name] = value[
+                                :,
+                                start_offset[1] : end_offset[1],
+                                start_offset[0] : end_offset[0],
+                            ].clone()
+                        elif isinstance(value, list):
+                            cropped[input_name] = [
+                                feat
+                                for feat in value
+                                if cur_geom.intersects(feat.geometry)
+                            ]
+                        else:
+                            raise ValueError(
+                                "got input that is neither tensor nor feature list"
+                            )
+                    return cropped
+
+                cur_raw_inputs = crop_input_dict(raw_inputs)
+                cur_passthrough_inputs = crop_input_dict(passthrough_inputs)
+
+                # Adjust the metadata as well.
+                cur_metadata = metadata.copy()
+                cur_metadata["bounds"] = cur_bounds
+                cur_metadata["patch_idx"] = patch_idx
+                cur_metadata["num_patches"] = len(patch_options)
+
+                # Now we can compute input and target dicts via the task.
+                input_dict, target_dict = self.dataset.task.process_inputs(
+                    cur_raw_inputs,
+                    metadata=cur_metadata,
+                    load_targets=not self.dataset.split_config.get_skip_targets(),
+                )
+                input_dict.update(cur_passthrough_inputs)
+                input_dict, target_dict = self.dataset.transforms(
+                    input_dict, target_dict
+                )
+                input_dict["dataset_source"] = self.dataset.name
+
+                yield input_dict, target_dict, cur_metadata
+
+    def get_dataset_examples(self) -> list[Window]:
+        """Returns a list of windows in this dataset."""
+        return self.dataset.get_dataset_examples()
 
 
 class RetryDataset(torch.utils.data.Dataset):
@@ -859,7 +1020,7 @@ class RetryDataset(torch.utils.data.Dataset):
         # One last try -- but don't catch any more errors.
         return self.dataset[idx]
 
-    def get_dataset_examples(self) -> list:
+    def get_dataset_examples(self) -> list[Window]:
         """Returns a list of windows in this dataset."""
         return self.dataset.get_dataset_examples()
 

--- a/rslearn/train/prediction_writer.py
+++ b/rslearn/train/prediction_writer.py
@@ -1,7 +1,8 @@
 """rslearn PredictionWriter implementation."""
 
 from collections.abc import Sequence
-from typing import Any, overload
+from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -19,34 +20,102 @@ from rslearn.dataset import Dataset, Window
 from rslearn.utils.array import copy_spatial_array
 from rslearn.utils.feature import Feature
 from rslearn.utils.geometry import PixelBounds
-from rslearn.utils.raster_format import load_raster_format
-from rslearn.utils.vector_format import load_vector_format
+from rslearn.utils.raster_format import RasterFormat, load_raster_format
+from rslearn.utils.vector_format import VectorFormat, load_vector_format
 
 from .lightning_module import RslearnLightningModule
 from .tasks.task import Task
 
 
+@dataclass
+class PendingPatchOutput:
+    """A patch output that hasn't been merged yet."""
+
+    bounds: PixelBounds
+    output: Any
+
+
 class PatchPredictionMerger:
     """Base class for merging predictions from multiple patches."""
 
-    @overload
-    def merge(self, outputs: list[Feature]) -> list[Feature]: ...
-
-    @overload
-    def merge(self, outputs: npt.NDArray[Any]) -> npt.NDArray[Any]: ...
-
-    def merge(
-        self, outputs: list[Feature] | npt.NDArray[Any]
-    ) -> list[Feature] | npt.NDArray[Any]:
+    def merge(self, window: Window, outputs: Sequence[PendingPatchOutput]) -> Any:
         """Merge the outputs.
 
         Args:
+            window: the window we are merging the outputs for.
             outputs: the outputs to process.
 
         Returns:
             the merged outputs.
         """
         raise NotImplementedError
+
+
+class VectorMerger(PatchPredictionMerger):
+    """Merger for vector data that simply concatenates the features."""
+
+    def merge(
+        self, window: Window, outputs: Sequence[PendingPatchOutput]
+    ) -> list[Feature]:
+        """Concatenate the vector features."""
+        return [feat for output in outputs for feat in output.output]
+
+
+class RasterMerger(PatchPredictionMerger):
+    """Merger for raster data that copies the rasters to the output."""
+
+    def __init__(self, padding: int | None = None):
+        """Create a new RasterMerger.
+
+        Args:
+            padding: the padding around the individual patch outputs to remove. This is
+                typically used when leveraging overlapping patches. Portions of outputs
+                at the border of the window will still be retained.
+        """
+        self.padding = padding
+
+    def merge(
+        self, window: Window, outputs: Sequence[PendingPatchOutput]
+    ) -> npt.NDArray:
+        """Merge the raster outputs."""
+        num_channels = outputs[0].output.shape[0]
+        dtype = outputs[0].output.dtype
+        merged_image = np.zeros(
+            (
+                num_channels,
+                window.bounds[3] - window.bounds[1],
+                window.bounds[2] - window.bounds[0],
+            ),
+            dtype=dtype,
+        )
+
+        # Ensure the outputs are sorted by height then width.
+        # This way when we merge we can be sure that outputs that are lower or further
+        # to the right will overwrite earlier outputs.
+        sorted_outputs = sorted(
+            outputs, key=lambda output: (output.bounds[0], output.bounds[1])
+        )
+        for output in sorted_outputs:
+            # So now we just need to compute the src_offset to copy.
+            # If the output is not on the left or top boundary, then we should apply
+            # the padding (if set).
+            src = output.output
+            src_offset = (output.bounds[0], output.bounds[1])
+            if self.padding is not None and output.bounds[0] != window.bounds[0]:
+                src = src[:, :, self.padding :]
+                src_offset = (src_offset[0] + self.padding, src_offset[1])
+            if self.padding is not None and output.bounds[1] != window.bounds[1]:
+                src = src[:, self.padding :, :]
+                src_offset = (src_offset[0], src_offset[1] + self.padding)
+
+            copy_spatial_array(
+                src=src,
+                dst=merged_image,
+                src_offset=src_offset,
+                dst_offset=(window.bounds[0], window.bounds[1]),
+            )
+
+        return merged_image
 
 
 class RslearnWriter(BasePredictionWriter):
@@ -80,8 +149,8 @@ class RslearnWriter(BasePredictionWriter):
         self.path = UPath(path, **path_options)
         self.dataset = Dataset(self.path)
         self.layer_config = self.dataset.layers[self.output_layer]
-        # TODO: This is a bit of a hack to get the type checker to be happy.
-        self.format: Any
+
+        self.format: RasterFormat | VectorFormat
         if self.layer_config.layer_type == LayerType.RASTER:
             assert isinstance(self.layer_config, RasterLayerConfig)
             band_cfg = self.layer_config.band_sets[0]
@@ -94,12 +163,17 @@ class RslearnWriter(BasePredictionWriter):
         else:
             raise ValueError(f"invalid layer type {self.layer_config.layer_type}")
 
-        self.merger = merger
+        if merger is not None:
+            self.merger = merger
+        elif self.layer_config.layer_type == LayerType.RASTER:
+            self.merger = RasterMerger()
+        elif self.layer_config.layer_type == LayerType.VECTOR:
+            self.merger = VectorMerger()
 
         # Map from window name to pending data to write.
         # This is used when windows are split up into patches, so the data from all the
         # patches of each window need to be reconstituted.
-        self.pending_outputs: dict[str, Any] = {}
+        self.pending_outputs: dict[str, list[PendingPatchOutput]] = {}
 
     def write_on_batch_end(
         self,
@@ -192,17 +266,10 @@ class RslearnWriter(BasePredictionWriter):
             cur_bounds: the bounds of the current patch.
             output: the output data.
         """
-        if self.layer_config.layer_type == LayerType.RASTER:
-            if not isinstance(output, np.ndarray):
-                raise ValueError("expected output for raster layer to be numpy array")
-            self._incorporate_raster_output(window, cur_bounds, output)
-
-        elif self.layer_config.layer_type == LayerType.VECTOR:
-            if not isinstance(output, list):
-                raise ValueError(
-                    "expected output for vector layer to be list of features"
-                )
-            self._incorporate_vector_output(window, cur_bounds, output)
+        # Incorporate the output into our list of pending patch outputs.
+        if window.name not in self.pending_outputs:
+            self.pending_outputs[window.name] = []
+        self.pending_outputs[window.name].append(PendingPatchOutput(cur_bounds, output))
 
         if patch_idx < num_patches - 1:
             return
@@ -213,74 +280,21 @@ class RslearnWriter(BasePredictionWriter):
         del self.pending_outputs[window.name]
 
         # Merge outputs from overlapped patches if merger is set.
-        if self.merger is not None:
-            pending_output = self.merger.merge(pending_output)
+        merged_output = self.merger.merge(window, pending_output)
 
         if self.layer_config.layer_type == LayerType.RASTER:
             assert isinstance(self.layer_config, RasterLayerConfig)
             raster_dir = window.get_raster_dir(
                 self.output_layer, self.layer_config.band_sets[0].bands
             )
+            assert isinstance(self.format, RasterFormat)
             self.format.encode_raster(
-                raster_dir, window.projection, window.bounds, pending_output
+                raster_dir, window.projection, window.bounds, merged_output
             )
 
         elif self.layer_config.layer_type == LayerType.VECTOR:
             layer_dir = window.get_layer_dir(self.output_layer)
-            self.format.encode_vector(layer_dir, pending_output)
+            assert isinstance(self.format, VectorFormat)
+            self.format.encode_vector(layer_dir, merged_output)
 
         window.mark_layer_completed(self.output_layer)
-
-    def _incorporate_raster_output(
-        self,
-        window: Window,
-        cur_bounds: PixelBounds,
-        output: npt.NDArray,
-    ) -> None:
-        """Incorporate the partial output into the output for this window.
-
-        Args:
-            window: the window this output corresponds to.
-            cur_bounds: the bounds within the window that this output covers. This
-                could be the entire window, but could also be a patch of the window if
-                the window is processed in patches.
-            output: the output data.
-        """
-        if window.name not in self.pending_outputs:
-            self.pending_outputs[window.name] = np.zeros(
-                (
-                    output.shape[0],
-                    window.bounds[3] - window.bounds[1],
-                    window.bounds[2] - window.bounds[0],
-                ),
-                dtype=output.dtype,
-            )
-
-        # Use copy_spatial_array to handle the copy since, when using patches,
-        # the last column/row of outputs might extend beyond the bounds of the
-        # window.
-        copy_spatial_array(
-            src=output,
-            dst=self.pending_outputs[window.name],
-            src_offset=(cur_bounds[0], cur_bounds[1]),
-            dst_offset=(window.bounds[0], window.bounds[1]),
-        )
-
-    def _incorporate_vector_output(
-        self,
-        window: Window,
-        cur_bounds: PixelBounds,
-        output: list[Feature],
-    ) -> None:
-        """Incorporate the partial output into the output for this window.
-
-        Args:
-            window: the window this output corresponds to.
-            cur_bounds: the bounds within the window that this output covers. This
-                could be the entire window, but could also be a patch of the window if
-                the window is processed in patches.
-            output: the output data.
-        """
-        if window.name not in self.pending_outputs:
-            self.pending_outputs[window.name] = []
-        self.pending_outputs[window.name].extend(output)

--- a/rslearn/train/tasks/segmentation.py
+++ b/rslearn/train/tasks/segmentation.py
@@ -47,6 +47,7 @@ class SegmentationTask(BasicTask):
         metric_kwargs: dict[str, Any] = {},
         miou_metric_kwargs: dict[str, Any] = {},
         prob_scales: list[float] | None = None,
+        other_metrics: dict[str, Metric] = {},
         **kwargs: Any,
     ) -> None:
         """Initialize a new SegmentationTask.
@@ -72,6 +73,7 @@ class SegmentationTask(BasicTask):
                 before computing the argmax. There is one scale per class. Note that
                 this is only applied during prediction, not when computing val or test
                 metrics.
+            other_metrics: additional metrics to configure on this task.
             kwargs: additional arguments to pass to BasicTask
         """
         super().__init__(**kwargs)
@@ -85,6 +87,7 @@ class SegmentationTask(BasicTask):
         self.metric_kwargs = metric_kwargs
         self.miou_metric_kwargs = miou_metric_kwargs
         self.prob_scales = prob_scales
+        self.other_metrics = other_metrics
 
     def process_inputs(
         self,
@@ -222,6 +225,9 @@ class SegmentationTask(BasicTask):
                 pass_probabilities=False,
             )
 
+        if self.other_metrics:
+            metrics.update(self.other_metrics)
+
         return MetricCollection(metrics)
 
 
@@ -250,11 +256,17 @@ class SegmentationHead(torch.nn.Module):
         if targets:
             labels = torch.stack([target["classes"] for target in targets], dim=0)
             mask = torch.stack([target["valid"] for target in targets], dim=0)
-            loss = (
-                torch.nn.functional.cross_entropy(logits, labels, reduction="none")
-                * mask
+            per_pixel_loss = torch.nn.functional.cross_entropy(
+                logits, labels, reduction="none"
             )
-            loss = torch.mean(loss)
+            mask_sum = torch.sum(mask)
+            if mask_sum > 0:
+                # Compute average loss over valid pixels.
+                loss = torch.sum(per_pixel_loss * mask) / torch.sum(mask)
+            else:
+                # If there are no valid pixels, we avoid dividing by zero and just let
+                # the summed mask loss be zero.
+                loss = torch.sum(per_pixel_loss * mask)
 
         return outputs, {"cls": loss}
 
@@ -262,7 +274,12 @@ class SegmentationHead(torch.nn.Module):
 class SegmentationMetric(Metric):
     """Metric for segmentation task."""
 
-    def __init__(self, metric: Metric, pass_probabilities: bool = True):
+    def __init__(
+        self,
+        metric: Metric,
+        pass_probabilities: bool = True,
+        class_idx: int | None = None,
+    ):
         """Initialize a new SegmentationMetric.
 
         Args:
@@ -270,10 +287,12 @@ class SegmentationMetric(Metric):
                 classes from the targets and masking out invalid pixels.
             pass_probabilities: whether to pass predicted probabilities to the metric.
                 If False, argmax is applied to pass the predicted classes instead.
+            class_idx: if metric returns value for multiple classes, select this class.
         """
         super().__init__()
         self.metric = metric
         self.pass_probablities = pass_probabilities
+        self.class_idx = class_idx
 
     def update(
         self, preds: list[Any] | torch.Tensor, targets: list[dict[str, Any]]
@@ -304,7 +323,10 @@ class SegmentationMetric(Metric):
 
     def compute(self) -> Any:
         """Returns the computed metric."""
-        return self.metric.compute()
+        result = self.metric.compute()
+        if self.class_idx is not None:
+            result = result[self.class_idx]
+        return result
 
     def reset(self) -> None:
         """Reset metric."""

--- a/rslearn/train/transforms/concatenate.py
+++ b/rslearn/train/transforms/concatenate.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import torch
 
-from .transform import Transform
+from .transform import Transform, read_selector, write_selector
 
 
 class Concatenate(Transform):
@@ -40,10 +40,10 @@ class Concatenate(Transform):
         """
         images = []
         for selector, wanted_bands in self.selections.items():
-            image = self.read_selector(input_dict, target_dict, selector)
+            image = read_selector(input_dict, target_dict, selector)
             if wanted_bands:
                 image = image[wanted_bands, :, :]
             images.append(image)
         result = torch.concatenate(images, dim=0)
-        self.write_selector(input_dict, target_dict, self.output_selector, result)
+        write_selector(input_dict, target_dict, self.output_selector, result)
         return input_dict, target_dict

--- a/rslearn/train/transforms/crop.py
+++ b/rslearn/train/transforms/crop.py
@@ -5,7 +5,7 @@ from typing import Any
 import torch
 import torchvision
 
-from .transform import Transform
+from .transform import Transform, read_selector
 
 
 class Crop(Transform):
@@ -111,7 +111,7 @@ class Crop(Transform):
         """
         smallest_image_shape = None
         for selector in self.image_selectors:
-            image = self.read_selector(input_dict, target_dict, selector)
+            image = read_selector(input_dict, target_dict, selector)
             if (
                 smallest_image_shape is None
                 or image.shape[-1] < smallest_image_shape[1]

--- a/rslearn/train/transforms/transform.py
+++ b/rslearn/train/transforms/transform.py
@@ -6,87 +6,89 @@ from typing import Any
 import torch
 
 
+def get_dict_and_subselector(
+    input_dict: dict[str, Any], target_dict: dict[str, Any], selector: str
+) -> tuple[dict[str, Any], str]:
+    """Determine whether to use input or target dict, and the sub-selector.
+
+    For example, if the selector is "input/x", then we use input dict and the
+    sub-selector is "x".
+
+    If neither input/ nor target/ prefixes are present, then we assume it is for
+    input dict.
+
+    Args:
+        input_dict: the input dict
+        target_dict: the target dict
+        selector: the full selector configured by the user
+
+    Returns:
+        a tuple (referenced dict, sub-selector string)
+    """
+    input_prefix = "input/"
+    target_prefix = "target/"
+
+    if selector.startswith(input_prefix):
+        d = input_dict
+        selector = selector[len(input_prefix) :]
+    elif selector.startswith(target_prefix):
+        d = target_dict
+        selector = selector[len(target_prefix) :]
+    else:
+        d = input_dict
+
+    return d, selector
+
+
+def read_selector(
+    input_dict: dict[str, Any], target_dict: dict[str, Any], selector: str
+) -> Any:
+    """Read the item referenced by the selector.
+
+    Args:
+        input_dict: the input dict
+        target_dict: the target dict
+        selector: the selector specifying the item to read
+
+    Returns:
+        the item specified by the selector
+    """
+    d, selector = get_dict_and_subselector(input_dict, target_dict, selector)
+    parts = selector.split("/")
+    cur = d
+    for part in parts:
+        cur = cur[part]
+    return cur
+
+
+def write_selector(
+    input_dict: dict[str, Any],
+    target_dict: dict[str, Any],
+    selector: str,
+    v: Any,
+) -> None:
+    """Write the item to the specified selector.
+
+    Args:
+        input_dict: the input dict
+        target_dict: the target dict
+        selector: the selector specifying the item to write
+        v: the value to write
+    """
+    d, selector = get_dict_and_subselector(input_dict, target_dict, selector)
+    parts = selector.split("/")
+    cur = d
+    for part in parts[:-1]:
+        cur = cur[part]
+    cur[parts[-1]] = v
+
+
 class Transform(torch.nn.Module):
     """An rslearn transform.
 
     Provides helper functions for subclasses to select input and target keys and to
     transform them.
     """
-
-    def get_dict_and_subselector(
-        self, input_dict: dict[str, Any], target_dict: dict[str, Any], selector: str
-    ) -> tuple[dict[str, Any], str]:
-        """Determine whether to use input or target dict, and the sub-selector.
-
-        For example, if the selector is "input/x", then we use input dict and the
-        sub-selector is "x".
-
-        If neither input/ nor target/ prefixes are present, then we assume it is for
-        input dict.
-
-        Args:
-            input_dict: the input dict
-            target_dict: the target dict
-            selector: the full selector configured by the user
-
-        Returns:
-            a tuple (referenced dict, sub-selector string)
-        """
-        input_prefix = "input/"
-        target_prefix = "target/"
-
-        if selector.startswith(input_prefix):
-            d = input_dict
-            selector = selector[len(input_prefix) :]
-        elif selector.startswith(target_prefix):
-            d = target_dict
-            selector = selector[len(target_prefix) :]
-        else:
-            d = input_dict
-
-        return d, selector
-
-    def read_selector(
-        self, input_dict: dict[str, Any], target_dict: dict[str, Any], selector: str
-    ) -> Any:
-        """Read the item referenced by the selector.
-
-        Args:
-            input_dict: the input dict
-            target_dict: the target dict
-            selector: the selector specifying the item to read
-
-        Returns:
-            the item specified by the selector
-        """
-        d, selector = self.get_dict_and_subselector(input_dict, target_dict, selector)
-        parts = selector.split("/")
-        cur = d
-        for part in parts:
-            cur = cur[part]
-        return cur
-
-    def write_selector(
-        self,
-        input_dict: dict[str, Any],
-        target_dict: dict[str, Any],
-        selector: str,
-        v: Any,
-    ) -> None:
-        """Write the item to the specified selector.
-
-        Args:
-            input_dict: the input dict
-            target_dict: the target dict
-            selector: the selector specifying the item to write
-            v: the value to write
-        """
-        d, selector = self.get_dict_and_subselector(input_dict, target_dict, selector)
-        parts = selector.split("/")
-        cur = d
-        for part in parts[:-1]:
-            cur = cur[part]
-        cur[parts[-1]] = v
 
     def apply_fn(
         self,
@@ -106,9 +108,9 @@ class Transform(torch.nn.Module):
             kwargs: additional arguments to pass to the function
         """
         for selector in selectors:
-            v = self.read_selector(input_dict, target_dict, selector)
+            v = read_selector(input_dict, target_dict, selector)
             v = fn(v, **kwargs)
-            self.write_selector(input_dict, target_dict, selector, v)
+            write_selector(input_dict, target_dict, selector, v)
 
 
 class Identity(Transform):

--- a/tests/fixtures/datasets/image_to_class.py
+++ b/tests/fixtures/datasets/image_to_class.py
@@ -78,7 +78,7 @@ def image_to_class_dataset(tmp_path: pathlib.Path) -> Dataset:
 
     # Add label.
     feature = Feature(
-        STGeometry(window.projection, shapely.Point(1, 1), None),
+        STGeometry(window.projection, shapely.box(*window.bounds), None),
         {
             "label": 1,
         },

--- a/tests/unit/train/test_dataset.py
+++ b/tests/unit/train/test_dataset.py
@@ -207,7 +207,7 @@ def test_dataset_covers_border(image_to_class_dataset: Dataset) -> None:
             point_coverage[(col, row)] = False
 
     # With overlap_ratio=0.5, there should be 9 windows given that overlap is 1 pixel.
-    assert len(dataset_with_overlap) == 9
+    assert len(list(dataset_with_overlap)) == 9
 
     for _, _, metadata in dataset:
         bounds = metadata["bounds"]

--- a/tests/unit/train/test_dataset.py
+++ b/tests/unit/train/test_dataset.py
@@ -185,7 +185,7 @@ def test_dataset_covers_border(image_to_class_dataset: Dataset) -> None:
     # - (0, 1)
     # - (1, 0)
     # - (1, 1)
-    assert len(dataset) == 4
+    assert len(list(dataset)) == 4
 
     for _, _, metadata in dataset:
         bounds = metadata["bounds"]

--- a/tests/unit/train/test_dataset.py
+++ b/tests/unit/train/test_dataset.py
@@ -362,7 +362,6 @@ class TestAllPatchesDataset:
             all_patches_dataset = AllPatchesDataset(
                 model_dataset, (4, 4), rank=rank, world_size=world_size
             )
-            assert len(all_patches_dataset) == 1
             samples = list(all_patches_dataset)
             assert len(samples) == 1
             assert samples[0][2]["window_name"] == window.name
@@ -388,7 +387,6 @@ class TestAllPatchesDataset:
             all_patches_dataset = AllPatchesDataset(
                 model_dataset, (4, 4), rank=rank, world_size=world_size
             )
-            assert len(all_patches_dataset) == 1
             samples = list(all_patches_dataset)
             assert len(samples) == 1
             window_names.add(samples[0][2]["window_name"])
@@ -417,8 +415,8 @@ class TestAllPatchesDataset:
             all_patches_dataset = AllPatchesDataset(
                 model_dataset, (4, 4), rank=rank, world_size=world_size
             )
-            assert len(all_patches_dataset) == 4
             samples = list(all_patches_dataset)
+            assert len(samples) == 4
             for sample in samples:
                 patch_id = (sample[2]["window_name"], sample[2]["bounds"])
                 seen_patches[patch_id] = seen_patches.get(patch_id, 0) + 1
@@ -446,6 +444,5 @@ class TestAllPatchesDataset:
             all_patches_dataset = AllPatchesDataset(
                 model_dataset, (4, 4), rank=rank, world_size=world_size
             )
-            assert len(all_patches_dataset) == 0
             samples = list(all_patches_dataset)
             assert len(samples) == 0


### PR DESCRIPTION
This PR depends on #214 since otherwise there would be some conflicts.

It contains miscellaneous changes to support crop type application. More specifically, we want to support overlap between patches (input crops) for segmentation tasks and handling that during merging, and to support loading all patches more efficiently for very small patches.

* EncoderModuleWrapper: change to accept list of modules so we can apply e.g. a list of `rslearn.models.conv.Conv` for the encoder. Otherwise there is no way to provide a list here.
* PickFeatures: add a collapse option to output a single feature map instead of the list. This way it can be used to select features to pass directly to a decoder head like ClassificationHead or SegmentationHead.
* Change how SplitConfig.load_all_patches is implemented -- instead of being an option to ModelDataset, it will now result in an AllPatchesDataset that wraps ModelDataset. AllPatchesDataset is an IterableDataset so it can read entire windows, and then yield each patch from that window as a separate training example.
* I also made a minor change to not use RetryDataset by default, instead the retries is an argument to RslearnDataModule and it will only wrap the dataset with a RetryDataset if retries is set. This way errors are more obvious when retries are not needed.
* RslearnWriter: refactor the patch merging so it can handle merging raster data.
* SegmentationTask: support accepting a dict of custom metrics so user can provide things like precision / recall metrics.
* Also there is some minor refactoring of Transform in this PR.

Here is an example using EncoderModuleWrapper and PickFeatures:
```
class_path: rslearn.models.multitask.MultiTaskModel
init_args:
  encoder:
    - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
      init_args:
        encoder:
          class_path: rslearn.models.module_wrapper.EncoderModuleWrapper
          init_args:
            modules:
              - class_path: rslearn.models.conv.Conv
                init_args:
                  in_channels: 9
                  out_channels: 512
                  kernel_size: 3
        image_channels: 9
        backbone_channels: [[1, 512]]
  decoders:
    segment:
      - class_path: rslearn.models.conv.Conv
        init_args:
          in_channels: 512
          out_channels: 20
          kernel_size: 3
          activation:
            class_path: torch.nn.Identity
      - class_path: rslearn.models.pick_features.PickFeatures
        init_args:
          indexes: [0]
          collapse: true
      - class_path: rslearn.train.tasks.segmentation.SegmentationHead
```
