### PR TITLE
Add ResizeFeatures transform.

### DIFF
--- a/rslearn/models/resize_features.py
+++ b/rslearn/models/resize_features.py
@@ -1,0 +1,45 @@
+"""The ResizeFeatures module."""
+
+import torch
+
+
+class ResizeFeatures(torch.nn.Module):
+    """Resize input features to new sizes."""
+
+    def __init__(
+        self,
+        out_sizes: list[tuple[int, int]],
+        mode: str = "bilinear",
+    ):
+        """Initialize a ResizeFeatures.
+
+        Args:
+            out_sizes: the output sizes of the feature maps. There must be one entry
+                for each input feature map.
+            mode: mode to pass to torch.nn.Upsample, e.g. "bilinear" (default) or
+                "nearest".
+        """
+        super().__init__()
+        layers = []
+        for size in out_sizes:
+            layers.append(
+                torch.nn.Upsample(
+                    size=size,
+                    mode=mode,
+                )
+            )
+        self.layers = torch.nn.ModuleList(layers)
+
+    def forward(
+        self, features: list[torch.Tensor], inputs: list[torch.Tensor]
+    ) -> list[torch.Tensor]:
+        """Resize the input feature maps to new sizes.
+
+        Args:
+            features: list of feature maps at different resolutions.
+            inputs: original inputs (ignored).
+
+        Returns:
+            resized feature maps
+        """
+        return [self.layers[idx](feat_map) for idx, feat_map in enumerate(features)]

--- a/tests/unit/models/test_resize_features.py
+++ b/tests/unit/models/test_resize_features.py
@@ -1,0 +1,21 @@
+"""Tests for the rslearn.models.resize_features module."""
+
+import torch
+
+from rslearn.models.resize_features import ResizeFeatures
+
+
+def test_resize_two_feature_maps() -> None:
+    """Resize two feature maps.
+
+    - 6x6 -> 8x8
+    - 3x3 -> 4x4
+    """
+    feature_maps = [
+        torch.zeros((1, 2, 6, 6), dtype=torch.float32),
+        torch.zeros((1, 4, 3, 3), dtype=torch.float32),
+    ]
+    resize_features = ResizeFeatures(out_sizes=[(8, 8), (4, 4)])
+    result = resize_features(feature_maps, None)
+    assert result[0].shape == (1, 2, 8, 8)
+    assert result[1].shape == (1, 4, 4, 4)


### PR DESCRIPTION
This transform resizes multiple feature maps to a fixed size. It is helpful for model architectures that require input to be resized to a certain shape, so we can resize the output features back to a shape that is power of 2 off from the input size.