### PR TITLE
Add forkserver preload to rslearn to speed up data loader initialization

### DIFF
--- a/rslearn/lightning_cli.py
+++ b/rslearn/lightning_cli.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import multiprocessing
 import os
 import shutil
 import sys
@@ -10,7 +11,7 @@ import tempfile
 import fsspec
 import jsonargparse
 import wandb
-from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch import LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 from lightning.pytorch.utilities import rank_zero_only
@@ -18,8 +19,6 @@ from upath import UPath
 
 from rslearn.arg_parser import RslearnArgumentParser
 from rslearn.log_utils import get_logger
-from rslearn.train.data_module import RslearnDataModule
-from rslearn.train.lightning_module import RslearnLightningModule
 from rslearn.utils.fsspec import open_atomic
 from rslearn.utils.jsonargparse import init_jsonargparse
 
@@ -406,9 +405,29 @@ def model_handler() -> None:
     """Handler for any rslearn model X commands."""
     init_jsonargparse()
 
+    # Set forkserver preload since torch can take a long time to load in each process.
+    logger.debug("Configuring forkserver preload")
+    multiprocessing.set_forkserver_preload(
+        [
+            "fiona",
+            "jsonargparse",
+            "numpy",
+            "pickle",
+            "PIL",
+            "torch",
+            "torch.multiprocessing",
+            "torchvision",
+            "upath",
+            "wandb",
+            "rslearn.main",
+            "rslearn.train.dataset",
+            "rslearn.train.data_module",
+        ]
+    )
+
     RslearnLightningCLI(
-        model_class=RslearnLightningModule,
-        datamodule_class=RslearnDataModule,
+        model_class=LightningModule,
+        datamodule_class=LightningDataModule,
         args=sys.argv[2:],
         subclass_mode_model=True,
         subclass_mode_data=True,

--- a/rslearn/train/all_crops_dataset.py
+++ b/rslearn/train/all_crops_dataset.py
@@ -9,9 +9,12 @@ import shapely
 import torch
 
 from rslearn.dataset import Window
+from rslearn.log_utils import get_logger
 from rslearn.train.dataset import DataInput, ModelDataset
 from rslearn.train.model_context import RasterImage, SampleMetadata
 from rslearn.utils.geometry import PixelBounds, STGeometry
+
+logger = get_logger(__name__)
 
 
 def get_window_crop_options(
@@ -281,7 +284,9 @@ class IterableAllCropsDataset(torch.utils.data.IterableDataset):
     ) -> Iterator[tuple[dict[str, Any], dict[str, Any], SampleMetadata]]:
         """Iterate over all crops in each element of the underlying ModelDataset."""
         # Iterate over the window IDs until we have returned enough samples.
+        logger.debug("Getting worker iteration data")
         window_ids, num_samples_needed = self._get_worker_iteration_data()
+        logger.debug("Got %d needed samples", num_samples_needed)
         num_samples_returned = 0
 
         for iteration_idx in itertools.count():


### PR DESCRIPTION
Previously we had this in rslearn_projects but now we don't go through rslearn_projects when running fine-tuning. I changed the preload to be fairly generic so it should only include the core requirements along with optional requirements that are needed in lightning_cli.py anyway like wandb.