### PR TITLE
FasterRCNN should not mutate targets list.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.1.3"
+version = "0.1.4"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     { name = "OlmoEarth Team" },

--- a/rslearn/models/faster_rcnn.py
+++ b/rslearn/models/faster_rcnn.py
@@ -199,16 +199,19 @@ class FasterRCNN(Predictor):
 
         # Fix target labels to be 1 size in case it's empty.
         # For some reason this is needed.
+        # Builds new list so the caller's targets are never modified.
         if targets:
-            for i, target_dict in enumerate(targets):
-                if len(target_dict["labels"]) != 0:
-                    continue
-                targets[i] = dict(
+            targets = [
+                dict(
                     target_dict,
                     labels=torch.zeros(
                         (1,), dtype=torch.int64, device=target_dict["labels"].device
                     ),
                 )
+                if len(target_dict["labels"]) == 0
+                else target_dict
+                for target_dict in targets
+            ]
 
         # take the first (and assumed to be only) timestep
         image_list = [inp["image"].image[:, 0] for inp in context.inputs]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32'",
@@ -4410,7 +4410,7 @@ wheels = [
 
 [[package]]
 name = "rslearn"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
When a particular target list member is empty,
FasterRCNN requires it to be resized to not blow
up. FasterRCNN performs this update in-place
against the targets list it receives.

In a SingleTask setting, this mutation causes eval code,
which consumes the same list, to hit a runtime error.

In the MultiTask setting, this effect is masked
because MultiTask copies the targets list itself
before a forward pass, incidentally ensuring data
isolation.

This changeset makes FasterRCNN itself responsible
for copying the targets list internally to avoid the problem
consistently.