### PR TITLE
Adding Temporal Compositing Options

### DIFF
--- a/docs/DatasetConfig.md
+++ b/docs/DatasetConfig.md
@@ -143,7 +143,10 @@ Raster layers have additional configuration:
   // layers with a data source. It is used when there is a difference in CRS or
   // resolution between the item from the data source and the window's target.
   // It is one of "nearest", "bilinear" (default), "cubic", "cubic_spline".
-  "resampling_method": "bilinear"
+  "resampling_method": "bilinear",
+  // Method how to select pixel values when multiple items in a group cover the same
+  // pixel. One of "FIRST_VALID", "MEAN", "MEDIAN". Defaults to "FIRST_VALID".
+  "compositing_method": "FIRST_VALID"
 }
 ```
 
@@ -334,6 +337,11 @@ The space mode defines the spatial matching.
   case, each item group consists of exactly one item.
 - INTERSECTS means that items that intersect the window bounds can be used. In this
   case, each item group consists of exactly one item.
+- COMPOSITE means that one composite covering the window, that combines all elements
+  intersecting the data source during the complete time period should be created. In this case, only a single
+  group containing all intersecting items exists. During materialization these are reduced,
+  such that the complete window is covered and if there are multiple items covering a pixel,
+  the value is computed based on `composite_method` in the layer config. Ignores `max_matches`.
 
 For raster data, with MOSAIC, multiple items may be combined together to materialize a
 raster aligned with the window, while CONTAINS and INTERSECTS means that each
@@ -354,7 +362,8 @@ The time mode defines the temporal matching.
 Finally, max matches is the maximum number of item groups that should be created. The
 default is 1. For MOSAIC, this means to attempt to create one mosaic covering the
 window; zero item groups will be returned only if there are zero items intersecting the
-window. For CONTAINS and INTERSECTS, this means to select the first matching item.
+window. For CONTAINS and INTERSECTS, this means to select the first matching item. For
+COMPOSITE this is currently not used.
 
 If max matches is greater than one, then for MOSAIC, it will attempt to create multiple
 mosaics up to that quantity of mosaics. However, it will only start the next mosaic

--- a/docs/DatasetConfig.md
+++ b/docs/DatasetConfig.md
@@ -337,16 +337,21 @@ The space mode defines the spatial matching.
   case, each item group consists of exactly one item.
 - INTERSECTS means that items that intersect the window bounds can be used. In this
   case, each item group consists of exactly one item.
-- COMPOSITE means that one composite covering the window, that combines all elements
-  intersecting the data source during the complete time period should be created. In this case, only a single
-  group containing all intersecting items exists. During materialization these are reduced,
-  such that the complete window is covered and if there are multiple items covering a pixel,
-  the value is computed based on `composite_method` in the layer config. Ignores `max_matches`.
+- COMPOSITE means that one composite-mosaic covering the window should be created.
+  In this case, only a single group containing all intersecting items exists. During
+  materialization these are reduced, such that the complete window is covered. If there
+  are multiple items covering a pixel, the value is computed based on `composite_method`
+  in the layer config. Ignores `max_matches`.
 
 For raster data, with MOSAIC, multiple items may be combined together to materialize a
 raster aligned with the window, while CONTAINS and INTERSECTS means that each
 materialized raster should correspond to one item (possibly after cropping and
 re-projection).
+
+**Composite vs. Mosaic**
+A mosaic stitches adjacent images into one seamless picture, using one pixel value where
+images overlap. A composite combines overlapping images over time (temporal aggregation)
+with a specified method such as the mean or median and also produces a seamless mosaic.
 
 The time mode defines the temporal matching.
 

--- a/rslearn/config/__init__.py
+++ b/rslearn/config/__init__.py
@@ -2,6 +2,7 @@
 
 from .dataset import (
     BandSetConfig,
+    CompositingMethod,
     DataSourceConfig,
     DType,
     LayerConfig,
@@ -18,6 +19,7 @@ from .dataset import (
 
 __all__ = [
     "BandSetConfig",
+    "CompositingMethod",
     "DataSourceConfig",
     "DType",
     "LayerConfig",

--- a/rslearn/config/dataset.py
+++ b/rslearn/config/dataset.py
@@ -250,6 +250,16 @@ class SpaceMode(Enum):
     The duration of the sub-periods is controlled by another option in QueryConfig.
     """
 
+    COMPOSITE = 5
+    """Creates one composite covering the entire window.
+
+    During querying all items intersecting the window are placed in one group.
+    The compositing_method in the rasterlayer config specifies how these items are reduced
+    to a single item (e.g MEAN/MEDIAN/FIRST_VALID) during materialization.
+    """
+
+    # TODO add PER_PERIOD_COMPOSITE
+
 
 class TimeMode(Enum):
     """Temporal  matching mode when looking up items corresponding to a window."""
@@ -446,7 +456,7 @@ class LayerConfig:
 
 
 class CompositingMethod(Enum):
-    """Method how to select pixels for the composite/mosaic from corresponding items of a window"""
+    """Method how to select pixels for the composite from corresponding items of a window."""
 
     FIRST_VALID = 1
     """Select first valid pixel in order of corresponding items (might be sorted)"""
@@ -505,7 +515,9 @@ class RasterLayerConfig(LayerConfig):
         if "alias" in config:
             kwargs["alias"] = config["alias"]
         if "compositing_method" in config:
-            kwargs["compositing_method"] = CompositingMethod[config["compositing_method"]]
+            kwargs["compositing_method"] = CompositingMethod[
+                config["compositing_method"]
+            ]
         return RasterLayerConfig(**kwargs)  # type: ignore
 
 

--- a/rslearn/config/dataset.py
+++ b/rslearn/config/dataset.py
@@ -445,6 +445,19 @@ class LayerConfig:
         return self.serialize() == other.serialize()
 
 
+class CompositingMethod(Enum):
+    """Method how to select pixels for the composite/mosaic from corresponding items of a window"""
+
+    FIRST_VALID = 1
+    """Select first valid pixel in order of corresponding items (might be sorted)"""
+
+    MEAN = 2
+    """Select per-pixel mean value of corresponding items of a window"""
+
+    MEDIAN = 3
+    """Select per-pixel median value of corresponding items of a window"""
+
+
 class RasterLayerConfig(LayerConfig):
     """Configuration of a raster layer."""
 
@@ -455,6 +468,7 @@ class RasterLayerConfig(LayerConfig):
         data_source: DataSourceConfig | None = None,
         resampling_method: Resampling = Resampling.bilinear,
         alias: str | None = None,
+        compositing_method: CompositingMethod = CompositingMethod.FIRST_VALID,
     ):
         """Initialize a new RasterLayerConfig.
 
@@ -464,10 +478,12 @@ class RasterLayerConfig(LayerConfig):
             data_source: optional DataSourceConfig if this layer is retrievable
             resampling_method: how to resample rasters (if needed), default bilinear resampling
             alias: alias for this layer to use in the tile store
+            compositing_method: how to compute pixel values in the composite of each windows items
         """
         super().__init__(layer_type, data_source, alias)
         self.band_sets = band_sets
         self.resampling_method = resampling_method
+        self.compositing_method = compositing_method
 
     @staticmethod
     def from_config(config: dict[str, Any]) -> "RasterLayerConfig":
@@ -488,6 +504,8 @@ class RasterLayerConfig(LayerConfig):
             ]
         if "alias" in config:
             kwargs["alias"] = config["alias"]
+        if "compositing_method" in config:
+            kwargs["compositing_method"] = CompositingMethod[config["compositing_method"]]
         return RasterLayerConfig(**kwargs)  # type: ignore
 
 

--- a/rslearn/data_sources/utils.py
+++ b/rslearn/data_sources/utils.py
@@ -285,6 +285,14 @@ def match_candidate_items_to_window(
             geometry, items, query_config.period_duration, query_config.max_matches
         )
 
+    elif query_config.space_mode == SpaceMode.COMPOSITE:
+        group = []
+        for item, item_shp in zip(items, item_shps):
+            if not shp_intersects(item_shp, geometry.shp):
+                continue
+            group.append(item)
+        groups = [group]
+
     else:
         raise ValueError(f"invalid space mode {query_config.space_mode}")
 

--- a/rslearn/dataset/materialize.py
+++ b/rslearn/dataset/materialize.py
@@ -443,6 +443,13 @@ def build_median_composite(
     return result
 
 
+compositing_methods = {
+    CompositingMethod.FIRST_VALID: build_first_valid_composite,
+    CompositingMethod.MEAN: build_mean_composite,
+    CompositingMethod.MEDIAN: build_median_composite,
+}
+
+
 def build_composite(
     group: list[ItemType],
     compositing_method: CompositingMethod,
@@ -469,42 +476,17 @@ def build_composite(
     if nodata_vals is None:
         nodata_vals = [0 for _ in band_cfg.bands]
 
-    if compositing_method == CompositingMethod.FIRST_VALID:
-        return build_first_valid_composite(
-            group=group,
-            nodata_vals=nodata_vals,
-            bands=band_cfg.bands,
-            bounds=bounds,
-            band_dtype=band_cfg.dtype.value,
-            tile_store=tile_store,
-            projection=projection,
-            resampling_method=layer_cfg.resampling_method,
-            remapper=remapper,
-        )
-    elif compositing_method == CompositingMethod.MEAN:
-        return build_mean_composite(
-            group=group,
-            nodata_vals=nodata_vals,
-            bands=band_cfg.bands,
-            bounds=bounds,
-            band_dtype=band_cfg.dtype.value,
-            tile_store=tile_store,
-            projection=projection,
-            resampling_method=layer_cfg.resampling_method,
-            remapper=remapper,
-        )
-    elif compositing_method == CompositingMethod.MEDIAN:
-        return build_median_composite(
-            group=group,
-            nodata_vals=nodata_vals,
-            bands=band_cfg.bands,
-            bounds=bounds,
-            band_dtype=band_cfg.dtype.value,
-            tile_store=tile_store,
-            projection=projection,
-            resampling_method=layer_cfg.resampling_method,
-            remapper=remapper,
-        )
+    return compositing_methods[compositing_method](
+        group=group,
+        nodata_vals=nodata_vals,
+        bands=band_cfg.bands,
+        bounds=bounds,
+        band_dtype=band_cfg.dtype.value,
+        tile_store=tile_store,
+        projection=projection,
+        resampling_method=layer_cfg.resampling_method,
+        remapper=remapper,
+    )
 
 
 @Materializers.register("raster")

--- a/rslearn/dataset/materialize.py
+++ b/rslearn/dataset/materialize.py
@@ -354,7 +354,7 @@ def build_mean_composite(
     Returns:
         Composite of shape (bands, bounds) having per-pixel mean of all items in the group
     """
-    # TODO: Might want to add a rurnning sum/count based method to reduce memory utilization
+    # TODO: Might want to add a running sum/count based method to reduce memory utilization
 
     stacked_arrays = read_and_stack_raster_windows(
         group=group,
@@ -487,7 +487,17 @@ def build_composite(
             remapper=remapper,
         )
     elif compositing_method == CompositingMethod.MEDIAN:
-        raise NotImplementedError("MEDIAN compositing is not yet implemented.")
+        return build_median_composite(
+            group=group,
+            nodata_vals=nodata_vals,
+            bands=band_cfg.bands,
+            bounds=bounds,
+            band_dtype=band_cfg.dtype.value,
+            tile_store=tile_store,
+            projection=projection,
+            resampling_method=layer_cfg.resampling_method,
+            remapper=remapper,
+        )
 
 
 @Materializers.register("raster")

--- a/rslearn/dataset/materialize.py
+++ b/rslearn/dataset/materialize.py
@@ -127,9 +127,16 @@ def get_needed_band_sets_and_indexes(
     bands: list[str],
     tile_store: TileStoreWithLayer,
 ) -> list[tuple[list[str], list[int], list[int]]]:
-    """TODO."""
-    # Identify which tile store layer(s) to read to get the configured
-    # bands.
+    """Identify indexes of required bands in tile store.
+
+    Returns:
+        A list for each tile-store layer that contains at least
+        one requested band, a tuple: (src_bands, src_idx, dst_idx) where
+        - src_bands: the full band list for that layer,
+        - src_idx: indexes into src_bands of the bands that were requested,
+        - dst_idx: corresponding indexes in the requested `bands` list.
+    """
+    # Identify which tile store layer(s) to read to get the configured bands.
     wanted_band_indexes = {}
     for i, band in enumerate(bands):
         wanted_band_indexes[band] = i

--- a/tests/unit/dataset/test_materialize.py
+++ b/tests/unit/dataset/test_materialize.py
@@ -1,12 +1,22 @@
 import pathlib
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
+import pytest
+from shapely.geometry import Polygon
 from upath import UPath
 
 from rslearn.const import WGS84_PROJECTION
-from rslearn.dataset.materialize import read_raster_window_from_tiles
+from rslearn.data_sources.data_source import Item
+from rslearn.dataset.materialize import (
+    build_mean_composite,
+    build_median_composite,
+    read_raster_window_from_tiles,
+)
 from rslearn.tile_stores.default import DefaultTileStore
 from rslearn.tile_stores.tile_store import TileStoreWithLayer
+from rslearn.utils.geometry import STGeometry
 
 
 class TestReadRasterWindowFromTiles:
@@ -96,3 +106,421 @@ class TestReadRasterWindowFromTiles:
         assert np.all(dst[:, 0:2, 0:2] == 3)
         # Bottom-right should be unchanged (still 0).
         assert np.all(dst[:, 2:4, 2:4] == 0)
+
+
+class TestBuildMeanComposite:
+    """Unit tests for build_mean_composite"""
+
+    LAYER_NAME = "layer"
+    BANDS = ["band1", "band2"]
+    BOUNDS = (0, 0, 4, 4)
+    PROJECTION = WGS84_PROJECTION
+
+    @pytest.fixture
+    def tile_store(self, tmp_path: pathlib.Path) -> DefaultTileStore:
+        store = DefaultTileStore()
+        store.set_dataset_path(UPath(tmp_path))
+        return store
+
+    def make_item(self, name: str) -> Item:
+        """Create a simple mock item with a name property."""
+        return Item(
+            name=name,
+            geometry=STGeometry(
+                projection=self.PROJECTION,
+                shp=Polygon([(0, 0), (10, 0), (10, 10), (0, 10)]),
+                time_range=None,
+            ),
+        )
+
+    def test_mean_of_two_items(self, tile_store: DefaultTileStore) -> None:
+        """Test mean composite of two 2-band rasters with valid values."""
+        nodata_vals = [0, 0]
+
+        array1 = np.array(
+            [np.full((4, 4), 2, dtype=np.uint8), np.full((4, 4), 6, dtype=np.uint8)]
+        )
+        array2 = np.array(
+            [np.full((4, 4), 4, dtype=np.uint8), np.full((4, 4), 10, dtype=np.uint8)]
+        )
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+
+        for item, data in zip([item1, item2], [array1, array2]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                data,
+            )
+
+        composite = build_mean_composite(
+            group=[item1, item2],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.uint8,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        expected = np.array(
+            [
+                np.full((4, 4), 3, dtype=np.uint8),  # Mean of 2 and 4
+                np.full((4, 4), 8, dtype=np.uint8),  # Mean of 6 and 10
+            ]
+        )
+        assert np.array_equal(composite, expected)
+
+    def test_mean_three_items_partial_overlap(
+        self, tile_store: DefaultTileStore
+    ) -> None:
+        """Test mean composite with 3 items having different spatial extents (float32)."""
+        nodata_vals = [0.0, 0.0]
+
+        def make_array(val1: Any, val2: Any) -> npt.NDArray[np.float32]:
+            return np.array(
+                [
+                    np.full((4, 4), val1, dtype=np.float32),
+                    np.full((4, 4), val2, dtype=np.float32),
+                ],
+                dtype=np.float32,
+            )
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+        item3 = self.make_item("item3")
+
+        # item1: full coverage
+        array1 = make_array(3.0, 9.0)
+
+        # item2: only covers left half (nodata in right half)
+        array2 = make_array(6.0, 12.0)
+        array2[:, :, 2:4] = 0.0
+
+        # item3: only covers bottom half
+        array3 = make_array(9.0, 15.0)
+        array3[:, 0:2, :] = 0.0
+
+        for item, array in zip([item1, item2, item3], [array1, array2, array3]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                array,
+            )
+
+        composite = build_mean_composite(
+            group=[item1, item2, item3],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.float32,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        # Expected values are exact means (no rounding)
+        expected = np.array(
+            [
+                [  # band1
+                    [4.5, 4.5, 3.0, 3.0],
+                    [4.5, 4.5, 3.0, 3.0],
+                    [6.0, 6.0, 6.0, 6.0],
+                    [6.0, 6.0, 6.0, 6.0],
+                ],
+                [  # band2
+                    [10.5, 10.5, 9.0, 9.0],
+                    [10.5, 10.5, 9.0, 9.0],
+                    [12.0, 12.0, 12.0, 12.0],
+                    [12.0, 12.0, 12.0, 12.0],
+                ],
+            ],
+            dtype=np.float32,
+        )
+
+        assert np.array_equal(composite, expected)
+
+    def test_mean_with_different_nodata_vals(
+        self, tile_store: DefaultTileStore
+    ) -> None:
+        """Test mean composite where each band has a different nodata value (float32)."""
+
+        # Different nodata values for each band
+        nodata_vals = [0.0, 99.0]  # Band 1 has 0.0 as nodata, Band 2 has 99.0 as nodata
+
+        array1 = np.array(
+            [
+                np.full((4, 4), 2.0, dtype=np.float32),
+                np.full((4, 4), 6.0, dtype=np.float32),
+            ]
+        )
+        array2 = np.array(
+            [
+                np.full((4, 4), 4.0, dtype=np.float32),
+                np.full((4, 4), 10.0, dtype=np.float32),
+            ]
+        )
+
+        # Manually set some pixels to nodata
+        array1[0, 0, 0] = 0.0  # Set (0,0) to nodata in first band
+        array2[1, 1, 1] = 99.0  # Set (1,1) to nodata in second band
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+
+        for item, data in zip([item1, item2], [array1, array2]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                data,
+            )
+
+        composite = build_mean_composite(
+            group=[item1, item2],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.float32,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        # Expected float means
+        expected = np.array(
+            [
+                np.full((4, 4), 3.0, dtype=np.float32),  # Mean of 2.0 and 4.0
+                np.full((4, 4), 8.0, dtype=np.float32),  # Mean of 6.0 and 10.0
+            ]
+        )
+
+        # Override the pixels where a nodata was injected:
+        expected[0, 0, 0] = 4.0  # band 1, (0,0): only valid value is 4.0
+        expected[1, 1, 1] = 6.0  # band 2, (1,1): only valid value is 6.0
+
+        # Check that the composite is as expected (allow small float error)
+        assert np.allclose(composite, expected, atol=1e-6)
+
+
+class TestBuildMedianComposite:
+    """Unit tests for build_median_composite"""
+
+    LAYER_NAME = "layer"
+    BANDS = ["band1", "band2"]
+    BOUNDS = (0, 0, 4, 4)
+    PROJECTION = WGS84_PROJECTION
+
+    @pytest.fixture
+    def tile_store(self, tmp_path: pathlib.Path) -> DefaultTileStore:
+        store = DefaultTileStore()
+        store.set_dataset_path(UPath(tmp_path))
+        return store
+
+    def make_item(self, name: str) -> Item:
+        """Create a simple mock item with a name property."""
+        return Item(
+            name=name,
+            geometry=STGeometry(
+                projection=self.PROJECTION,
+                shp=Polygon([(0, 0), (10, 0), (10, 10), (0, 10)]),
+                time_range=None,
+            ),
+        )
+
+    def test_median_of_two_items(self, tile_store: DefaultTileStore) -> None:
+        """Median of two 2-band rasters with valid values everywhere."""
+        nodata_vals = [0, 0]
+
+        array1 = np.array(
+            [
+                np.full((4, 4), 2, dtype=np.uint8),
+                np.full((4, 4), 6, dtype=np.uint8),
+            ]
+        )
+        array2 = np.array(
+            [
+                np.full((4, 4), 4, dtype=np.uint8),
+                np.full((4, 4), 10, dtype=np.uint8),
+            ]
+        )
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+
+        for item, data in zip([item1, item2], [array1, array2]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                data,
+            )
+
+        composite = build_median_composite(
+            group=[item1, item2],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.uint8,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        # Median of (2,4) -> 3; (6,10) -> 8
+        expected = np.array(
+            [
+                np.full((4, 4), 3, dtype=np.uint8),
+                np.full((4, 4), 8, dtype=np.uint8),
+            ]
+        )
+        assert np.array_equal(composite, expected)
+
+    def test_median_three_items_partial_overlap(
+        self, tile_store: DefaultTileStore
+    ) -> None:
+        """Median with 3 items having different spatial extents."""
+        nodata_vals = [0, 0]
+
+        def make_array(val1: Any, val2: Any) -> npt.NDArray[np.float32]:
+            return np.array(
+                [
+                    np.full((4, 4), val1, dtype=np.uint8),
+                    np.full((4, 4), val2, dtype=np.uint8),
+                ]
+            )
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+        item3 = self.make_item("item3")
+
+        # item1: full coverage
+        array1 = make_array(3, 9)
+
+        # item2: covers left half only (right half nodata)
+        array2 = make_array(6, 12)
+        array2[:, :, 2:4] = 0
+
+        # item3: covers bottom half only (top half nodata)
+        array3 = make_array(9, 15)
+        array3[:, 0:2, :] = 0
+
+        for item, array in zip([item1, item2, item3], [array1, array2, array3]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                array,
+            )
+
+        composite = build_median_composite(
+            group=[item1, item2, item3],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.uint8,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        # Band1 values by region (exclude nodata=0):
+        # TL: {3,6} -> median (3+6)/2 = 4.5 -> 4 (uint8)
+        # TR: {3}   -> 3
+        # BL: {3,6,9} -> 6
+        # BR: {3,9} -> (3+9)/2 = 6
+        # Band2: TL {9,12}->10.5->10; TR {9}->9; BL {9,12,15}->12; BR {9,15}->12
+        expected = np.array(
+            [
+                [  # band1
+                    [4, 4, 3, 3],
+                    [4, 4, 3, 3],
+                    [6, 6, 6, 6],
+                    [6, 6, 6, 6],
+                ],
+                [  # band2
+                    [10, 10, 9, 9],
+                    [10, 10, 9, 9],
+                    [12, 12, 12, 12],
+                    [12, 12, 12, 12],
+                ],
+            ],
+            dtype=np.uint8,
+        )
+
+        assert np.array_equal(composite, expected)
+
+    def test_median_with_different_nodata_vals(
+        self, tile_store: DefaultTileStore
+    ) -> None:
+        """Median where each band has a different nodata value and per-pixel masks."""
+        nodata_vals = [0, 99]
+
+        array1 = np.array(
+            [
+                np.full((4, 4), 2, dtype=np.uint8),
+                np.full((4, 4), 6, dtype=np.uint8),
+            ]
+        )
+        array2 = np.array(
+            [
+                np.full((4, 4), 4, dtype=np.uint8),
+                np.full((4, 4), 10, dtype=np.uint8),
+            ]
+        )
+
+        # Set some pixels to band-specific nodata
+        array1[0, 0, 0] = 0  # band1 nodata at (0,0)
+        array2[1, 1, 1] = 99  # band2 nodata at (1,1)
+
+        item1 = self.make_item("item1")
+        item2 = self.make_item("item2")
+
+        for item, data in zip([item1, item2], [array1, array2]):
+            tile_store.write_raster(
+                self.LAYER_NAME,
+                item.name,
+                self.BANDS,
+                self.PROJECTION,
+                self.BOUNDS,
+                data,
+            )
+
+        composite = build_median_composite(
+            group=[item1, item2],
+            nodata_vals=nodata_vals,
+            bands=self.BANDS,
+            bounds=self.BOUNDS,
+            band_dtype=np.uint8,
+            tile_store=TileStoreWithLayer(tile_store, self.LAYER_NAME),
+            projection=self.PROJECTION,
+            remapper=None,
+        )
+
+        # Base median everywhere: (2,4)->3; (6,10)->8.
+        # band1 at (0,0): only 4 is valid -> 4
+        # band2 at (1,1): only 6 is valid -> 6
+        expected = np.array(
+            [
+                np.full((4, 4), 3, dtype=np.uint8),
+                np.full((4, 4), 8, dtype=np.uint8),
+            ]
+        )
+        expected[0, 0, 0] = 4
+        expected[1, 1, 1] = 6
+
+        assert np.array_equal(composite, expected)


### PR DESCRIPTION
**Summary**
This PR adds functionality to create mean and median composites.
 
**Changes**
- Query Config spatial mode now includes `COMPOSITE` -> creates single group for evrey window containing all items in time range.
- RasterLayer Config now includes `compositing_method` option, allowing to specify `FIRST_VALID | MEAN | MEDIAN`.

**Discussion Points**
- Mean compositing: Currently quite memory inefficient: Loads all items windows of the time-period into memory. We might want to think about doing more of a running mean / running-sum approach to reduce memory requirements. Did a short benchmark and running-mean was on average 45% slower however reduced memory significantly depending on the number of items.
- Max_matches: Compositing is currently not using `max_matches` as I believe only a single composite should be created per time period. However, max_matches in this case could be used to limit the number of items in the composite. This might be helpful e.g for having items sorted by cloud cover and then building the composite only with e.g top-k matches. However, would make the implementation a bit more complex as we would have to identify the top-k matches per pixel.
- Instead of the `COMPOSITE` spatial mode that I added, this might be kept as `MOSAIC`. However from my understanding for a composite the `MOSAIC` mode would be required setting `max_matches` > 1, which is interpreted as having multiple final mosaics instead of multiple items included in the mosaic and would populate multiple groups. 
