### PR TITLE
Enhance EarthDaily Sentinel-2 documentation and refactor data sources

### DIFF
--- a/docs/DataSources.md
+++ b/docs/DataSources.md
@@ -14,14 +14,20 @@ detailed page with configuration options and available bands. See
 
 #### Sentinel-2
 
+EarthDaily has two Sentinel-2 L2A sources with similar names:
+`earthdaily.Sentinel2` uses EarthDaily's Collection 1 (`sentinel-2-c1-l2a`) and returns
+scale/offset-applied reflectance by default, while `earthdaily.Sentinel2L2A` uses the
+older `sentinel-2-l2a` collection with Planetary Computer-style asset names and optional
+DN harmonization.
+
 | Data Source | Provider | Notes |
 |---|---|---|
 | [planetary_computer.Sentinel2](data_sources/planetary_computer_Sentinel2.md) | Microsoft Planetary Computer | L2A COGs, direct materialization |
 | [aws_open_data.Sentinel2](data_sources/aws_open_data_Sentinel2.md) | AWS (Element 84) | L1C and L2A |
 | [aws_sentinel2_element84.Sentinel2](data_sources/aws_sentinel2_element84_Sentinel2.md) | AWS (Element 84) | L2A COGs, direct materialization |
 | [copernicus.Sentinel2](data_sources/copernicus.md#rslearndatasourcescopernicussentinel2) | ESA Copernicus OData API | L1C and L2A |
-| [earthdaily.Sentinel2](data_sources/earthdaily_Sentinel2.md) | EarthDaily | L2A Collection 1 (`sentinel-2-c1-l2a`), supports scale/offset |
-| [earthdaily.Sentinel2L2A](data_sources/earthdaily_Sentinel2L2A.md) | EarthDaily | `sentinel-2-l2a` (PC-style assets), optional harmonization |
+| [earthdaily.Sentinel2 (C1 L2A)](data_sources/earthdaily_Sentinel2C1L2A.md) | EarthDaily | Collection 1 L2A (`sentinel-2-c1-l2a`), scale/offset reflectance |
+| [earthdaily.Sentinel2L2A](data_sources/earthdaily_Sentinel2L2A.md) | EarthDaily | Legacy/PC-style L2A (`sentinel-2-l2a`), optional DN harmonization |
 | [gcp_public_data.Sentinel2](data_sources/gcp_public_data_Sentinel2.md) | Google Cloud Storage | L1C scenes |
 
 #### Sentinel-1

--- a/docs/data_sources/earthdaily_Sentinel2C1L2A.md
+++ b/docs/data_sources/earthdaily_Sentinel2C1L2A.md
@@ -13,8 +13,16 @@ By default, this data source applies per-asset scale/offset values from STAC
 `raster:bands` metadata (`apply_scale_offset: true`) to convert raw pixel values into
 physical units using `physical = raw * scale + offset`. Set `apply_scale_offset: false`
 to keep raw values.
+The underlying COG pixels are stored as integer DN/sample values, not physical
+reflectance values. rslearn applies the scale/offset during read/materialization unless
+`apply_scale_offset: false` is configured.
 For Sentinel-2 spectral bands, this physical unit is reflectance (typically BOA
 reflectance for L2A products), e.g. raw `10000` with scale `0.0001` maps to `1.0`.
+
+`apply_scale_offset` is not Sentinel-2 processing-baseline harmonization. It decodes
+the C1 COG storage values into reflectance. The `harmonize` option used by
+Planetary Computer-style Sentinel-2 sources adjusts DN values across processing
+baselines; this C1 source does not expose a `harmonize` argument.
 
 When `apply_scale_offset: true`, configure the target `band_sets[].dtype` as `float32`.
 rslearn will raise during initialization if a non-float dtype is configured through the

--- a/docs/data_sources/earthdaily_Sentinel2C1L2A.md
+++ b/docs/data_sources/earthdaily_Sentinel2C1L2A.md
@@ -1,8 +1,11 @@
 ## rslearn.data_sources.earthdaily.Sentinel2
 
-Sentinel-2 L2A data on [EarthDaily](https://earthdaily.com/) platform (collection: `sentinel-2-c1-l2a`).
-For EarthDaily collection `sentinel-2-l2a` with Planetary Computer-style asset keys and
-optional harmonization, use `rslearn.data_sources.earthdaily.Sentinel2L2A`.
+Sentinel-2 L2A data on [EarthDaily](https://earthdaily.com/) platform using the
+Collection 1 archive (`sentinel-2-c1-l2a`).
+
+Naming note: `earthdaily.Sentinel2` means the EarthDaily Collection 1 source. For the
+older EarthDaily `sentinel-2-l2a` collection with Planetary Computer-style asset keys
+and optional DN harmonization, use `rslearn.data_sources.earthdaily.Sentinel2L2A`.
 
 See [EarthDaily Setup](earthdaily.md) for required dependency/credentials.
 

--- a/docs/data_sources/earthdaily_Sentinel2L2A.md
+++ b/docs/data_sources/earthdaily_Sentinel2L2A.md
@@ -4,16 +4,20 @@ Sentinel-2 L2A data on [EarthDaily](https://earthdaily.com/) platform using coll
 `sentinel-2-l2a`. The underlying assets are from the AWS Open Data Sentinel-2 L2A COG
 collection.
 
+Naming note: `earthdaily.Sentinel2L2A` is the compatibility source for the older
+`sentinel-2-l2a` collection. For EarthDaily Collection 1 (`sentinel-2-c1-l2a`) with
+scale/offset-applied reflectance, use `rslearn.data_sources.earthdaily.Sentinel2`.
+
 This class uses the same Sentinel-2 asset keys as
 `rslearn.data_sources.planetary_computer.Sentinel2` (`B01`-`B12` except `B10`, plus
-`B8A` and `visual`).
+`B8A`, `SCL`, and `visual`).
 
 Authentication and dependency requirements are the same as
 `rslearn.data_sources.earthdaily.Sentinel2` (optional `earthdaily[platform]`,
 `EDS_CLIENT_ID`, `EDS_SECRET`, `EDS_AUTH_URL`, `EDS_API_URL`).
 
 For collection lifecycle context (`sentinel-2-c1-l2a` replacing `sentinel-2-l2a`) and
-known archive gaps, see [earthdaily.Sentinel2](earthdaily_Sentinel2.md#collection-status).
+known archive gaps, see [earthdaily.Sentinel2 (C1 L2A)](earthdaily_Sentinel2C1L2A.md#collection-status).
 
 ### Configuration
 
@@ -55,6 +59,7 @@ These bands are available:
 - B11
 - B12
 - B8A
+- SCL
 - R
 - G
 - B
@@ -72,9 +77,9 @@ present, rslearn falls back to the processing baseline encoded in STAC
 `properties["sentinel:product_id"]` when available, then to the item ID, and
 otherwise to the acquisition date:
 
-- scenes with baseline 04.00+ include a +1000 DN offset for non-visual bands,
+- scenes with baseline 04.00+ include a +1000 DN offset for reflectance bands,
 - harmonization undoes this by subtracting 1000 DN (with clipping at zero),
 - fallback applies this adjustment when the scene ID encodes baseline 04.00+,
 - if the scene ID does not expose a processing baseline, fallback applies the
   adjustment for acquisitions on/after 2022-01-25,
-- `visual` (TCI RGB) is not harmonized.
+- `SCL` and `visual` (TCI RGB) are not harmonized.

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -700,9 +700,13 @@ class EarthDaily(DataSource, TileStore):
 class Sentinel2(EarthDaily):
     """EarthDaily Sentinel-2 Collection 1 L2A source.
 
-    Uses the `sentinel-2-c1-l2a` collection and applies per-asset scale/offset metadata
-    from STAC `raster:bands` when present. For the older `sentinel-2-l2a` collection
-    with Planetary Computer-style asset keys, use `Sentinel2L2A`.
+    Uses the `sentinel-2-c1-l2a` collection. The COG pixels are stored as integer
+    DN/sample values, not physical reflectance values; by default rslearn applies
+    per-asset scale/offset metadata from STAC `raster:bands` during
+    read/materialization. This scale/offset decoding is not Sentinel-2
+    processing-baseline harmonization. For the older `sentinel-2-l2a` collection with
+    Planetary Computer-style asset keys and optional DN harmonization, use
+    `Sentinel2L2A`.
     """
 
     COLLECTION_NAME = "sentinel-2-c1-l2a"
@@ -772,7 +776,10 @@ class Sentinel2(EarthDaily):
             retry_backoff_factor: backoff factor for EarthDaily API client retries.
             context: rslearn data source context.
             apply_scale_offset: apply per-asset scale/offset metadata from STAC
-                `raster:bands` (defaults to True). Set to False to use raw values.
+                `raster:bands` during read/materialization (defaults to True).
+                This decodes C1 COG storage values to physical values; it is not
+                Sentinel-2 processing-baseline harmonization. Set to False to use the
+                raw integer DN/sample values from the COG.
         """
         if apply_scale_offset and context.layer_config is not None:
             invalid_band_sets = [

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -698,10 +698,11 @@ class EarthDaily(DataSource, TileStore):
 
 
 class Sentinel2(EarthDaily):
-    """Sentinel-2 L2A on EarthDaily platform.
+    """EarthDaily Sentinel-2 Collection 1 L2A source.
 
     Uses the `sentinel-2-c1-l2a` collection and applies per-asset scale/offset metadata
-    from STAC `raster:bands` when present.
+    from STAC `raster:bands` when present. For the older `sentinel-2-l2a` collection
+    with Planetary Computer-style asset keys, use `Sentinel2L2A`.
     """
 
     COLLECTION_NAME = "sentinel-2-c1-l2a"
@@ -1012,9 +1013,10 @@ class Sentinel2(EarthDaily):
 
 
 class Sentinel2L2A(EarthDaily):
-    """Sentinel-2 L2A on EarthDaily platform using `sentinel-2-l2a` collection.
+    """EarthDaily Sentinel-2 `sentinel-2-l2a` compatibility source.
 
     This collection exposes the same asset keys as Planetary Computer Sentinel-2.
+    For EarthDaily Collection 1 (`sentinel-2-c1-l2a`), use `Sentinel2`.
     """
 
     COLLECTION_NAME = "sentinel-2-l2a"
@@ -1032,8 +1034,10 @@ class Sentinel2L2A(EarthDaily):
         "B11": ["B11"],
         "B12": ["B12"],
         "B8A": ["B8A"],
+        "SCL": ["SCL"],
         "visual": ["R", "G", "B"],
     }
+    NON_REFLECTANCE_ASSETS = frozenset({"SCL", "visual"})
     PROCESSING_BASELINE_PATTERN = re.compile(r"(?:^|_)N(?P<baseline>\d{4})(?:_|$)")
     HARMONIZE_PROCESSING_BASELINE = 400
     HARMONIZE_CUTOFF = datetime(2022, 1, 25)
@@ -1138,7 +1142,7 @@ class Sentinel2L2A(EarthDaily):
     def _get_harmonize_callback_for_item(
         self, item: EarthDailyItem, asset_key: str
     ) -> Callable[[npt.NDArray[Any]], npt.NDArray[Any]] | None:
-        if not self.harmonize or asset_key == "visual":
+        if not self.harmonize or asset_key in self.NON_REFLECTANCE_ASSETS:
             return None
         if item.name in self._harmonize_callback_cache:
             return self._harmonize_callback_cache[item.name]

--- a/tests/unit/data_sources/test_earthdaily_sentinel2_l2a.py
+++ b/tests/unit/data_sources/test_earthdaily_sentinel2_l2a.py
@@ -132,9 +132,56 @@ def test_read_raster_does_not_harmonize_visual(
     np.testing.assert_array_equal(out, raw)
 
 
+def test_read_raster_does_not_harmonize_scl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tif_path = tmp_path / "SCL.tif"
+    raw = np.array([[[0, 4], [8, 11]]], dtype=np.uint8)
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=1,
+        dtype=str(raw.dtype),
+        crs=CRS.from_epsg(3857),
+        transform=Affine(1, 0, 0, 0, -1, 0),
+    ) as dst:
+        dst.write(raw)
+
+    item = _make_item(
+        {"SCL": str(tif_path), "product_metadata": "https://example.com/meta.xml"}
+    )
+    ds = Sentinel2L2A(harmonize=True, assets=["SCL"], cache_dir=None)
+    monkeypatch.setattr(ds, "get_item_by_name", lambda _name: item)
+    monkeypatch.setattr(
+        ds,
+        "_get_product_xml",
+        lambda _item: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    out = ds.read_raster(
+        layer_name="layer",
+        item=item,
+        bands=["SCL"],
+        projection=Projection(CRS.from_epsg(3857), 1, -1),
+        bounds=(0, 0, 2, 2),
+    ).get_chw_array()
+
+    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out, raw)
+
+
 def test_rejects_unknown_assets() -> None:
     with pytest.raises(ValueError, match="unknown EarthDaily Sentinel-2 L2A assets"):
         Sentinel2L2A(assets=["red"], cache_dir=None)
+
+
+def test_sentinel2_l2a_exposes_scl() -> None:
+    ds = Sentinel2L2A(assets=["SCL"], cache_dir=None)
+    assert ds.asset_bands == {"SCL": ["SCL"]}
 
 
 def test_sentinel2_l2a_disables_scale_offset_parsing() -> None:


### PR DESCRIPTION
- Clarified EarthDaily Sentinel-2 naming in docs.
- Renamed the C1 docs page from earthdaily_Sentinel2.md to earthdaily_Sentinel2C1L2A.md.
- Updated docs/DataSources.md to label earthdaily.Sentinel2 as C1 L2A.

- Added cross-links explaining:
- earthdaily.Sentinel2 = sentinel-2-c1-l2a, scale/offset reflectance.
- earthdaily.Sentinel2L2A = sentinel-2-l2a, PC-style assets, optional DN harmonization.
- Updated EarthDaily Sentinel-2 class docstrings to reflect that distinction.
- Added SCL support to earthdaily.Sentinel2L2A.
- Made earthdaily.Sentinel2L2A skip harmonization for both SCL and visual, matching Planetary Computer behavior.
- Updated earthdaily_Sentinel2L2A.md to document SCL.
- Added tests confirming SCL is exposed and not harmonized.