### PR TITLE
Fix last.ckpt checkpointing bug due to save_last behavior change.

### DIFF
--- a/docs/ModelConfig.md
+++ b/docs/ModelConfig.md
@@ -693,15 +693,6 @@ trainer:
         # generally be omitted. When using MultiTaskModel, this option should usually
         # match with the sub-task name.
         selector: ["detect"]
-    # The ModelCheckpoint callback saves model checkpoints.
-    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-      init_args:
-        # We keep the checkpoint that has the maximum mAP value on the detect task.
-        save_top_k: 1
-        monitor: val_detect/mAP
-        mode: max
-        # We also keep the latest checkpoint.
-        save_last: true
 ```
 
 ## Model Management Options
@@ -747,6 +738,10 @@ load_checkpoint_required: auto
 # 'no' will disable logging.
 # 'auto' will use 'yes' during fit and 'no' during val/test/predict.
 log_mode: auto
+# The metric to monitor for saving the best checkpoint.
+monitor: val_loss
+# Whether the metric being monitored should be maximized (max) or minimized (min).
+monitor_mode: min
 ```
 
 ## Using Custom Classes

--- a/docs/examples/BitemporalSentinel2.md
+++ b/docs/examples/BitemporalSentinel2.md
@@ -240,13 +240,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # Save both the latest checkpoint (last.ckpt) and the best one (epoch=....ckpt).
-    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-      init_args:
-        save_top_k: 1
-        save_last: true
-        monitor: val_accuracy
-        mode: max
     # It is recommended to freeze the OlmoEarth encoder for the first few epochs.
     - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
       init_args:
@@ -257,6 +250,9 @@ trainer:
 project_name: ${PROJECT_NAME}
 run_name: ${RUN_NAME}
 management_dir: ${MANAGEMENT_DIR}
+# Save best checkpoint based on accuracy metric.
+monitor: val_accuracy
+monitor_mode: max
 ```
 
 See [TasksAndModels](../TasksAndModels.md) for more details about the SimpleTimeSeries

--- a/docs/examples/FinetuneOlmoEarth.md
+++ b/docs/examples/FinetuneOlmoEarth.md
@@ -209,14 +209,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # Save the latest checkpoint (last.ckpt) as well as best one based on accuracy
-    # metric.
-    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-      init_args:
-        save_top_k: 1
-        save_last: true
-        monitor: val_accuracy
-        mode: max
     # We find that freezing the model for the first few epochs helps to improve the
     # performance of the fine-tuned models.
     - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
@@ -242,6 +234,9 @@ trainer:
 project_name: ${PROJECT_NAME}
 run_name: ${RUN_NAME}
 management_dir: ${MANAGEMENT_DIR}
+# Save best checkpoint based on accuracy metric.
+monitor: val_accuracy
+monitor_mode: max
 ```
 
 Save this as `model.yaml` and then run `model fit`:

--- a/docs/examples/ProgrammaticWindows.md
+++ b/docs/examples/ProgrammaticWindows.md
@@ -303,13 +303,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # Save both the latest checkpoint (last.ckpt) and the best one (epoch=....ckpt).
-    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-      init_args:
-        save_top_k: 1
-        save_last: true
-        monitor: val_accuracy
-        mode: max
     # It is recommended to freeze the OlmoEarth encoder for the first few epochs.
     - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
       init_args:
@@ -320,6 +313,9 @@ trainer:
 project_name: ${PROJECT_NAME}
 run_name: ${RUN_NAME}
 management_dir: ${MANAGEMENT_DIR}
+# Save best checkpoint based on accuracy metric.
+monitor: val_accuracy
+monitor_mode: max
 ```
 
 Save this as `model.yaml`.

--- a/docs/examples/WindowsFromGeojson.md
+++ b/docs/examples/WindowsFromGeojson.md
@@ -324,14 +324,6 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: "epoch"
-    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-      init_args:
-        # We keep two checkpoints, the one that has best mAP on validation set, and the
-        # latest one. They are saved to the marine_infrastructure_checkpoints folder.
-        save_top_k: 1
-        save_last: true
-        monitor: val_mAP
-        mode: max
     # We freeze the SatlasPretrain backbone for one epoch before unfreezing.
     - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
       init_args:
@@ -342,6 +334,9 @@ trainer:
 project_name: marine_infrastructure
 run_name: satlaspretrain_finetune
 management_dir: ${MANAGEMENT_DIR}
+# Save the best checkpoint based on mAP on validation set.
+monitor: val_mAP
+monitor_mode: max
 ```
 
 After saving this as `model.yaml`, we can now start the fine-tuning:


### PR DESCRIPTION
The solution is to use two ModelCheckpoint callbacks. All model configs using model management will need to change since there is no good way to handle the previous way of configuring things. It should raise error for outdated configs.

The updates to the docs show examples of the config changes.

The README example is not changed here but it will be fixed in #532.