### PR TITLE
Fix error when setting deprecated nodata_vals option

### DIFF
--- a/rslearn/config/dataset.py
+++ b/rslearn/config/dataset.py
@@ -235,6 +235,8 @@ class BandSetConfig(BaseModel):
             )
             if len(self.nodata_vals) > 0:
                 self.nodata_value = unique_nodata_value(self.nodata_vals)
+            # Clear self.nodata_vals so it doesn't cause error in case of re-validation.
+            self.nodata_vals = None
 
         return self
 


### PR DESCRIPTION
The ValueError for self.nodata_vals + self.nodata_value being set is raised because after serialization / de-serialization, the model is validated again with both set. We have to set `self.nodata_vals` to None when we set `self.nodata_value`.