### PR TITLE
bump version to 0.0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.0.26"
+version = "0.0.27"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     { name = "OlmoEarth Team" },

--- a/uv.lock
+++ b/uv.lock
@@ -4294,7 +4294,7 @@ wheels = [
 
 [[package]]
 name = "rslearn"
-version = "0.0.26"
+version = "0.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
This way we can use the DirectMaterializeDataSource class in olmoearth_run.