### PR TITLE
Add EDA cloud-mask compositor and related documentation

### DIFF
--- a/docs/Compositors.md
+++ b/docs/Compositors.md
@@ -29,3 +29,4 @@ FIRST_VALID in that ranked order.
 |---|---|
 | [rslearn.dataset.omni_cloud_mask.OmniCloudMaskFirstValid](compositors/omni_cloud_mask_OmniCloudMaskFirstValid.md) | Uses OmniCloudMask model inference on R/G/NIR. |
 | [rslearn.dataset.sentinel2_scl.Sentinel2SCLFirstValid](compositors/sentinel2_scl_Sentinel2SCLFirstValid.md) | Uses Sentinel-2 SCL classes to score cloudiness. |
+| [rslearn.dataset.sentinel2_eda_cloud_mask.Sentinel2EDACloudMaskFirstValid](compositors/sentinel2_eda_cloud_mask_Sentinel2EDACloudMaskFirstValid.md) | Uses EarthDaily Sentinel-2 EDA cloud-mask classes (`sentinel-2-eda-cloud-mask`). |

--- a/docs/compositors/sentinel2_eda_cloud_mask_Sentinel2EDACloudMaskFirstValid.md
+++ b/docs/compositors/sentinel2_eda_cloud_mask_Sentinel2EDACloudMaskFirstValid.md
@@ -1,0 +1,49 @@
+## rslearn.dataset.sentinel2_eda_cloud_mask.Sentinel2EDACloudMaskFirstValid
+
+Ranks each item in a group using Sentinel-2 EDA cloud-mask values over the requested
+window, then applies FIRST_VALID in ranked order.
+
+This compositor is Sentinel-2/EarthDaily specific and requires an EDA cloud-mask band
+(default: `eda_cloud_mask`).
+
+### Configuration
+
+```jsonc
+{
+  "compositing_method": {
+    "class_path": "rslearn.dataset.sentinel2_eda_cloud_mask.Sentinel2EDACloudMaskFirstValid",
+    "init_args": {
+      "cloud_mask_band": "eda_cloud_mask",
+      "null_weight": 5,
+      "clear_weight": 0,
+      "cloud_weight": 5,
+      "shadow_weight": 1,
+      "thin_cloud_weight": 1,
+      "unknown_weight": 5
+    }
+  }
+}
+```
+
+### Scoring
+
+The score is a weighted sum of class fractions:
+
+- `0`: null / nodata
+- `1`: clear
+- `2`: cloud
+- `3`: cloud shadow
+- `4`: thin cloud
+- values outside `0..4`: unknown
+
+Lower score is better.
+
+With defaults, score is:
+`5*null + 5*cloud + shadow + thin_cloud + 5*unknown` (`clear_weight=0`).
+
+### Execution Notes
+
+- Ranking runs during **materialize**, not **prepare**.
+- It runs only for item groups with more than one item.
+- This works for both `ingest: true` and `ingest: false`.
+- If `cloud_mask_band` is missing for an item, materialization raises an error.

--- a/docs/data_sources/earthdaily_Sentinel2.md
+++ b/docs/data_sources/earthdaily_Sentinel2.md
@@ -47,7 +47,7 @@ Source: <https://github.com/Element84/earth-search>
     // - "assets" uses EarthDaily STAC asset keys (e.g. "red", "nir", "visual", "scl").
     // - "band_sets[].bands" uses rslearn band names (e.g. "B04", "B08", "R", "scl").
     //
-    // Example: ["red", "green", "blue", "nir", "swir16", "swir22", "visual", "scl"]
+    // Example: ["red", "green", "blue", "nir", "swir16", "swir22", "visual", "scl", "eda_cloud_mask"]
     "assets": null,
     // Optional: maximum cloud cover (%) to filter items at search time.
     // If set, it takes precedence over cloud_cover_threshold and overrides any
@@ -122,6 +122,7 @@ EarthDaily assets when `assets` is null):
 - B8A
 - R, G, B (from the `visual` asset)
 - scl, aot, wvp
+- eda_cloud_mask (linked from collection `sentinel-2-eda-cloud-mask`)
 
 Common EarthDaily asset key to rslearn band name mapping:
 - coastal → B01
@@ -140,3 +141,12 @@ Common EarthDaily asset key to rslearn band name mapping:
 - scl → scl
 - aot → aot
 - wvp → wvp
+- eda_cloud_mask → eda_cloud_mask (fetched from `sentinel-2-eda-cloud-mask` using `eda:derived_from_item_id`)
+
+### EDA Cloud-Mask Compositing
+
+`rslearn.dataset.sentinel2_eda_cloud_mask.Sentinel2EDACloudMaskFirstValid` can rank
+Sentinel-2 items using EarthDaily EDA cloud-mask classes and then apply FIRST_VALID.
+
+With `assets: null`, rslearn automatically includes `eda_cloud_mask` when that
+compositor is configured in `compositing_method`.

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -193,6 +193,42 @@ class EarthDaily(DataSource, TileStore):
 
         return self.eds_client, self.client, self.collection
 
+    @staticmethod
+    def _resolve_asset_href(
+        stac_item_id: str,
+        asset_key: str,
+        asset_obj: pystac.Asset,
+        *,
+        allow_direct_href_fallback: bool,
+    ) -> str:
+        """Resolve the downloadable href for a STAC asset.
+
+        Args:
+            stac_item_id: STAC item id for error context.
+            asset_key: STAC asset key for error context.
+            asset_obj: STAC asset object.
+            allow_direct_href_fallback: whether `asset.href` is accepted when
+                `alternate.download.href` is missing.
+        """
+        href: str | None = None
+        alt = asset_obj.extra_fields.get("alternate")
+        if isinstance(alt, dict):
+            download = alt.get("download")
+            if isinstance(download, dict):
+                raw_href = download.get("href")
+                if isinstance(raw_href, str) and raw_href:
+                    href = raw_href
+
+        if href is not None:
+            return href
+
+        if allow_direct_href_fallback and isinstance(asset_obj.href, str):
+            return asset_obj.href
+
+        raise ValueError(
+            f"item {stac_item_id} asset {asset_key} is missing alternate.download.href"
+        )
+
     def _stac_item_to_item(self, stac_item: pystac.Item) -> EarthDailyItem:
         shp = shapely.geometry.shape(stac_item.geometry)
 
@@ -217,23 +253,12 @@ class EarthDaily(DataSource, TileStore):
             if asset_key not in self.asset_bands and not is_metadata_asset:
                 continue
 
-            href: str | None = None
-            alt = asset_obj.extra_fields.get("alternate")
-            if isinstance(alt, dict):
-                download = alt.get("download")
-                if isinstance(download, dict):
-                    raw_href = download.get("href")
-                    if isinstance(raw_href, str) and raw_href:
-                        href = raw_href
-
-            if href is None:
-                if is_metadata_asset and isinstance(asset_obj.href, str):
-                    href = asset_obj.href
-                else:
-                    raise ValueError(
-                        f"item {stac_item.id} asset {asset_key} is missing "
-                        "alternate.download.href"
-                    )
+            href = self._resolve_asset_href(
+                stac_item.id,
+                asset_key,
+                asset_obj,
+                allow_direct_href_fallback=is_metadata_asset,
+            )
 
             asset_urls[asset_key] = href
 
@@ -705,6 +730,11 @@ class Sentinel2(EarthDaily):
     """
 
     COLLECTION_NAME = "sentinel-2-c1-l2a"
+    EDA_CLOUD_MASK_COLLECTION_NAME = "sentinel-2-eda-cloud-mask"
+    EDA_CLOUD_MASK_ASSET_KEY = "eda_cloud_mask"
+    EDA_CLOUD_MASK_EXCLUDE_ASSETS = frozenset(
+        {"thumbnail", "overview", "product_metadata", "granule_metadata"}
+    )
 
     # EarthDaily Sentinel-2 asset keys to rslearn band names.
     # For spectral bands, we use Sentinel-2 band IDs as rslearn band names.
@@ -726,7 +756,144 @@ class Sentinel2(EarthDaily):
         "scl": ["scl"],
         "aot": ["aot"],
         "wvp": ["wvp"],
+        # Linked from `sentinel-2-eda-cloud-mask` via
+        # properties["eda:derived_from_item_id"].
+        "eda_cloud_mask": ["eda_cloud_mask"],
     }
+
+    @staticmethod
+    def _get_compositor_scoring_bands(context: DataSourceContext) -> set[str]:
+        """Get extra bands needed by known cloud-aware ranking compositors."""
+        if context.layer_config is None:
+            return set()
+
+        compositing_method = context.layer_config.compositing_method
+        if not isinstance(compositing_method, dict):
+            return set()
+
+        class_path = compositing_method.get("class_path")
+        init_args = compositing_method.get("init_args", {})
+        if not isinstance(init_args, dict):
+            init_args = {}
+
+        if class_path == "rslearn.dataset.omni_cloud_mask.OmniCloudMaskFirstValid":
+            return {
+                str(init_args.get("red_band", "B04")),
+                str(init_args.get("green_band", "B03")),
+                str(init_args.get("nir_band", "B8A")),
+            }
+
+        if class_path == "rslearn.dataset.sentinel2_scl.Sentinel2SCLFirstValid":
+            return {str(init_args.get("scl_band", "scl"))}
+
+        if (
+            class_path
+            == "rslearn.dataset.sentinel2_eda_cloud_mask.Sentinel2EDACloudMaskFirstValid"
+        ):
+            return {
+                str(
+                    init_args.get(
+                        "cloud_mask_band", Sentinel2.EDA_CLOUD_MASK_ASSET_KEY
+                    )
+                )
+            }
+
+        return set()
+
+    def _pick_eda_cloud_mask_asset_key(self, stac_item: pystac.Item) -> str | None:
+        """Pick the most likely cloud-mask data asset key from a mask STAC item."""
+        preferred_key: str | None = None
+        for asset_key in stac_item.assets:
+            if asset_key in self.EDA_CLOUD_MASK_EXCLUDE_ASSETS:
+                continue
+            if preferred_key is None:
+                preferred_key = asset_key
+            lowered = asset_key.lower()
+            if "cloud" in lowered and "mask" in lowered:
+                return asset_key
+        return preferred_key
+
+    def _get_eda_cloud_mask_asset_url_from_stac_item(
+        self, stac_item: pystac.Item
+    ) -> tuple[str, str] | None:
+        """Extract `(source_item_id, mask_url)` from an EDA cloud-mask STAC item."""
+        source_item_id = stac_item.properties.get("eda:derived_from_item_id")
+        if not isinstance(source_item_id, str) or not source_item_id:
+            return None
+
+        asset_key = self._pick_eda_cloud_mask_asset_key(stac_item)
+        if asset_key is None:
+            return None
+        asset = stac_item.assets.get(asset_key)
+        if asset is None:
+            return None
+
+        href = self._resolve_asset_href(
+            stac_item.id,
+            asset_key,
+            asset,
+            allow_direct_href_fallback=True,
+        )
+        return source_item_id, href
+
+    def _search_eda_cloud_mask_by_source_item_id(
+        self, client: pystac_client.Client, source_item_id: str
+    ) -> str | None:
+        """Lookup cloud-mask URL for one Sentinel-2 source item id."""
+        result = client.search(
+            collections=[self.EDA_CLOUD_MASK_COLLECTION_NAME],
+            query={"eda:derived_from_item_id": {"eq": source_item_id}},
+            max_items=1,
+        )
+        for stac_item in result.item_collection():
+            parsed = self._get_eda_cloud_mask_asset_url_from_stac_item(stac_item)
+            if parsed is None:
+                continue
+            _, href = parsed
+            return href
+        return None
+
+    def _cache_eda_cloud_masks_for_window(
+        self,
+        client: pystac_client.Client,
+        wgs84_geometry: STGeometry,
+    ) -> None:
+        """Populate the source-item->mask-url cache from one window query."""
+        result = client.search(
+            collections=[self.EDA_CLOUD_MASK_COLLECTION_NAME],
+            intersects=shapely.to_geojson(wgs84_geometry.shp),
+            datetime=wgs84_geometry.time_range,
+            max_items=self.search_max_items,
+        )
+        for stac_item in result.item_collection():
+            parsed = self._get_eda_cloud_mask_asset_url_from_stac_item(stac_item)
+            if parsed is None:
+                continue
+            source_item_id, href = parsed
+            self._eda_cloud_mask_asset_url_cache[source_item_id] = href
+
+    def _attach_eda_cloud_mask_asset(
+        self,
+        item: EarthDailyItem,
+        client: pystac_client.Client,
+    ) -> bool:
+        """Attach linked EDA cloud-mask URL to the item when available.
+
+        Returns:
+            True if the item has a usable cloud-mask URL after this call.
+        """
+        source_item_id = item.name
+        if source_item_id in self._eda_cloud_mask_asset_url_cache:
+            href = self._eda_cloud_mask_asset_url_cache[source_item_id]
+        else:
+            href = self._search_eda_cloud_mask_by_source_item_id(client, source_item_id)
+            self._eda_cloud_mask_asset_url_cache[source_item_id] = href
+
+        if href is None:
+            return False
+
+        item.asset_urls[self.EDA_CLOUD_MASK_ASSET_KEY] = href
+        return True
 
     def __init__(
         self,
@@ -796,6 +963,7 @@ class Sentinel2(EarthDaily):
             wanted_bands: set[str] = set()
             for band_set in context.layer_config.band_sets:
                 wanted_bands.update(band_set.bands)
+            wanted_bands.update(self._get_compositor_scoring_bands(context))
             for asset_key, band_names in self.ASSET_BANDS.items():
                 if wanted_bands.intersection(set(band_names)):
                     asset_bands[asset_key] = band_names
@@ -834,6 +1002,18 @@ class Sentinel2(EarthDaily):
         self.search_max_items = search_max_items
         self.sort_items_by = sort_items_by
         self.apply_scale_offset = apply_scale_offset
+        self._needs_eda_cloud_mask = self.EDA_CLOUD_MASK_ASSET_KEY in self.asset_bands
+        self._eda_cloud_mask_asset_url_cache: dict[str, str | None] = {}
+
+    def get_item_by_name(self, name: str) -> EarthDailyItem:
+        """Get Sentinel-2 item by id, with optional linked EDA cloud-mask asset."""
+        item = super().get_item_by_name(name)
+        if not self._needs_eda_cloud_mask:
+            return item
+
+        _, client, _ = self._load_client()
+        self._attach_eda_cloud_mask_asset(item, client)
+        return item
 
     def read_raster(
         self,
@@ -942,9 +1122,18 @@ class Sentinel2(EarthDaily):
                     f"invalid sort_items_by setting ({self.sort_items_by})"
                 )
 
+            if self._needs_eda_cloud_mask:
+                self._cache_eda_cloud_masks_for_window(client, wgs84_geometry)
+
             candidate_items = [
                 self.get_item_by_name(stac_item.id) for stac_item in stac_items
             ]
+            if self._needs_eda_cloud_mask and self.skip_items_missing_assets:
+                candidate_items = [
+                    item
+                    for item in candidate_items
+                    if self.EDA_CLOUD_MASK_ASSET_KEY in item.asset_urls
+                ]
             cur_groups = match_candidate_items_to_window(
                 geometry, candidate_items, query_config
             )

--- a/rslearn/dataset/sentinel2_eda_cloud_mask.py
+++ b/rslearn/dataset/sentinel2_eda_cloud_mask.py
@@ -1,0 +1,172 @@
+"""Sentinel-2 EDA cloud-mask compositor for cloud-aware FIRST_VALID compositing."""
+
+from datetime import datetime
+
+import numpy as np
+import numpy.typing as npt
+from rasterio.enums import Resampling
+
+from rslearn.data_sources.data_source import ItemType
+from rslearn.log_utils import get_logger
+from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.geometry import PixelBounds, Projection
+from rslearn.utils.raster_array import RasterArray
+
+from .compositing import Compositor, FirstValidCompositor
+from .remap import Remapper
+from .tile_utils import get_needed_band_sets_and_indexes, read_raster_window_from_tiles
+
+logger = get_logger(__name__)
+
+
+class Sentinel2EDACloudMaskFirstValid(Compositor):
+    """Sort items by Sentinel-2 EDA cloud-mask classes, then apply FIRST_VALID.
+
+    For each item in the group, this compositor reads one cloud-mask band over the
+    requested window and computes a weighted score from class fractions:
+
+    - 0: null / nodata
+    - 1: clear
+    - 2: cloud
+    - 3: cloud shadow
+    - 4: thin cloud
+
+    Lower scores are preferred.
+    """
+
+    def __init__(
+        self,
+        cloud_mask_band: str = "eda_cloud_mask",
+        null_weight: int = 5,
+        clear_weight: int = 0,
+        cloud_weight: int = 5,
+        shadow_weight: int = 1,
+        thin_cloud_weight: int = 1,
+        unknown_weight: int = 5,
+    ) -> None:
+        """Create a new Sentinel2EDACloudMaskFirstValid compositor.
+
+        Args:
+            cloud_mask_band: band name for EDA cloud mask.
+            null_weight: weight for class 0 pixels.
+            clear_weight: weight for class 1 pixels.
+            cloud_weight: weight for class 2 pixels.
+            shadow_weight: weight for class 3 pixels.
+            thin_cloud_weight: weight for class 4 pixels.
+            unknown_weight: weight for classes outside 0..4.
+        """
+        self.cloud_mask_band = cloud_mask_band
+        self.null_weight = null_weight
+        self.clear_weight = clear_weight
+        self.cloud_weight = cloud_weight
+        self.shadow_weight = shadow_weight
+        self.thin_cloud_weight = thin_cloud_weight
+        self.unknown_weight = unknown_weight
+
+    def _score_item(
+        self,
+        item: ItemType,
+        tile_store: TileStoreWithLayer,
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling_method: Resampling,
+    ) -> float | None:
+        """Score a single item using EDA cloud-mask class fractions."""
+        scoring_bands = [self.cloud_mask_band]
+        # EDA cloud-mask class 0 represents null/nodata, so keep 0 as nodata.
+        nodata_val = 0
+
+        needed_band_sets_and_indexes = get_needed_band_sets_and_indexes(
+            item, scoring_bands, tile_store
+        )
+        if len(needed_band_sets_and_indexes) == 0:
+            raise ValueError(
+                f"missing scoring bands {scoring_bands} for item {item.name}"
+            )
+
+        raster = read_raster_window_from_tiles(
+            tile_store=tile_store,
+            item=item,
+            bands=scoring_bands,
+            projection=projection,
+            bounds=bounds,
+            nodata_val=nodata_val,
+            band_dtype=np.uint8,
+            resampling=resampling_method,
+        )
+        if raster is None:
+            return None
+
+        mask = raster.array[0, 0, :, :]
+        null_frac = float((mask == 0).mean())
+        clear_frac = float((mask == 1).mean())
+        cloud_frac = float((mask == 2).mean())
+        shadow_frac = float((mask == 3).mean())
+        thin_cloud_frac = float((mask == 4).mean())
+        unknown_frac = float((~np.isin(mask, [0, 1, 2, 3, 4])).mean())
+
+        score = (
+            null_frac * self.null_weight
+            + clear_frac * self.clear_weight
+            + cloud_frac * self.cloud_weight
+            + shadow_frac * self.shadow_weight
+            + thin_cloud_frac * self.thin_cloud_weight
+            + unknown_frac * self.unknown_weight
+        )
+        logger.debug(
+            "Sentinel-2 EDA cloud mask for %s: null=%.3f clear=%.3f cloud=%.3f "
+            "shadow=%.3f thin=%.3f unknown=%.3f score=%.3f",
+            item.name,
+            null_frac,
+            clear_frac,
+            cloud_frac,
+            shadow_frac,
+            thin_cloud_frac,
+            unknown_frac,
+            score,
+        )
+        return score
+
+    def build_composite(
+        self,
+        group: list[ItemType],
+        nodata_val: int | float | None,
+        bands: list[str],
+        bounds: PixelBounds,
+        band_dtype: npt.DTypeLike,
+        tile_store: TileStoreWithLayer,
+        projection: Projection,
+        resampling_method: Resampling,
+        remapper: Remapper | None,
+        request_time_range: tuple[datetime, datetime] | None = None,
+    ) -> RasterArray:
+        """Score items by EDA cloudiness, sort, then delegate to FIRST_VALID."""
+        if len(group) > 1:
+            scored: list[tuple[float, ItemType]] = []
+            for item in group:
+                score = self._score_item(
+                    item, tile_store, projection, bounds, resampling_method
+                )
+                if score is None:
+                    logger.debug(
+                        "no data for Sentinel-2 EDA cloud-mask scoring of item %s",
+                        item.name,
+                    )
+                    continue
+                scored.append((score, item))
+
+            scored.sort(key=lambda t: t[0])
+            group = [item for _, item in scored]
+
+        return FirstValidCompositor().build_composite(
+            group=group,
+            nodata_val=nodata_val,
+            bands=bands,
+            bounds=bounds,
+            band_dtype=band_dtype,
+            tile_store=tile_store,
+            projection=projection,
+            resampling_method=resampling_method,
+            remapper=remapper,
+            request_time_range=request_time_range,
+        )

--- a/tests/integration/data_sources/test_earthdaily_sentinel2.py
+++ b/tests/integration/data_sources/test_earthdaily_sentinel2.py
@@ -13,6 +13,7 @@ from upath import UPath
 
 from rslearn.config.dataset import QueryConfig
 from rslearn.const import WGS84_PROJECTION
+from rslearn.data_sources.utils import MatchedItemGroup
 from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
 from rslearn.utils.geometry import Projection, STGeometry
 
@@ -323,6 +324,118 @@ def test_sentinel2_get_items_passes_query_to_helper(
         "eo:cloud_cover": {"lt": 15.0},
     }
     assert captured["max_items"] == 500
+
+
+def test_sentinel2_get_items_links_eda_cloud_mask_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("earthdaily")
+
+    from rslearn.data_sources.earthdaily import EarthDailyItem, Sentinel2
+
+    class StubAsset:
+        def __init__(self, href: str):
+            self.href = href
+            self.extra_fields = {"alternate": {"download": {"href": href}}}
+
+    class StubStacItem:
+        def __init__(
+            self,
+            item_id: str,
+            *,
+            properties: dict[str, object] | None = None,
+            assets: dict[str, StubAsset] | None = None,
+        ):
+            self.id = item_id
+            self.properties = properties or {}
+            self.assets = assets or {}
+            self.datetime = None
+
+    class StubSearchResult:
+        def __init__(self, items: list[StubStacItem]):
+            self._items = items
+
+        def item_collection(self) -> list[StubStacItem]:
+            return self._items
+
+    class StubClient:
+        def __init__(self):
+            self.calls: list[dict[str, object]] = []
+
+        def search(self, **kwargs: object) -> StubSearchResult:
+            self.calls.append(kwargs)
+            collections = kwargs.get("collections")
+            if collections == [Sentinel2.COLLECTION_NAME]:
+                return StubSearchResult(
+                    [
+                        StubStacItem("src1", properties={"eo:cloud_cover": 10.0}),
+                        StubStacItem("src2", properties={"eo:cloud_cover": 20.0}),
+                    ]
+                )
+
+            if collections == [Sentinel2.EDA_CLOUD_MASK_COLLECTION_NAME]:
+                query = kwargs.get("query")
+                if query is None:
+                    # Window-level prefetch.
+                    return StubSearchResult(
+                        [
+                            StubStacItem(
+                                "cm-src1",
+                                properties={"eda:derived_from_item_id": "src1"},
+                                assets={
+                                    "cloud_mask": StubAsset(
+                                        "https://example.com/src1_cloud_mask.tif"
+                                    )
+                                },
+                            )
+                        ]
+                    )
+                if query == {"eda:derived_from_item_id": {"eq": "src2"}}:
+                    return StubSearchResult([])
+
+            return StubSearchResult([])
+
+    data_source = Sentinel2(
+        assets=["red", "eda_cloud_mask"],
+        apply_scale_offset=False,
+    )
+    client = StubClient()
+    monkeypatch.setattr(
+        data_source, "_load_client", lambda: (object(), client, object())
+    )
+
+    geometry = STGeometry(
+        WGS84_PROJECTION,
+        shapely.box(-1, -1, 1, 1),
+        (datetime(2020, 1, 1), datetime(2020, 1, 2)),
+    )
+
+    def fake_get_item_by_name(name: str) -> EarthDailyItem:
+        item = EarthDailyItem(
+            name=name,
+            geometry=geometry,
+            asset_urls={"red": f"https://example.com/{name}_red.tif"},
+        )
+        data_source._attach_eda_cloud_mask_asset(item, client)
+        return item
+
+    monkeypatch.setattr(data_source, "get_item_by_name", fake_get_item_by_name)
+    monkeypatch.setattr(
+        "rslearn.data_sources.earthdaily.match_candidate_items_to_window",
+        lambda _geometry, items, _query_config: [
+            MatchedItemGroup(items=items, request_time_range=_geometry.time_range)
+        ],
+    )
+
+    groups = data_source.get_items([geometry], QueryConfig())
+
+    assert len(groups) == 1
+    assert len(groups[0]) == 1
+    # src2 should be filtered out because linked cloud-mask was missing.
+    assert [item.name for item in groups[0][0].items] == ["src1"]
+    assert groups[0][0].items[0].asset_urls["eda_cloud_mask"] == (
+        "https://example.com/src1_cloud_mask.tif"
+    )
 
 
 def test_sentinel2_ingest_raises_on_download_failure(

--- a/tests/unit/data_sources/test_earthdaily_scale_offset.py
+++ b/tests/unit/data_sources/test_earthdaily_scale_offset.py
@@ -209,3 +209,20 @@ def test_init_allows_non_float32_when_scale_offset_disabled() -> None:
         assets=["red"],
         context=DataSourceContext(layer_config=layer_cfg),
     )
+
+
+def test_context_rgb_with_eda_cloud_mask_ranking_adds_mask_asset() -> None:
+    layer_cfg = LayerConfig(
+        type=LayerType.RASTER,
+        band_sets=[BandSetConfig(dtype=DType.FLOAT32, bands=["R", "G", "B"])],
+        compositing_method={
+            "class_path": (
+                "rslearn.dataset.sentinel2_eda_cloud_mask."
+                "Sentinel2EDACloudMaskFirstValid"
+            ),
+            "init_args": {"cloud_mask_band": "eda_cloud_mask"},
+        },
+    )
+
+    data_source = Sentinel2(context=DataSourceContext(layer_config=layer_cfg))
+    assert set(data_source.asset_bands.keys()) == {"visual", "eda_cloud_mask"}

--- a/tests/unit/dataset/test_sentinel2_eda_cloud_mask.py
+++ b/tests/unit/dataset/test_sentinel2_eda_cloud_mask.py
@@ -1,0 +1,158 @@
+"""Tests for Sentinel2EDACloudMaskFirstValid compositor."""
+
+import pathlib
+
+import numpy as np
+import pytest
+from rasterio.enums import Resampling
+from shapely.geometry import Polygon
+from upath import UPath
+
+from rslearn.const import WGS84_PROJECTION
+from rslearn.data_sources.data_source import Item
+from rslearn.dataset.sentinel2_eda_cloud_mask import Sentinel2EDACloudMaskFirstValid
+from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.tile_stores.default import DefaultTileStore
+from rslearn.utils.geometry import PixelBounds, STGeometry
+from rslearn.utils.raster_array import RasterArray
+
+LAYER_NAME = "layer"
+BOUNDS: PixelBounds = (0, 0, 4, 4)
+PROJECTION = WGS84_PROJECTION
+OUTPUT_BANDS = ["B04"]
+STORE_BANDS = OUTPUT_BANDS + ["eda_cloud_mask"]
+
+
+def _make_item(name: str) -> Item:
+    bbox = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+    return Item(name, STGeometry(PROJECTION, bbox, None))
+
+
+class TestSentinel2EDACloudMaskFirstValid:
+    """Tests for Sentinel2EDACloudMaskFirstValid compositor."""
+
+    def _write_items(
+        self,
+        store: DefaultTileStore,
+        items: list[Item],
+        arrays: list[np.ndarray],
+    ) -> None:
+        for item, arr in zip(items, arrays):
+            store.write_raster(
+                LAYER_NAME,
+                item,
+                STORE_BANDS,
+                PROJECTION,
+                BOUNDS,
+                RasterArray(chw_array=arr),
+            )
+
+    def test_sorts_items_by_eda_cloud_mask_score(self, tmp_path: pathlib.Path) -> None:
+        """Items should be reordered so the least cloudy item is first."""
+        store = DefaultTileStore()
+        store.set_dataset_path(UPath(tmp_path))
+
+        item_cloudy = _make_item("cloudy")
+        item_clear = _make_item("clear")
+
+        cloudy_data = np.stack(
+            [
+                np.full((4, 4), 100, dtype=np.uint16),  # B04
+                np.full((4, 4), 2, dtype=np.uint16),  # EDA cloud class
+            ],
+            axis=0,
+        )
+        clear_data = np.stack(
+            [
+                np.full((4, 4), 200, dtype=np.uint16),  # B04
+                np.full((4, 4), 1, dtype=np.uint16),  # EDA clear class
+            ],
+            axis=0,
+        )
+        self._write_items(store, [item_cloudy, item_clear], [cloudy_data, clear_data])
+
+        compositor = Sentinel2EDACloudMaskFirstValid(cloud_mask_band="eda_cloud_mask")
+        result = compositor.build_composite(
+            group=[item_cloudy, item_clear],
+            nodata_val=0,
+            bands=OUTPUT_BANDS,
+            bounds=BOUNDS,
+            band_dtype=np.uint16,
+            tile_store=TileStoreWithLayer(store, LAYER_NAME),
+            projection=PROJECTION,
+            resampling_method=Resampling.bilinear,
+            remapper=None,
+        )
+
+        assert np.all(result.get_chw_array() == 200)
+
+    def test_single_item_no_scoring(self, tmp_path: pathlib.Path) -> None:
+        """With a single item, EDA cloud-mask scoring should not run."""
+        store = DefaultTileStore()
+        store.set_dataset_path(UPath(tmp_path))
+
+        item = _make_item("single")
+        data = np.stack(
+            [
+                np.full((4, 4), 42, dtype=np.uint16),
+                np.full((4, 4), 1, dtype=np.uint16),
+            ],
+            axis=0,
+        )
+        self._write_items(store, [item], [data])
+
+        compositor = Sentinel2EDACloudMaskFirstValid(cloud_mask_band="eda_cloud_mask")
+
+        def fail_score(*args: object, **kwargs: object) -> float | None:
+            raise AssertionError("should not be called")
+
+        original_score_item = compositor._score_item
+        compositor._score_item = fail_score  # type: ignore[method-assign]
+        try:
+            result = compositor.build_composite(
+                group=[item],
+                nodata_val=0,
+                bands=OUTPUT_BANDS,
+                bounds=BOUNDS,
+                band_dtype=np.uint16,
+                tile_store=TileStoreWithLayer(store, LAYER_NAME),
+                projection=PROJECTION,
+                resampling_method=Resampling.bilinear,
+                remapper=None,
+            )
+        finally:
+            compositor._score_item = original_score_item  # type: ignore[method-assign]
+
+        assert np.all(result.get_chw_array() == 42)
+
+    def test_missing_cloud_mask_band_raises(self, tmp_path: pathlib.Path) -> None:
+        """Scoring should fail if the configured cloud-mask band is unavailable."""
+        store = DefaultTileStore()
+        store.set_dataset_path(UPath(tmp_path))
+
+        item_a = _make_item("a")
+        item_b = _make_item("b")
+        for item, value in [(item_a, 10), (item_b, 20)]:
+            data = np.full((1, 4, 4), value, dtype=np.uint16)
+            store.write_raster(
+                LAYER_NAME,
+                item,
+                OUTPUT_BANDS,
+                PROJECTION,
+                BOUNDS,
+                RasterArray(chw_array=data),
+            )
+
+        compositor = Sentinel2EDACloudMaskFirstValid(cloud_mask_band="eda_cloud_mask")
+        with pytest.raises(ValueError, match="missing scoring bands"):
+            compositor.build_composite(
+                group=[item_a, item_b],
+                nodata_val=0,
+                bands=OUTPUT_BANDS,
+                bounds=BOUNDS,
+                band_dtype=np.uint16,
+                tile_store=TileStoreWithLayer(store, LAYER_NAME),
+                projection=PROJECTION,
+                resampling_method=Resampling.bilinear,
+                remapper=None,
+            )


### PR DESCRIPTION
- Implement Sentinel2EDACloudMaskFirstValid compositor for cloud-aware FIRST_VALID compositing using EarthDaily EDA cloud-mask classes.
- Update EarthDaily data source to support EDA cloud-mask asset retrieval.
- Enhance Compositors documentation to include EDA cloud-mask compositor.
- Add tests for EDA cloud-mask asset linking and scoring behavior.