### PR TITLE
MaxPoolResize

### DIFF
--- a/rslearn/train/transforms/adaptive_pooling.py
+++ b/rslearn/train/transforms/adaptive_pooling.py
@@ -1,0 +1,81 @@
+"""Adaptive pooling transform."""
+
+from typing import Any, Literal
+
+import torch
+
+from rslearn.train.model_context import RasterImage
+
+from .transform import Transform
+
+POOLING_MODES = {
+    "max": torch.nn.functional.adaptive_max_pool2d,
+    "mean": torch.nn.functional.adaptive_avg_pool2d,
+}
+
+
+class AdaptivePooling(Transform):
+    """Pools inputs to a target size using adaptive spatial pooling.
+
+    Supports max pooling and mean pooling over each spatial region. Mean pooling
+    returns floating-point outputs for non-floating inputs so the averages are
+    preserved.
+    """
+
+    def __init__(
+        self,
+        target_size: tuple[int, int],
+        selectors: list[str] | None = None,
+        pooling: Literal["max", "mean"] = "max",
+        skip_missing: bool = False,
+    ):
+        """Initialize an adaptive pooling transform.
+
+        Args:
+            target_size: the (height, width) to pool to.
+            selectors: items to transform.
+            pooling: the adaptive pooling mode to use. Must be "max" or "mean".
+            skip_missing: if True, skip selectors that don't exist in the input/target
+                dicts.
+        """
+        super().__init__(skip_missing=skip_missing)
+        if pooling not in POOLING_MODES:
+            raise ValueError(f"Unsupported pooling mode {pooling!r}")
+
+        self.target_size = target_size
+        self.selectors = [] if selectors is None else selectors
+        self.pooling = pooling
+
+    def apply_pooling(self, image: RasterImage) -> RasterImage:
+        """Apply adaptive spatial pooling on the specified image.
+
+        Args:
+            image: the image to transform (CTHW tensor).
+
+        Returns:
+            the pooled image.
+        """
+        # image.image is [C, T, H, W]. Merge C and T so we can pool over
+        # (H, W), then restore the original leading dims.
+        c, t, h, w = image.image.shape
+        merged = image.image.reshape(c * t, 1, h, w)
+        pooled = POOLING_MODES[self.pooling](merged.float(), self.target_size)
+        if self.pooling == "max" or image.image.is_floating_point():
+            pooled = pooled.to(image.image.dtype)
+        image.image = pooled.reshape(c, t, *self.target_size)
+        return image
+
+    def forward(
+        self, input_dict: dict[str, Any], target_dict: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Apply transform over the inputs and targets.
+
+        Args:
+            input_dict: the input
+            target_dict: the target
+
+        Returns:
+            transformed (input_dicts, target_dicts) tuple
+        """
+        self.apply_fn(self.apply_pooling, input_dict, target_dict, self.selectors)
+        return input_dict, target_dict

--- a/rslearn/train/transforms/resize.py
+++ b/rslearn/train/transforms/resize.py
@@ -92,10 +92,9 @@ class MaxPoolResize(Transform):
             skip_missing: if True, skip selectors that don't exist in the
                 input/target dicts.
         """
-        super().__init__()
+        super().__init__(skip_missing=skip_missing)
         self.target_size = target_size
         self.selectors = selectors
-        self.skip_missing = skip_missing
 
     def apply_max_pool_resize(self, image: RasterImage) -> RasterImage:
         """Apply adaptive max-pool resizing on the specified image.

--- a/rslearn/train/transforms/resize.py
+++ b/rslearn/train/transforms/resize.py
@@ -73,9 +73,8 @@ class Resize(Transform):
 class MaxPoolResize(Transform):
     """Resizes inputs to a target size using adaptive max pooling.
 
-    Unlike Resize (which uses interpolation), this uses max pooling over each
-    spatial region.  This is useful for binary label masks: if *any* pixel in a
-    pooling region is positive, the output pixel is positive.
+    Unlike Resize (which uses interpolation), this uses adaptive 2D max pooling
+    over each spatial region.
     """
 
     def __init__(

--- a/rslearn/train/transforms/resize.py
+++ b/rslearn/train/transforms/resize.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import torch
 import torchvision
 from torchvision.transforms import InterpolationMode
 
@@ -67,66 +66,4 @@ class Resize(Transform):
             transformed (input_dicts, target_dicts) tuple
         """
         self.apply_fn(self.apply_resize, input_dict, target_dict, self.selectors)
-        return input_dict, target_dict
-
-
-class MaxPoolResize(Transform):
-    """Resizes inputs to a target size using adaptive max pooling.
-
-    Unlike Resize (which uses interpolation), this uses adaptive 2D max pooling
-    over each spatial region.
-    """
-
-    def __init__(
-        self,
-        target_size: tuple[int, int],
-        selectors: list[str] = [],
-        skip_missing: bool = False,
-    ):
-        """Initialize a MaxPoolResize transform.
-
-        Args:
-            target_size: the (height, width) to resize to.
-            selectors: items to transform.
-            skip_missing: if True, skip selectors that don't exist in the
-                input/target dicts.
-        """
-        super().__init__(skip_missing=skip_missing)
-        self.target_size = target_size
-        self.selectors = selectors
-
-    def apply_max_pool_resize(self, image: RasterImage) -> RasterImage:
-        """Apply adaptive max-pool resizing on the specified image.
-
-        Args:
-            image: the image to transform (CTHW tensor).
-
-        Returns:
-            the resized image.
-        """
-        # image.image is [C, T, H, W].  Merge C and T so we can max-pool over
-        # (H, W), then restore the original leading dims.
-        c, t, h, w = image.image.shape
-        merged = image.image.reshape(c * t, 1, h, w)
-        pooled = torch.nn.functional.adaptive_max_pool2d(
-            merged.float(), self.target_size
-        )
-        image.image = pooled.reshape(c, t, *self.target_size).to(image.image.dtype)
-        return image
-
-    def forward(
-        self, input_dict: dict[str, Any], target_dict: dict[str, Any]
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Apply transform over the inputs and targets.
-
-        Args:
-            input_dict: the input
-            target_dict: the target
-
-        Returns:
-            transformed (input_dicts, target_dicts) tuple
-        """
-        self.apply_fn(
-            self.apply_max_pool_resize, input_dict, target_dict, self.selectors
-        )
         return input_dict, target_dict

--- a/rslearn/train/transforms/resize.py
+++ b/rslearn/train/transforms/resize.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import torch
 import torchvision
 from torchvision.transforms import InterpolationMode
 
@@ -66,4 +67,68 @@ class Resize(Transform):
             transformed (input_dicts, target_dicts) tuple
         """
         self.apply_fn(self.apply_resize, input_dict, target_dict, self.selectors)
+        return input_dict, target_dict
+
+
+class MaxPoolResize(Transform):
+    """Resizes inputs to a target size using adaptive max pooling.
+
+    Unlike Resize (which uses interpolation), this uses max pooling over each
+    spatial region.  This is useful for binary label masks: if *any* pixel in a
+    pooling region is positive, the output pixel is positive.
+    """
+
+    def __init__(
+        self,
+        target_size: tuple[int, int],
+        selectors: list[str] = [],
+        skip_missing: bool = False,
+    ):
+        """Initialize a MaxPoolResize transform.
+
+        Args:
+            target_size: the (height, width) to resize to.
+            selectors: items to transform.
+            skip_missing: if True, skip selectors that don't exist in the
+                input/target dicts.
+        """
+        super().__init__()
+        self.target_size = target_size
+        self.selectors = selectors
+        self.skip_missing = skip_missing
+
+    def apply_max_pool_resize(self, image: RasterImage) -> RasterImage:
+        """Apply adaptive max-pool resizing on the specified image.
+
+        Args:
+            image: the image to transform (CTHW tensor).
+
+        Returns:
+            the resized image.
+        """
+        # image.image is [C, T, H, W].  Merge C and T so we can max-pool over
+        # (H, W), then restore the original leading dims.
+        c, t, h, w = image.image.shape
+        merged = image.image.reshape(c * t, 1, h, w)
+        pooled = torch.nn.functional.adaptive_max_pool2d(
+            merged.float(), self.target_size
+        )
+        image.image = pooled.reshape(c, t, *self.target_size).to(image.image.dtype)
+        return image
+
+    def forward(
+        self, input_dict: dict[str, Any], target_dict: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Apply transform over the inputs and targets.
+
+        Args:
+            input_dict: the input
+            target_dict: the target
+
+        Returns:
+            transformed (input_dicts, target_dicts) tuple
+        """
+        self.apply_fn(
+            self.apply_max_pool_resize, input_dict, target_dict, self.selectors
+        )
         return input_dict, target_dict

--- a/tests/unit/train/transforms/test_adaptive_pooling.py
+++ b/tests/unit/train/transforms/test_adaptive_pooling.py
@@ -1,0 +1,78 @@
+"""Unit tests for rslearn.train.transforms.adaptive_pooling."""
+
+from typing import Any
+
+import torch
+
+from rslearn.train.model_context import RasterImage
+from rslearn.train.transforms.adaptive_pooling import AdaptivePooling
+
+
+def test_adaptive_pooling_max_all_zeros() -> None:
+    """Max adaptive pooling on an all-zero label mask should produce all zeros."""
+    label = torch.zeros(1, 1, 10, 10, dtype=torch.int32)
+    transform = AdaptivePooling((2, 2), ["target/classes"], pooling="max")
+    input_dict: dict[str, Any] = {}
+    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
+    _, out_target = transform(input_dict, target_dict)
+    assert out_target["classes"].image.shape == (1, 1, 2, 2)
+    assert (out_target["classes"].image == 0).all()
+
+
+def test_adaptive_pooling_max_single_positive_pixel() -> None:
+    """Max adaptive pooling should propagate a 1 to the matching pooled region."""
+    label = torch.zeros(1, 1, 10, 10, dtype=torch.int32)
+    label[0, 0, 3, 7] = 1
+    transform = AdaptivePooling((2, 2), ["target/classes"], pooling="max")
+    input_dict: dict[str, Any] = {}
+    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
+    _, out_target = transform(input_dict, target_dict)
+    assert out_target["classes"].image.shape == (1, 1, 2, 2)
+    assert out_target["classes"].image.sum().item() == 1
+    assert out_target["classes"].image[0, 0, 0, 1] == 1
+
+
+def test_adaptive_pooling_max_bool_multi_timestep() -> None:
+    """Max adaptive pooling should pool each boolean timestep independently."""
+    label = torch.zeros(1, 2, 4, 4, dtype=torch.bool)
+    label[0, 0, 0, 0] = True
+    label[0, 1, 3, 2] = True
+
+    transform = AdaptivePooling((2, 2), ["target/classes"], pooling="max")
+    input_dict: dict[str, Any] = {}
+    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
+    _, out_target = transform(input_dict, target_dict)
+
+    expected = torch.tensor(
+        [[[[True, False], [False, False]], [[False, False], [False, True]]]],
+        dtype=torch.bool,
+    )
+    assert out_target["classes"].image.shape == (1, 2, 2, 2)
+    assert out_target["classes"].image.dtype == torch.bool
+    assert torch.equal(out_target["classes"].image, expected)
+
+
+def test_adaptive_pooling_mean_float_multi_timestep() -> None:
+    """Mean adaptive pooling should average each timestep independently."""
+    image = torch.tensor(
+        [
+            [
+                [[1, 1, 3, 3], [1, 1, 3, 3], [5, 5, 7, 7], [5, 5, 7, 7]],
+                [[2, 2, 4, 4], [2, 2, 4, 4], [6, 6, 8, 8], [6, 6, 8, 8]],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    transform = AdaptivePooling((2, 2), ["target/image"], pooling="mean")
+    input_dict: dict[str, Any] = {}
+    target_dict: dict[str, Any] = {"image": RasterImage(image)}
+    _, out_target = transform(input_dict, target_dict)
+
+    expected = torch.tensor(
+        [[[[1, 3], [5, 7]], [[2, 4], [6, 8]]]],
+        dtype=torch.float32,
+    )
+    assert out_target["image"].image.shape == (1, 2, 2, 2)
+    assert out_target["image"].image.dtype == torch.float32
+    assert torch.equal(out_target["image"].image, expected)

--- a/tests/unit/train/transforms/test_resize.py
+++ b/tests/unit/train/transforms/test_resize.py
@@ -3,11 +3,11 @@ from typing import Any
 import torch
 
 from rslearn.train.model_context import RasterImage
-from rslearn.train.transforms.resize import MaxPoolResize, Resize
+from rslearn.train.transforms.resize import Resize
 
 
 def test_resize() -> None:
-    """Verify that converting to decibels works."""
+    """Verify nearest-neighbor resize on a 4D raster image."""
     target_class_4D = torch.tensor(
         [[[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]]], dtype=torch.float32
     ).unsqueeze(dim=1)
@@ -20,50 +20,3 @@ def test_resize() -> None:
     ).unsqueeze(dim=1)
     assert torch.all(tsf_target_4D["image"].image == expected_target_4D)
     assert tsf_input_4D == {}
-
-
-def test_max_pool_resize_all_zeros() -> None:
-    """MaxPoolResize on an all-zero label mask should produce all zeros."""
-    # CTHW: 1 channel, 1 timestep, 10x10 spatial — all zeros
-    label = torch.zeros(1, 1, 10, 10, dtype=torch.int32)
-    transform = MaxPoolResize((2, 2), ["target/classes"])
-    input_dict: dict[str, Any] = {}
-    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
-    _, out_target = transform(input_dict, target_dict)
-    assert out_target["classes"].image.shape == (1, 1, 2, 2)
-    assert (out_target["classes"].image == 0).all()
-
-
-def test_max_pool_resize_single_positive_pixel() -> None:
-    """MaxPoolResize with one positive pixel should propagate a 1 to that pool region."""
-    # CTHW: 1 channel, 1 timestep, 10x10 spatial — all zeros except one pixel
-    label = torch.zeros(1, 1, 10, 10, dtype=torch.int32)
-    label[0, 0, 3, 7] = 1  # falls in pool region (0, 1) for a 2x2 output
-    transform = MaxPoolResize((2, 2), ["target/classes"])
-    input_dict: dict[str, Any] = {}
-    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
-    _, out_target = transform(input_dict, target_dict)
-    assert out_target["classes"].image.shape == (1, 1, 2, 2)
-    # The output should not be all zeros — the region containing the positive pixel is 1
-    assert out_target["classes"].image.sum().item() == 1
-    assert out_target["classes"].image[0, 0, 0, 1] == 1
-
-
-def test_max_pool_resize_bool_multi_timestep() -> None:
-    """MaxPoolResize should pool each boolean timestep independently."""
-    label = torch.zeros(1, 2, 4, 4, dtype=torch.bool)
-    label[0, 0, 0, 0] = True
-    label[0, 1, 3, 2] = True
-
-    transform = MaxPoolResize((2, 2), ["target/classes"])
-    input_dict: dict[str, Any] = {}
-    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
-    _, out_target = transform(input_dict, target_dict)
-
-    expected = torch.tensor(
-        [[[[True, False], [False, False]], [[False, False], [False, True]]]],
-        dtype=torch.bool,
-    )
-    assert out_target["classes"].image.shape == (1, 2, 2, 2)
-    assert out_target["classes"].image.dtype == torch.bool
-    assert torch.equal(out_target["classes"].image, expected)

--- a/tests/unit/train/transforms/test_resize.py
+++ b/tests/unit/train/transforms/test_resize.py
@@ -47,3 +47,23 @@ def test_max_pool_resize_single_positive_pixel() -> None:
     # The output should not be all zeros — the region containing the positive pixel is 1
     assert out_target["classes"].image.sum().item() == 1
     assert out_target["classes"].image[0, 0, 0, 1] == 1
+
+
+def test_max_pool_resize_bool_multi_timestep() -> None:
+    """MaxPoolResize should pool each boolean timestep independently."""
+    label = torch.zeros(1, 2, 4, 4, dtype=torch.bool)
+    label[0, 0, 0, 0] = True
+    label[0, 1, 3, 2] = True
+
+    transform = MaxPoolResize((2, 2), ["target/classes"])
+    input_dict: dict[str, Any] = {}
+    target_dict: dict[str, Any] = {"classes": RasterImage(label)}
+    _, out_target = transform(input_dict, target_dict)
+
+    expected = torch.tensor(
+        [[[[True, False], [False, False]], [[False, False], [False, True]]]],
+        dtype=torch.bool,
+    )
+    assert out_target["classes"].image.shape == (1, 2, 2, 2)
+    assert out_target["classes"].image.dtype == torch.bool
+    assert torch.equal(out_target["classes"].image, expected)


### PR DESCRIPTION
Adding support for a adaptive max/mean pool transform.
Useful for binary prediction tasks where the label raster is at higher resolution than the desired prediction resolution.
eg: label is at 10m resolution but we want a 40m binary prediction resolution, maxpooling over the spatial dims allow to downscale the label on the fly.