### PR TITLE
W&B force resume after checkpoint loading

### DIFF
--- a/rslearn/lightning_cli.py
+++ b/rslearn/lightning_cli.py
@@ -379,6 +379,7 @@ class RslearnLightningCLI(LightningCLI):
                 with (project_dir / WANDB_ID_FNAME).open("r") as f:
                     wandb_id = f.read().strip()
                     c.trainer.logger.init_args.id = wandb_id
+                    c.trainer.logger.init_args.resume = "must"
 
     def before_instantiate_classes(self) -> None:
         """Called before Lightning class initialization."""


### PR DESCRIPTION
This should fix WB logging problems (W&B history override) when a job is preempted and restarted.