### PR TITLE
Fix harmonization in element84 sentinel-2 data source.

### DIFF
--- a/tests/integration/data_sources/test_aws_sentinel2_element84.py
+++ b/tests/integration/data_sources/test_aws_sentinel2_element84.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import numpy as np
+from rasterio.crs import CRS
 from upath import UPath
 
 from rslearn.config import (
@@ -8,7 +10,7 @@ from rslearn.config import (
 )
 from rslearn.data_sources.aws_sentinel2_element84 import Sentinel2
 from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
-from rslearn.utils import STGeometry
+from rslearn.utils.geometry import Projection, STGeometry
 
 
 def test_aws_sentinel2_element84(
@@ -64,3 +66,63 @@ def test_materialize_all_bands(tmp_path: pathlib.Path, seattle2020: STGeometry) 
             bounds[3] - bounds[1],
             bounds[2] - bounds[0],
         )
+
+
+def test_harmonize_applied() -> None:
+    """Make sure harmonize is applied for scenes that need it."""
+    harmonized_data_source = Sentinel2(harmonize=True)
+    unharmonized_data_source = Sentinel2()
+    # This is a scene that is processed using baseline and needs harmonization.
+    stac_id = "S2B_56MPC_20180101_1_L2A"
+    item = harmonized_data_source.get_item_by_name(stac_id)
+    assert item.properties["earthsearch:boa_offset_applied"]
+
+    # Get bounds of the raster in WebMercator and read a subset of it.
+    projection = Projection(CRS.from_epsg(3857), 10, -10)
+    bounds = harmonized_data_source.get_raster_bounds(
+        "unused", item.name, ["B04"], projection
+    )
+    center = ((bounds[0] + bounds[2]) // 2, (bounds[1] + bounds[3]) // 2)
+    read_bounds = (
+        center[0] - 8,
+        center[1] - 8,
+        center[0] + 8,
+        center[1] + 8,
+    )
+    harmonized_array = harmonized_data_source.read_raster(
+        "unused", item.name, ["B04"], projection, read_bounds
+    )
+    unharmonized_array = unharmonized_data_source.read_raster(
+        "unused", item.name, ["B04"], projection, read_bounds
+    )
+    assert np.all(harmonized_array == (np.clip(unharmonized_array, 1000, None) - 1000))
+
+
+def test_harmonize_not_applied() -> None:
+    """Make sure harmonize is not applied if the scene is processed using old baseline."""
+    harmonized_data_source = Sentinel2(harmonize=True)
+    unharmonized_data_source = Sentinel2()
+    # This scene is processed using old baseline so its values should not be changed.
+    stac_id = "S2B_56KKE_20180101_0_L2A"
+    item = harmonized_data_source.get_item_by_name(stac_id)
+    assert not item.properties["earthsearch:boa_offset_applied"]
+
+    # Get bounds of the raster in WebMercator and read a subset of it.
+    projection = Projection(CRS.from_epsg(3857), 10, -10)
+    bounds = harmonized_data_source.get_raster_bounds(
+        "unused", item.name, ["B04"], projection
+    )
+    center = ((bounds[0] + bounds[2]) // 2, (bounds[1] + bounds[3]) // 2)
+    read_bounds = (
+        center[0] - 8,
+        center[1] - 8,
+        center[0] + 8,
+        center[1] + 8,
+    )
+    harmonized_array = harmonized_data_source.read_raster(
+        "unused", item.name, ["B04"], projection, read_bounds
+    )
+    unharmonized_array = unharmonized_data_source.read_raster(
+        "unused", item.name, ["B04"], projection, read_bounds
+    )
+    assert np.all(harmonized_array == unharmonized_array)


### PR DESCRIPTION
Previously the self.harmonize wasn't being used. The product_metadata doesn't exist but we can check the STAC item property instead to at least get whether the offset was applied (and we just assume it is -1000). I added tests to make sure harmonization is being done if enabled.