### PR TITLE
Fix bug in data loading

### DIFF
--- a/rslearn/train/data_module.py
+++ b/rslearn/train/data_module.py
@@ -125,7 +125,7 @@ class RslearnDataModule(L.LightningDataModule):
                 task=self.task,
                 workers=self.init_workers,
                 name=self.name,
-                fix_patch_pick=(stage != "train"),
+                fix_patch_pick=(stage != "fit"),
             )
             logger.info(f"got {len(dataset)} examples in split {split}")
             if split_config.get_load_all_patches():


### PR DESCRIPTION
Fixes bug where for each window, the same patch is always chosen (even though it's supposed to be randomly selected during training). This is desirable for validation when `load_all_patches=False` but not for training.