### PR TITLE
Remove unnecessary test fixtures

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,11 +62,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Set Environment Variables
-        run: |
-          echo "TEST_BUCKET=test-bucket" >> $GITHUB_ENV
-          echo "TEST_PREFIX=tests/"
-
       - name: Store Image Names
         # We need the docker image name downstream in test & deploy. This saves the full docker image names to outputs
         id: image-names
@@ -94,11 +89,6 @@ jobs:
         run: |
           docker pull ${{ needs.build.outputs.ghcr_docker_image }}
 
-      - name: Set Environment Variables
-        run: |
-          echo "TEST_BUCKET=test-bucket-rslearn" >> $GITHUB_ENV
-          echo "GCSFS_DEFAULT_PROJECT=skylight-proto-1" >> $GITHUB_ENV
-
       - name: Run Unit Tests
         run: |
           docker run --rm \
@@ -119,6 +109,8 @@ jobs:
             -e TEST_BUCKET="${{ env.TEST_BUCKET }}" \
             -v ${{env.GOOGLE_GHA_CREDS_PATH}}:/tmp/gcp-credentials.json:ro \
             -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-credentials.json \
+            -e TEST_BUCKET=test-bucket-rslearn \
+            -e TEST_PREFIX=tests/ \
             -e CI="true" \
             --network host \
             ${{ needs.build.outputs.ghcr_docker_image }} \

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,0 +1,12 @@
+Tests
+-----
+
+Several data source tests verify that the test runs correctly when certain
+configuration options are non-local UPaths rather than local ones. These tests use
+UPaths on Google Cloud Storage and depend on GCS access. To run them, the TEST_BUCKET
+and TEST_PREFIX environment variables must be set, e.g.:
+
+```
+TEST_BUCKET=test-bucket-rslearn
+TEST_PREFIX=tests/
+```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,3 @@
-import os
-
-import pytest
-from google.cloud import storage
-
 from .fixtures.datasets.local_files_dataset import local_files_dataset
 from .fixtures.geometries.seattle2020 import seattle2020, tropical_forest2024
 
@@ -11,24 +6,3 @@ __all__ = [
     "seattle2020",
     "tropical_forest2024",
 ]
-
-
-# maybe I don't want to explictly autouse this
-@pytest.fixture(scope="session", autouse=True)
-def test_bucket() -> str:
-    os.environ.setdefault("TEST_BUCKET", "test-bucket-rslearn")
-    test_bucket = os.environ["TEST_BUCKET"]
-    print(f"test_bucket: {test_bucket}")
-    storage_client = storage.Client()
-    try:
-        storage_client.get_bucket(test_bucket)
-        print(f"Bucket {test_bucket} exists.")
-    except Exception as e:
-        raise AssertionError(f"Bucket {test_bucket} does not exist: {str(e)}")
-    return test_bucket
-
-
-@pytest.fixture(scope="session", autouse=True)
-def test_prefix() -> str:
-    os.environ.setdefault("TEST_PREFIX", "tests/")
-    return os.environ["TEST_PREFIX"]


### PR DESCRIPTION
The `test_bucket` and `test_prefix` fixtures seem to just set some defaults for environment variables. It seems better to let the tests that depend on them fail if the environment variables are not set, rather than set defaults that would only work for people with access to that specific bucket.

Resolves #260.