### PR TITLE
fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'astral-sh/setup-uv@v6'
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
       - uses: 'actions/checkout@v5'
       - name: 'validate release tag matches pyproject version'
         run: |


### PR DESCRIPTION
Publish GHAs are failing right now due to allegedly
misconfigured cache dependencies.

(see: (https://github.com/allenai/rslearn/actions/runs/18390936283)))

I think this might fix it. I'll delete the v0.0.8 tag + release and retry
after this merges.