### PR TITLE
Allows template parameters in dataset config.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.0.5"
+version = "0.0.6"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     { name = "OlmoEarth Team" },

--- a/rslearn/arg_parser.py
+++ b/rslearn/arg_parser.py
@@ -1,33 +1,12 @@
 """Custom Lightning ArgumentParser with environment variable substitution support."""
 
 import os
-import re
 from typing import Any
 
 from jsonargparse import Namespace
 from lightning.pytorch.cli import LightningArgumentParser
 
-
-def substitute_env_vars_in_string(content: str) -> str:
-    """Substitute environment variables in a string.
-
-    Replaces ${VAR_NAME} patterns with os.getenv(VAR_NAME, "") values.
-    This works on raw string content before YAML parsing.
-
-    Args:
-        content: The string content containing template variables
-
-    Returns:
-        The string with environment variables substituted
-    """
-    pattern = r"\$\{([^}]+)\}"
-
-    def replace_variable(match_obj: re.Match[str]) -> str:
-        var_name = match_obj.group(1)
-        env_value = os.getenv(var_name, "")
-        return env_value if env_value is not None else ""
-
-    return re.sub(pattern, replace_variable, content)
+from rslearn.template_params import substitute_env_vars_in_string
 
 
 class RslearnArgumentParser(LightningArgumentParser):

--- a/rslearn/dataset/dataset.py
+++ b/rslearn/dataset/dataset.py
@@ -8,6 +8,7 @@ from upath import UPath
 
 from rslearn.config import load_layer_config
 from rslearn.log_utils import get_logger
+from rslearn.template_params import substitute_env_vars_in_string
 from rslearn.tile_stores import TileStore, load_tile_store
 
 from .index import DatasetIndex
@@ -52,7 +53,9 @@ class Dataset:
 
         # Load dataset configuration.
         with (self.path / "config.json").open("r") as f:
-            config = json.load(f)
+            config_content = f.read()
+            config_content = substitute_env_vars_in_string(config_content)
+            config = json.loads(config_content)
             self.layers = {}
             for layer_name, d in config["layers"].items():
                 # Layer names must not contain period, since we use period to

--- a/rslearn/template_params.py
+++ b/rslearn/template_params.py
@@ -1,0 +1,26 @@
+"""Template parameter substitution utilities for rslearn configuration files."""
+
+import os
+import re
+
+
+def substitute_env_vars_in_string(content: str) -> str:
+    """Substitute environment variables in a string.
+
+    Replaces ${VAR_NAME} patterns with os.getenv(VAR_NAME, "") values.
+    This works on raw string content before YAML/JSON parsing.
+
+    Args:
+        content: The string content containing template variables
+
+    Returns:
+        The string with environment variables substituted
+    """
+    pattern = r"\$\{([^}]+)\}"
+
+    def replace_variable(match_obj: re.Match[str]) -> str:
+        var_name = match_obj.group(1)
+        env_value = os.getenv(var_name, "")
+        return env_value if env_value is not None else ""
+
+    return re.sub(pattern, replace_variable, content)

--- a/tests/unit/dataset/test_dataset.py
+++ b/tests/unit/dataset/test_dataset.py
@@ -1,0 +1,99 @@
+"""Unit tests for Dataset class."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from upath import UPath
+
+from rslearn.dataset import Dataset
+
+
+class TestDataset:
+    """Test suite for Dataset class."""
+
+    def test_template_substitution_in_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that environment variables are substituted in dataset config.json."""
+        # Set up environment variables
+        monkeypatch.setenv("LABEL_LAYER", "labels")
+        monkeypatch.setenv("PREDICTION_OUTPUT_LAYER", "output")
+        monkeypatch.setenv("TILE_STORE_ROOT", "/path/to/tiles")
+
+        # Create a temporary dataset directory with config.json containing template variables
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dataset_path = Path(temp_dir)
+
+            # Create config.json with template variables - use a simple config that works
+            config_content = {
+                "layers": {
+                    "test_layer": {"type": "vector"},
+                    "${LABEL_LAYER}": {"type": "vector"},
+                    "${PREDICTION_OUTPUT_LAYER}": {"type": "vector"},
+                },
+                "tile_store": {"name": "foobar", "root_dir": "${TILE_STORE_ROOT}"},
+            }
+
+            with (dataset_path / "config.json").open("w") as f:
+                json.dump(config_content, f)
+
+            # Load the dataset - this should trigger template substitution
+            dataset = Dataset(UPath(dataset_path))
+
+            # Verify that environment variables were substituted in tile_store config
+            assert dataset.tile_store_config is not None
+            assert dataset.layers.keys() == {"test_layer", "labels", "output"}
+            assert dataset.tile_store_config["root_dir"] == "/path/to/tiles"
+
+    def test_template_substitution_missing_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that missing environment variables are replaced with empty strings."""
+        # Don't set MISSING_VAR environment variable
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dataset_path = Path(temp_dir)
+
+            # Create config.json with a missing environment variable
+            config_content = {
+                "layers": {"test_layer": {"type": "vector"}},
+                "tile_store": {
+                    "name": "file",
+                    "root_dir": "/base/path/${MISSING_VAR}/tiles",
+                },
+            }
+
+            with (dataset_path / "config.json").open("w") as f:
+                json.dump(config_content, f)
+
+            # Load the dataset
+            dataset = Dataset(UPath(dataset_path))
+
+            # Verify that missing variable was replaced with empty string
+            assert dataset.tile_store_config is not None
+            assert (
+                dataset.tile_store_config["root_dir"] == "/base/path//tiles"
+            )  # Empty string substitution
+
+    def test_no_template_variables(self) -> None:
+        """Test that configs without template variables work normally."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dataset_path = Path(temp_dir)
+
+            # Create config.json without any template variables
+            config_content = {
+                "layers": {"test_layer": {"type": "vector"}},
+                "tile_store": {"name": "file", "root_dir": "/static/path/to/tiles"},
+            }
+
+            with (dataset_path / "config.json").open("w") as f:
+                json.dump(config_content, f)
+
+            # Load the dataset
+            dataset = Dataset(UPath(dataset_path))
+
+            # Verify that static values remain unchanged
+            assert dataset.tile_store_config is not None
+            assert dataset.tile_store_config["root_dir"] == "/static/path/to/tiles"

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -3,7 +3,8 @@
 import pytest
 from lightning.pytorch import LightningDataModule, LightningModule
 
-from rslearn.arg_parser import RslearnArgumentParser, substitute_env_vars_in_string
+from rslearn.arg_parser import RslearnArgumentParser
+from rslearn.template_params import substitute_env_vars_in_string
 
 
 class DummyModel(LightningModule):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -4231,7 +4231,7 @@ wheels = [
 
 [[package]]
 name = "rslearn"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
In the same vein as #278 + #283, this changeset allows
template variables of the format `${TEMPLATE_VAR}` into
dataset config.jsons, which will be overwritten with
injectable env vars at startup. It leverages the same logic
that was used in model.yaml's argparser, but applied
during Dataset construction.

The changes facilitate esrun's need to to coordinate the writing
of label layers before fine tuning and targeting of prediction
output layers during inference into a discoverable location.