### PR TITLE
Fix SimpleTimeSeries so it passes ModelContext to the feature extractor.

### DIFF
--- a/rslearn/models/simple_time_series.py
+++ b/rslearn/models/simple_time_series.py
@@ -229,7 +229,13 @@ class SimpleTimeSeries(FeatureExtractor):
 
         # Now we can apply the underlying FeatureExtractor.
         # Its output must be a FeatureMaps.
-        encoder_output = self.encoder(batched_inputs)
+        assert batched_inputs is not None
+        encoder_output = self.encoder(
+            ModelContext(
+                inputs=batched_inputs,
+                metadatas=context.metadatas,
+            )
+        )
         if not isinstance(encoder_output, FeatureMaps):
             raise ValueError(
                 "output of underlying FeatureExtractor in SimpleTimeSeries must be a FeatureMaps"

--- a/tests/unit/models/test_simple_time_series.py
+++ b/tests/unit/models/test_simple_time_series.py
@@ -1,0 +1,56 @@
+"""Tests for rslearn.models.simple_time_series."""
+
+from typing import Any
+
+import pytest
+import torch
+from typing_extensions import override
+
+from rslearn.models.component import FeatureExtractor, FeatureMaps
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.train.model_context import ModelContext
+
+
+class IdentityFeatureExtractor(FeatureExtractor):
+    """A feature extractor for testing that just returns its input."""
+
+    @override
+    def forward(self, context: ModelContext) -> Any:
+        # Here we stack the inputs to get a BCHW feature map.
+        feat = torch.stack(
+            [input_dict["image"] for input_dict in context.inputs], dim=0
+        )
+        return FeatureMaps([feat])
+
+
+def test_simple_time_series() -> None:
+    """Just make sure SimpleTimeSeries performs mean temporal pooling properly."""
+    extractor = IdentityFeatureExtractor()
+    model = SimpleTimeSeries(
+        encoder=extractor,
+        image_channels=1,
+        op="mean",
+        backbone_channels=[(1, 1)],
+    )
+    # Try with input with two timesteps, one is 5s and one is 6s.
+    input_dict = {
+        "image": torch.cat(
+            [
+                5 * torch.ones((1, 4, 4), dtype=torch.float32),
+                6 * torch.ones((1, 4, 4), dtype=torch.float32),
+            ],
+            dim=0,
+        ),
+    }
+    context = ModelContext(
+        inputs=[input_dict],
+        metadatas=[],
+    )
+    output = model(context)
+    # The result should have one feature map. Since we use IdentityFeatureExtractor,
+    # the values should be mean of the two inputs.
+    assert isinstance(output, FeatureMaps)
+    assert len(output.feature_maps) == 1
+    feat = output.feature_maps[0]
+    assert feat.shape == (1, 1, 4, 4)
+    assert feat[0, 0, 0, 0] == pytest.approx(5.5)


### PR DESCRIPTION
It was broken with the model component API update since it was not updated to pass a ModelContext instead of the input dicts directly.

I added a test so it will catch it in the future.