### PR TITLE
Hadriens/model seq len

### DIFF
--- a/rslearn/utils/jsonargparse.py
+++ b/rslearn/utils/jsonargparse.py
@@ -101,10 +101,14 @@ def resolution_factor_serializer(v: ResolutionFactor) -> str:
     Returns:
         the ResolutionFactor encoded to string
     """
+    if hasattr(v, "init_args"):
+        init_args = v.init_args
+        return f"{init_args.numerator}/{init_args.denominator}"
+
     return f"{v.numerator}/{v.denominator}"
 
 
-def resolution_factor_deserializer(v: int | str) -> ResolutionFactor:
+def resolution_factor_deserializer(v: int | str | dict) -> ResolutionFactor:
     """Deserialize ResolutionFactor for jsonargparse.
 
     Args:
@@ -113,6 +117,26 @@ def resolution_factor_deserializer(v: int | str) -> ResolutionFactor:
     Returns:
         the decoded ResolutionFactor object
     """
+    # Handle already-instantiated ResolutionFactor
+    if isinstance(v, ResolutionFactor):
+        return v
+
+    # Handle Namespace from class_path syntax (used during config save/validation)
+    if hasattr(v, "init_args"):
+        init_args = v.init_args
+        return ResolutionFactor(
+            numerator=init_args.numerator,
+            denominator=init_args.denominator,
+        )
+
+    # Handle dict from class_path syntax in YAML config
+    if isinstance(v, dict) and "init_args" in v:
+        init_args = v["init_args"]
+        return ResolutionFactor(
+            numerator=init_args.get("numerator", 1),
+            denominator=init_args.get("denominator", 1),
+        )
+
     if isinstance(v, int):
         return ResolutionFactor(numerator=v)
     elif isinstance(v, str):

--- a/tests/unit/models/olmoearth_pretrain/test_model.py
+++ b/tests/unit/models/olmoearth_pretrain/test_model.py
@@ -70,130 +70,9 @@ def test_forward_no_pooling() -> None:
     # Feature shape should correspond to using patch_size=4.
     # 6 = 3 band sets * 2 timesteps
     assert features.shape == (1, 128, 1, 1, 6)
-    
 
     # Backbone channels should match patch size and depth.
-    
-
-
-def test_forward_with_different_timesteps() -> None:
-    """Test forward pass with different time steps per modality and per batch element"""
-    model = OlmoEarth(
-        checkpoint_path="tests/unit/models/olmoearth_pretrain/",
-        # With random initialization we only need config.json, not the weights.
-        random_initialization=True,
-        patch_size=4,
-        embedding_size=768,
-    )
-
-    max_timesteps = 8
-    H = 4
-    W = 4
-    inputs = [
-        {
-            # 12 channels per timestep.
-            "sentinel2_l2a": torch.zeros(
-                (max_timesteps * 12, H, W), dtype=torch.float32
-            ),
-            # 2 channels per timestep.
-            "sentinel1": torch.zeros((5 * 2, H, W), dtype=torch.float32),
-        },
-        {
-            # 12 channels per timestep.
-            "sentinel2_l2a": torch.zeros((7 * 12, H, W), dtype=torch.float32),
-            # 2 channels per timestep.
-            "sentinel1": torch.zeros((4 * 2, H, W), dtype=torch.float32),
-        },
-    ]
-    context = ModelContext(inputs=inputs, metadatas=[])
-    sample, present_modalities, _ = model._prepare_modality_inputs(context)
-    # tensors must follow shape: [b h w t c]
-    assert present_modalities == ["sentinel2_l2a", "sentinel1"]
-    assert sample.sentinel2_l2a.shape == (2, H, W, max_timesteps, 12)
-    assert sample.sentinel1.shape == (2, H, W, max_timesteps, 2)
-
-    assert (sample.sentinel2_l2a_mask[0] == MaskValue.ONLINE_ENCODER.value).all()
-    assert (
-        sample.sentinel2_l2a_mask[1, :, :, 0:7, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel2_l2a_mask[1, :, :, 7:, :] == MaskValue.MISSING.value).all()
-    assert (
-        sample.sentinel1_mask[0, :, :, 0:5, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel1_mask[0, :, :, 5:, :] == MaskValue.MISSING.value).all()
-    assert (
-        sample.sentinel1_mask[1, :, :, 0:4, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel1_mask[1, :, :, 4:, :] == MaskValue.MISSING.value).all()
-
-    assert sample.timestamps.shape == (2, max_timesteps, 3)
-    assert (sample.timestamps[:, :, 1] == torch.arange(max_timesteps)).all()
-
-    feature_list = model(context)
-
-    assert len(feature_list.feature_maps) == 1
-    features = feature_list.feature_maps[0]
-    assert features.shape == (2, 768, 1, 1)
-
-
-def test_forward_with_different_timesteps() -> None:
-    """Test forward pass with different time steps per modality and per batch element"""
-    model = OlmoEarth(
-        checkpoint_path="tests/unit/models/olmoearth_pretrain/",
-        # With random initialization we only need config.json, not the weights.
-        random_initialization=True,
-        patch_size=4,
-        embedding_size=768,
-    )
-
-    max_timesteps = 8
-    H = 4
-    W = 4
-    inputs = [
-        {
-            # 12 channels per timestep.
-            "sentinel2_l2a": torch.zeros(
-                (max_timesteps * 12, H, W), dtype=torch.float32
-            ),
-            # 2 channels per timestep.
-            "sentinel1": torch.zeros((5 * 2, H, W), dtype=torch.float32),
-        },
-        {
-            # 12 channels per timestep.
-            "sentinel2_l2a": torch.zeros((7 * 12, H, W), dtype=torch.float32),
-            # 2 channels per timestep.
-            "sentinel1": torch.zeros((4 * 2, H, W), dtype=torch.float32),
-        },
-    ]
-    context = ModelContext(inputs=inputs, metadatas=[])
-    sample, present_modalities, _ = model._prepare_modality_inputs(context)
-    # tensors must follow shape: [b h w t c]
-    assert present_modalities == ["sentinel2_l2a", "sentinel1"]
-    assert sample.sentinel2_l2a.shape == (2, H, W, max_timesteps, 12)
-    assert sample.sentinel1.shape == (2, H, W, max_timesteps, 2)
-
-    assert (sample.sentinel2_l2a_mask[0] == MaskValue.ONLINE_ENCODER.value).all()
-    assert (
-        sample.sentinel2_l2a_mask[1, :, :, 0:7, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel2_l2a_mask[1, :, :, 7:, :] == MaskValue.MISSING.value).all()
-    assert (
-        sample.sentinel1_mask[0, :, :, 0:5, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel1_mask[0, :, :, 5:, :] == MaskValue.MISSING.value).all()
-    assert (
-        sample.sentinel1_mask[1, :, :, 0:4, :] == MaskValue.ONLINE_ENCODER.value
-    ).all()
-    assert (sample.sentinel1_mask[1, :, :, 4:, :] == MaskValue.MISSING.value).all()
-
-    assert sample.timestamps.shape == (2, max_timesteps, 3)
-    assert (sample.timestamps[:, :, 1] == torch.arange(max_timesteps)).all()
-
-    feature_list = model(context)
-
-    assert len(feature_list.feature_maps) == 1
-    features = feature_list.feature_maps[0]
-    assert features.shape == (2, 768, 1, 1)
+    assert model.get_backbone_channels() == [(4, 128)]
 
 
 def test_error_if_no_checkpoint() -> None:
@@ -294,3 +173,63 @@ def test_with_simple_attnpool() -> None:
 
     # Backbone channels should match patch size and depth.
     assert model.get_backbone_channels() == [(4, 128)]
+
+
+def test_forward_with_different_timesteps() -> None:
+    """Test forward pass with different time steps per modality and per batch element"""
+    model = OlmoEarth(
+        checkpoint_path="tests/unit/models/olmoearth_pretrain/",
+        # With random initialization we only need config.json, not the weights.
+        random_initialization=True,
+        patch_size=4,
+        embedding_size=128,
+    )
+
+    max_timesteps = 8
+    H = 4
+    W = 4
+    inputs = [
+        {
+            # 12 channels per timestep.
+            "sentinel2_l2a": torch.zeros(
+                (max_timesteps * 12, H, W), dtype=torch.float32
+            ),
+            # 2 channels per timestep.
+            "sentinel1": torch.zeros((5 * 2, H, W), dtype=torch.float32),
+        },
+        {
+            # 12 channels per timestep.
+            "sentinel2_l2a": torch.zeros((7 * 12, H, W), dtype=torch.float32),
+            # 2 channels per timestep.
+            "sentinel1": torch.zeros((4 * 2, H, W), dtype=torch.float32),
+        },
+    ]
+    context = ModelContext(inputs=inputs, metadatas=[])
+    sample, present_modalities, _ = model._prepare_modality_inputs(context)
+    # tensors must follow shape: [b h w t c]
+    assert present_modalities == ["sentinel2_l2a", "sentinel1"]
+    assert sample.sentinel2_l2a.shape == (2, H, W, max_timesteps, 12)
+    assert sample.sentinel1.shape == (2, H, W, max_timesteps, 2)
+
+    assert (sample.sentinel2_l2a_mask[0] == MaskValue.ONLINE_ENCODER.value).all()
+    assert (
+        sample.sentinel2_l2a_mask[1, :, :, 0:7, :] == MaskValue.ONLINE_ENCODER.value
+    ).all()
+    assert (sample.sentinel2_l2a_mask[1, :, :, 7:, :] == MaskValue.MISSING.value).all()
+    assert (
+        sample.sentinel1_mask[0, :, :, 0:5, :] == MaskValue.ONLINE_ENCODER.value
+    ).all()
+    assert (sample.sentinel1_mask[0, :, :, 5:, :] == MaskValue.MISSING.value).all()
+    assert (
+        sample.sentinel1_mask[1, :, :, 0:4, :] == MaskValue.ONLINE_ENCODER.value
+    ).all()
+    assert (sample.sentinel1_mask[1, :, :, 4:, :] == MaskValue.MISSING.value).all()
+
+    assert sample.timestamps.shape == (2, max_timesteps, 3)
+    assert (sample.timestamps[:, :, 1] == torch.arange(max_timesteps)).all()
+
+    feature_list = model(context)
+
+    assert len(feature_list.feature_maps) == 1
+    features = feature_list.feature_maps[0]
+    assert features.shape == (2, 128, 1, 1)


### PR DESCRIPTION
Problem: current behavior does not allow for variable temporal sequence lengths across samples within batch for a given modality, and it does not allow for variable temporal sequence lengths across modalities.
This addresses the issue by:
    - Scanning input tensors to find the maximum temporal sequence length across samples and modalities
    - Pad all input tensors (across modalities) to the same sequence length
    
This is still not ideal as the padding happens at the end of the sequence, e.g.
A valid tensor of shape [H W t C] with t < max_t will be padded to [H W max_t, C] which means all invalid (masked) time steps are at the end of the temporal sequence.

Future step should be to infer from the window metadata (or any other mechanism) which time steps are missing to properly impute missing values at the right place in the sequence.