### PR TITLE
Fix bug in model predict

### DIFF
--- a/rslearn/models/multitask.py
+++ b/rslearn/models/multitask.py
@@ -23,7 +23,6 @@ class MultiTaskModel(torch.nn.Module):
         encoder: list[torch.nn.Module],
         decoders: dict[str, list[torch.nn.Module]],
         lazy_decode: bool = False,
-        loss_weights: dict[str, float] | None = None,
     ):
         """Initialize a new MultiTaskModel.
 
@@ -31,7 +30,6 @@ class MultiTaskModel(torch.nn.Module):
             encoder: modules to compute intermediate feature representations.
             decoders: modules to compute outputs and loss, should match number of tasks.
             lazy_decode: if True, only decode the outputs specified in the batch.
-            loss_weights: weights for each task's loss (default: None = equal weights)
         """
         super().__init__()
         self.lazy_decode = lazy_decode
@@ -44,14 +42,6 @@ class MultiTaskModel(torch.nn.Module):
             logger.info(
                 "lazy decoding enabled, check source is consistent across batch"
             )
-        if loss_weights is None:
-            loss_weights = {name: 1.0 for name in decoders.keys()}
-        for name in decoders.keys():
-            if name not in loss_weights:
-                logger.warning(f"extra task {name} not in loss_weights, setting to 1.0")
-                loss_weights[name] = 1.0
-        self.loss_weights = loss_weights
-        logger.info(f"loss_weights: {self.loss_weights}")
 
     def apply_decoder(
         self,
@@ -92,7 +82,7 @@ class MultiTaskModel(torch.nn.Module):
         for idx, entry in enumerate(cur_output):
             outputs[idx][name] = entry
         for loss_name, loss_value in cur_loss_dict.items():
-            losses[f"{name}_{loss_name}"] = loss_value * self.loss_weights[name]
+            losses[f"{name}_{loss_name}"] = loss_value
         return outputs, losses
 
     def forward(

--- a/rslearn/train/tasks/classification.py
+++ b/rslearn/train/tasks/classification.py
@@ -285,7 +285,7 @@ class ClassificationHead(torch.nn.Module):
         """
         outputs = torch.nn.functional.softmax(logits, dim=1)
 
-        loss = None
+        losses = {}
         if targets:
             class_labels = torch.stack([target["class"] for target in targets], dim=0)
             mask = torch.stack([target["valid"] for target in targets], dim=0)
@@ -295,9 +295,9 @@ class ClassificationHead(torch.nn.Module):
                 )
                 * mask
             )
-            loss = torch.mean(loss)
+            losses["cls"] = torch.mean(loss)
 
-        return outputs, {"cls": loss}
+        return outputs, losses
 
 
 class ClassificationMetric(Metric):

--- a/rslearn/train/tasks/classification.py
+++ b/rslearn/train/tasks/classification.py
@@ -174,7 +174,7 @@ class ClassificationTask(BasicTask):
                 class_idx = 1 - self.positive_class_id
         else:
             # For multiclass classification or when using the default threshold
-            class_idx = probs.argmax()
+            class_idx = probs.argmax().item()
 
         if not self.read_class_id:
             value = self.classes[class_idx]  # type: ignore

--- a/rslearn/train/tasks/regression.py
+++ b/rslearn/train/tasks/regression.py
@@ -221,18 +221,18 @@ class RegressionHead(torch.nn.Module):
         else:
             outputs = logits
 
-        loss = None
+        losses = {}
         if targets:
             labels = torch.stack([target["value"] for target in targets])
             mask = torch.stack([target["valid"] for target in targets])
             if self.loss_mode == "mse":
-                loss = torch.mean(torch.square(outputs - labels) * mask)
+                losses["regress"] = torch.mean(torch.square(outputs - labels) * mask)
             elif self.loss_mode == "l1":
-                loss = torch.mean(torch.abs(outputs - labels) * mask)
+                losses["regress"] = torch.mean(torch.abs(outputs - labels) * mask)
             else:
                 assert False
 
-        return outputs, {"regress": loss}
+        return outputs, losses
 
 
 class RegressionMetricWrapper(Metric):

--- a/rslearn/train/tasks/segmentation.py
+++ b/rslearn/train/tasks/segmentation.py
@@ -246,7 +246,7 @@ class SegmentationHead(torch.nn.Module):
         """
         outputs = torch.nn.functional.softmax(logits, dim=1)
 
-        loss = None
+        losses = {}
         if targets:
             labels = torch.stack([target["classes"] for target in targets], dim=0)
             mask = torch.stack([target["valid"] for target in targets], dim=0)
@@ -254,9 +254,9 @@ class SegmentationHead(torch.nn.Module):
                 torch.nn.functional.cross_entropy(logits, labels, reduction="none")
                 * mask
             )
-            loss = torch.mean(loss)
+            losses["cls"] = torch.mean(loss)
 
-        return outputs, {"cls": loss}
+        return outputs, losses
 
 
 class SegmentationMetric(Metric):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,11 @@ import multiprocessing
 
 import pytest
 
-from .fixtures.datasets.image_to_class import image_to_class_dataset
+from .fixtures.datasets.image_to_class import (
+    image_to_class_data_module,
+    image_to_class_dataset,
+    image_to_class_model,
+)
 
 logging.basicConfig()
 
@@ -15,4 +19,6 @@ def always_spawn() -> None:
 
 __all__ = [
     "image_to_class_dataset",
+    "image_to_class_data_module",
+    "image_to_class_model",
 ]

--- a/tests/fixtures/datasets/image_to_class.py
+++ b/tests/fixtures/datasets/image_to_class.py
@@ -8,6 +8,12 @@ from upath import UPath
 
 from rslearn.const import WGS84_PROJECTION
 from rslearn.dataset import Dataset, Window
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.singletask import SingleTaskModel
+from rslearn.models.swin import Swin
+from rslearn.train.data_module import RslearnDataModule
+from rslearn.train.dataset import DataInput
+from rslearn.train.tasks.classification import ClassificationHead, ClassificationTask
 from rslearn.utils import Feature, STGeometry
 from rslearn.utils.raster_format import SingleImageRasterFormat
 from rslearn.utils.vector_format import GeojsonVectorFormat
@@ -35,6 +41,7 @@ def image_to_class_dataset(tmp_path: pathlib.Path) -> Dataset:
                 ],
             },
             "label": {"type": "vector", "format": {"name": "geojson"}},
+            "output": {"type": "vector", "format": {"name": "geojson"}},
         },
         "tile_store": {
             "name": "file",
@@ -85,3 +92,33 @@ def image_to_class_dataset(tmp_path: pathlib.Path) -> Dataset:
     window.mark_layer_completed(layer_name)
 
     return Dataset(ds_path)
+
+
+@pytest.fixture
+def image_to_class_data_module(image_to_class_dataset: Dataset) -> RslearnDataModule:
+    """Create an RslearnDataModule for the image_to_class_dataset."""
+    image_data_input = DataInput("raster", ["image"], bands=["band"], passthrough=True)
+    target_data_input = DataInput("vector", ["label"])
+    task = ClassificationTask("label", ["cls0", "cls1"], read_class_id=True)
+    return RslearnDataModule(
+        path=image_to_class_dataset.path,
+        inputs={
+            "image": image_data_input,
+            "targets": target_data_input,
+        },
+        task=task,
+    )
+
+
+@pytest.fixture
+def image_to_class_model() -> SingleTaskModel:
+    """Create a SingleTaskModel for use with image_to_class_data_module."""
+    return SingleTaskModel(
+        encoder=[
+            Swin(arch="swin_v2_t", input_channels=1, output_layers=[3]),
+        ],
+        decoder=[
+            PoolingDecoder(in_channels=192, out_channels=2),
+            ClassificationHead(),
+        ],
+    )

--- a/tests/integration/train/test_freeze_unfreeze.py
+++ b/tests/integration/train/test_freeze_unfreeze.py
@@ -1,18 +1,11 @@
-from typing import Any
-
 import lightning.pytorch as pl
 import pytest
 from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 
-from rslearn.dataset import Dataset
-from rslearn.models.pooling_decoder import PoolingDecoder
 from rslearn.models.singletask import SingleTaskModel
-from rslearn.models.swin import Swin
 from rslearn.train.callbacks.freeze_unfreeze import FreezeUnfreeze
 from rslearn.train.data_module import RslearnDataModule
-from rslearn.train.dataset import DataInput
 from rslearn.train.lightning_module import RslearnLightningModule
-from rslearn.train.tasks.classification import ClassificationHead, ClassificationTask
 
 INITIAL_LR = 1e-3
 
@@ -52,44 +45,17 @@ class LMWithCustomPlateau(RslearnLightningModule):
         return d
 
 
-def get_itc_modules(
-    image_to_class_dataset: Dataset, pl_module_kwargs: dict[str, Any] = {}
-) -> tuple[LMWithCustomPlateau, RslearnDataModule]:
-    """Get the LightningModule and DataModule for the image to class task."""
-    image_data_input = DataInput("raster", ["image"], bands=["band"], passthrough=True)
-    target_data_input = DataInput("vector", ["label"])
-    task = ClassificationTask("label", ["cls0", "cls1"], read_class_id=True)
-    data_module = RslearnDataModule(
-        path=image_to_class_dataset.path,
-        inputs={
-            "image": image_data_input,
-            "targets": target_data_input,
-        },
-        task=task,
-    )
-    model = SingleTaskModel(
-        encoder=[
-            Swin(arch="swin_v2_t", input_channels=1, output_layers=[3]),
-        ],
-        decoder=[
-            PoolingDecoder(in_channels=192, out_channels=2),
-            ClassificationHead(),
-        ],
-    )
-    pl_module = LMWithCustomPlateau(
-        model=model,
-        task=task,
-        print_parameters=True,
-        lr=INITIAL_LR,
-        **pl_module_kwargs,
-    )
-    return pl_module, data_module
-
-
-def test_freeze_unfreeze(image_to_class_dataset: Dataset) -> None:
+def test_freeze_unfreeze(
+    image_to_class_data_module: RslearnDataModule, image_to_class_model: SingleTaskModel
+) -> None:
     """Test the FreezeUnfreeze callback by making sure the weights don't change in the
     first epoch but then unfreeze and do change in the second epoch."""
-    pl_module, data_module = get_itc_modules(image_to_class_dataset)
+    pl_module = LMWithCustomPlateau(
+        model=image_to_class_model,
+        task=image_to_class_data_module.task,
+        print_parameters=True,
+        lr=INITIAL_LR,
+    )
     freeze_unfreeze = FreezeUnfreeze(
         module_selector=["model", "encoder"],
         unfreeze_at_epoch=1,
@@ -102,23 +68,25 @@ def test_freeze_unfreeze(image_to_class_dataset: Dataset) -> None:
             record_callback,
         ],
     )
-    trainer.fit(pl_module, datamodule=data_module)
+    trainer.fit(pl_module, datamodule=image_to_class_data_module)
     assert record_callback.recorded_params[0] == record_callback.recorded_params[1]
     assert record_callback.recorded_params[0] != record_callback.recorded_params[2]
 
 
-def test_unfreeze_lr_factor(image_to_class_dataset: Dataset) -> None:
+def test_unfreeze_lr_factor(
+    image_to_class_data_module: RslearnDataModule, image_to_class_model: SingleTaskModel
+) -> None:
     """Make sure learning rate is set correctly after unfreezing."""
     plateau_factor = 0.5
     unfreeze_lr_factor = 3
-
-    pl_module, data_module = get_itc_modules(
-        image_to_class_dataset,
-        pl_module_kwargs=dict(
-            plateau=True,
-            plateau_factor=plateau_factor,
-            plateau_patience=0,
-        ),
+    pl_module = LMWithCustomPlateau(
+        model=image_to_class_model,
+        task=image_to_class_data_module.task,
+        print_parameters=True,
+        lr=INITIAL_LR,
+        plateau=True,
+        plateau_factor=plateau_factor,
+        plateau_patience=0,
     )
     freeze_unfreeze = FreezeUnfreeze(
         module_selector=["model", "encoder"],
@@ -129,7 +97,7 @@ def test_unfreeze_lr_factor(image_to_class_dataset: Dataset) -> None:
         max_epochs=2,
         callbacks=[freeze_unfreeze],
     )
-    trainer.fit(pl_module, datamodule=data_module)
+    trainer.fit(pl_module, datamodule=image_to_class_data_module)
     param_groups = trainer.optimizers[0].param_groups
     # Default parameters should undergo two plateaus.
     assert param_groups[0]["lr"] == pytest.approx(INITIAL_LR * (plateau_factor**2))

--- a/tests/integration/train/test_prediction_writer.py
+++ b/tests/integration/train/test_prediction_writer.py
@@ -1,0 +1,91 @@
+"""Integration tests for rslearn.train.prediction_writer."""
+
+import lightning.pytorch as pl
+
+from rslearn.dataset.dataset import Dataset
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.singletask import SingleTaskModel
+from rslearn.models.swin import Swin
+from rslearn.train.data_module import RslearnDataModule
+from rslearn.train.dataset import DataInput
+from rslearn.train.lightning_module import RslearnLightningModule
+from rslearn.train.optimizer import AdamW
+from rslearn.train.prediction_writer import RslearnWriter
+from rslearn.train.tasks.classification import ClassificationHead, ClassificationTask
+from rslearn.train.tasks.multi_task import MultiTask
+
+
+def test_predict(
+    image_to_class_data_module: RslearnDataModule, image_to_class_model: SingleTaskModel
+) -> None:
+    """Ensure prediction works."""
+    # Set up the basic RslearnLightningModule for the image_to_class task.
+    pl_module = RslearnLightningModule(
+        model=image_to_class_model,
+        task=image_to_class_data_module.task,
+        optimizer=AdamW(),
+    )
+    # Now create Trainer with an RslearnWriter.
+    writer = RslearnWriter(
+        path=image_to_class_data_module.path,
+        output_layer="output",
+    )
+    trainer = pl.Trainer(
+        callbacks=[writer],
+    )
+    trainer.predict(pl_module, datamodule=image_to_class_data_module)
+    window = Dataset(writer.path).load_windows()[0]
+    assert window.is_layer_completed("output")
+
+
+def test_predict_multi_task(image_to_class_dataset: Dataset) -> None:
+    """Ensure prediction writing still works with MultiTaskModel."""
+    image_data_input = DataInput("raster", ["image"], bands=["band"], passthrough=True)
+    target_data_input = DataInput("vector", ["label"])
+    task = MultiTask(
+        tasks={
+            "mytask": ClassificationTask("label", ["cls0", "cls1"], read_class_id=True)
+        },
+        input_mapping={
+            "mytask": {
+                "targets": "targets",
+            }
+        },
+    )
+    data_module = RslearnDataModule(
+        path=image_to_class_dataset.path,
+        inputs={
+            "image": image_data_input,
+            "targets": target_data_input,
+        },
+        task=task,
+    )
+    model = MultiTaskModel(
+        encoder=[
+            Swin(arch="swin_v2_t", input_channels=1, output_layers=[3]),
+        ],
+        decoders={
+            "mytask": [
+                PoolingDecoder(in_channels=192, out_channels=2),
+                ClassificationHead(),
+            ],
+        },
+    )
+    pl_module = RslearnLightningModule(
+        model=model,
+        task=task,
+        optimizer=AdamW(),
+    )
+    # Now create Trainer with an RslearnWriter.
+    writer = RslearnWriter(
+        path=image_to_class_dataset.path,
+        output_layer="output",
+        selector=["mytask"],
+    )
+    trainer = pl.Trainer(
+        callbacks=[writer],
+    )
+    trainer.predict(pl_module, datamodule=data_module)
+    window = Dataset(writer.path).load_windows()[0]
+    assert window.is_layer_completed("output")


### PR DESCRIPTION
Fix bug in `model predict` due to combination of returned losses being None and MultiTaskModel trying to apply task_weights.

I updated the ClassificationTask, SegmentationTask, and RegressionTask to return empty loss dict instead of loss dict with None loss entry.

I also moved the task_weights from MultiTaskModel to RslearnLightningModule so it can be applied for different kinds of models and also for individual losses within a task instead of just across tasks (e.g. object detection returns multiple losses that can be weighted separately). This will also avoid error in case there are custom Tasks that still return None in the loss dict.

I added integration test for this that fails without the changes. I also fixed a bug with ClassificationTask.process_outputs when read_class_id is set, where it tries to write a numpy scalar as JSON which fails instead of converting it to Python data type first.

Resolves #225.