### PR TITLE
Address Planetary Computer pagination limitation

### DIFF
--- a/rslearn/data_sources/planetary_computer.py
+++ b/rslearn/data_sources/planetary_computer.py
@@ -46,6 +46,9 @@ class PlanetaryComputer(StacDataSource, TileStore):
     """
 
     STAC_ENDPOINT = "https://planetarycomputer.microsoft.com/api/stac/v1"
+    # Planetary Computer supports returning up to 1000 items in response.
+    # However, it does not support pagination, so we just use 1000.
+    LIMIT = 1000
 
     def __init__(
         self,
@@ -99,6 +102,7 @@ class PlanetaryComputer(StacDataSource, TileStore):
             sort_ascending=sort_ascending,
             required_assets=required_assets,
             cache_dir=cache_upath,
+            limit=self.LIMIT,
         )
         self.asset_bands = asset_bands
         self.timeout = timeout

--- a/rslearn/data_sources/stac.py
+++ b/rslearn/data_sources/stac.py
@@ -93,7 +93,7 @@ class StacDataSource(ItemLookupDataSource[SourceItem]):
                 likely be necessary to make lots of get_item_by_name calls during
                 materialization. TODO: give direct materialization access to the Item
                 object.
-            limit: limit to pass to search queries.
+            limit: per-page item count limit to pass to search queries.
             properties_to_record: if these properties on the STAC item exist, they are
                 are retained in the SourceItem when we initialize it.
         """


### PR DESCRIPTION
It looks like the Planetary Computer STAC API does not support pagination. This PR addresses that issue.

Done:
* Increase limit argument to 1000, which is the maximum accepted by their STAC API, to minimize the chance that we are missing some items.

TODO:
* Raise error if the API returns 1000 items since that could mean we didn't get the full response and there may be better matching items (user should be told about it).