### PR TITLE
Load a model encoder

### DIFF
--- a/rslearn/models/olmoearth_pretrain/model.py
+++ b/rslearn/models/olmoearth_pretrain/model.py
@@ -58,7 +58,7 @@ class OlmoEarth(torch.nn.Module):
         random_initialization: bool = False,
         embedding_size: int | None = None,
         autocast_dtype: str | None = "bfloat16",
-        encoder_state_dict_path: str | None = None,
+        selector_state_dict_path: str | None = None,
     ):
         """Create a new OlmoEarth model.
 
@@ -82,7 +82,7 @@ class OlmoEarth(torch.nn.Module):
             embedding_size: optional embedding size to report via
                 get_backbone_channels (if model_id is not set).
             autocast_dtype: which dtype to use for autocasting, or set None to disable.
-            encoder_state_dict_path: If not None, we will overwrite the encoder weights with these weights.
+            selector_state_dict_path: If not None, we will overwrite the `selector` weights with these weights.
                 This can be useful if you want to do multiple rounds of finetuning for a model.
         """
         if (
@@ -135,9 +135,11 @@ class OlmoEarth(torch.nn.Module):
                 model = model[part]
         self.model = model
 
-        if encoder_state_dict_path is not None:
-            encoder_state_dict = torch.load(encoder_state_dict_path, weights_only=True)
-            self.model.encoder.load_state_dict(encoder_state_dict)
+        if selector_state_dict_path is not None:
+            selector_state_dict = torch.load(
+                selector_state_dict_path, weights_only=True
+            )
+            self.model.load_state_dict(selector_state_dict)
 
     def _load_model_from_checkpoint(
         self, checkpoint_upath: UPath, random_initialization: bool


### PR DESCRIPTION
I am really not sure this is the best way to do this. Its a bit messy.

Situation: I have an OlmoEarth model I've finetuned using rslp. I'd like to take this finetuned encoder and finetune it on a new task.

Challenge: How do I load these encoder weights?

Solution:

1. Take the ckpt files from pytorch lightning and transform them to a state dict, using [this script](https://github.com/allenai/olmoearth_projects/blob/e6f26228137cbdce68d1ffe3336f295f0525e8be/olmoearth_projects/projects/mozambique_lulc/ckpt_to_path.py).
2. Load the weights using this PR:
```python
from rslearn.models.olmoearth_pretrain.model import OlmoEarth
m = OlmoEarth(
    checkpoint_path="/weka/dfive-default/helios/checkpoints/joer/phase2.0_base_lr0.0001_wd0.02/step667200",
    patch_size=1, 
    selector_state_dict_path="mozambique_lulc/weights.pth"
)
```