### PR TITLE
Add class id remapper

### DIFF
--- a/rslearn/train/tasks/segmentation.py
+++ b/rslearn/train/tasks/segmentation.py
@@ -127,11 +127,12 @@ class SegmentationTask(BasicTask):
 
         assert raw_inputs["targets"].shape[0] == 1
         labels = raw_inputs["targets"][0, :, :].long()
-        new_labels = labels.clone()
 
         if self.class_id_mapping is not None:
+            new_labels = labels.clone()
             for old_id, new_id in self.class_id_mapping.items():
                 new_labels[labels == old_id] = new_id
+            labels = new_labels
 
         if self.nodata_value is not None:
             valid = (labels != self.nodata_value).float()
@@ -142,7 +143,7 @@ class SegmentationTask(BasicTask):
             valid = torch.ones(labels.shape, dtype=torch.float32)
 
         return {}, {
-            "classes": new_labels,
+            "classes": labels,
             "valid": valid,
         }
 


### PR DESCRIPTION
Add a remapper to map old class ids to new ones. In the model config, we can specify sth like this: `class_id_mapping: {1: 1, 2: 2, 3: 2, 4: 2, 5: 2, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0, 11: 2}`