### PR TITLE
[Enhancement] Add documentation and tests for ERA5 temporal stack materialization

### DIFF
--- a/docs/data_sources/earthdatahub_ERA5LandDailyUTCv1.md
+++ b/docs/data_sources/earthdatahub_ERA5LandDailyUTCv1.md
@@ -80,35 +80,8 @@ To materialize temporal aggregates instead, keep the same `NumpyRasterFormat` an
 
 Each reducer first builds the same clipped spatial mosaic temporal stack, then
 reduces across the T dimension to one timestep. For example, if dataset windows are
-bi-weekly, `TEMPORAL_MEAN` writes one mean aggregate per bi-weekly window:
-
-```jsonc
-{
-  "type": "raster",
-  "compositing_method": "TEMPORAL_MEAN",
-  "band_sets": [
-    {
-      "dtype": "float32",
-      "bands": ["t2m", "tp"],
-      "nodata_value": -9999.0,
-      "spatial_size": [1, 1],
-      "format": {
-        "class_path": "rslearn.utils.raster_format.NumpyRasterFormat"
-      }
-    }
-  ],
-  "data_source": {
-    "class_path": "rslearn.data_sources.earthdatahub.ERA5LandDailyUTCv1",
-    "init_args": {
-      "band_names": ["t2m", "tp"],
-      "trust_env": true
-    },
-    "query_config": {
-      "space_mode": "SINGLE_COMPOSITE"
-    }
-  }
-}
-```
+bi-weekly, changing `SPATIAL_MOSAIC_TEMPORAL_STACK` to `TEMPORAL_MEAN` writes one
+mean aggregate per bi-weekly window.
 
 ### Available Bands
 

--- a/docs/data_sources/earthdatahub_ERA5LandDailyUTCv1.md
+++ b/docs/data_sources/earthdatahub_ERA5LandDailyUTCv1.md
@@ -30,6 +30,86 @@ machine data.earthdatahub.destine.eu
 }
 ```
 
+### Recommended materialized time-series layer
+
+For small spatial windows with many daily timesteps, use the data source with
+`SINGLE_COMPOSITE`, `SPATIAL_MOSAIC_TEMPORAL_STACK`, and `NumpyRasterFormat`.
+This materializes one `(C, T, H, W)` NumPy array per window/layer/band set instead
+of one GeoTIFF per timestep.
+
+```jsonc
+{
+  "layers": {
+    "era5": {
+      "type": "raster",
+      "compositing_method": "SPATIAL_MOSAIC_TEMPORAL_STACK",
+      "band_sets": [
+        {
+          "dtype": "float32",
+          "bands": ["t2m", "tp"],
+          "nodata_value": -9999.0,
+          // Optional, but useful for point-like windows where ERA5 should be
+          // loaded as one pixel per timestep.
+          "spatial_size": [1, 1],
+          "format": {
+            "class_path": "rslearn.utils.raster_format.NumpyRasterFormat"
+          }
+        }
+      ],
+      "data_source": {
+        "class_path": "rslearn.data_sources.earthdatahub.ERA5LandDailyUTCv1",
+        "init_args": {
+          "band_names": ["t2m", "tp"],
+          "trust_env": true
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
+        }
+      }
+    }
+  }
+}
+```
+
+To materialize temporal aggregates instead, keep the same `NumpyRasterFormat` and
+`SINGLE_COMPOSITE` setup but replace the compositing method with one of:
+
+- `TEMPORAL_MEAN`
+- `TEMPORAL_MAX`
+- `TEMPORAL_MIN`
+
+Each reducer first builds the same clipped spatial mosaic temporal stack, then
+reduces across the T dimension to one timestep. For example, if dataset windows are
+bi-weekly, `TEMPORAL_MEAN` writes one mean aggregate per bi-weekly window:
+
+```jsonc
+{
+  "type": "raster",
+  "compositing_method": "TEMPORAL_MEAN",
+  "band_sets": [
+    {
+      "dtype": "float32",
+      "bands": ["t2m", "tp"],
+      "nodata_value": -9999.0,
+      "spatial_size": [1, 1],
+      "format": {
+        "class_path": "rslearn.utils.raster_format.NumpyRasterFormat"
+      }
+    }
+  ],
+  "data_source": {
+    "class_path": "rslearn.data_sources.earthdatahub.ERA5LandDailyUTCv1",
+    "init_args": {
+      "band_names": ["t2m", "tp"],
+      "trust_env": true
+    },
+    "query_config": {
+      "space_mode": "SINGLE_COMPOSITE"
+    }
+  }
+}
+```
+
 ### Available Bands
 
 - `d2m`: 2m dewpoint temperature (units: K)

--- a/tests/unit/data_sources/test_earthdatahub_era5_land_daily.py
+++ b/tests/unit/data_sources/test_earthdatahub_era5_land_daily.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -6,14 +7,154 @@ import pytest
 import shapely
 import xarray as xr
 import zarr  # noqa: F401
+from rasterio.crs import CRS
 from upath import UPath
 
 from rslearn.config import QueryConfig, SpaceMode
-from rslearn.const import WGS84_PROJECTION
+from rslearn.const import WGS84_EPSG, WGS84_PROJECTION
 from rslearn.data_sources.earthdatahub import ERA5LandDailyUTCv1
 from rslearn.data_sources.utils import MatchedItemGroup
+from rslearn.dataset import Dataset
+from rslearn.dataset.manage import (
+    ingest_dataset_windows,
+    materialize_dataset_windows,
+    prepare_dataset_windows,
+)
+from rslearn.dataset.window import Window
 from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
-from rslearn.utils.geometry import STGeometry
+from rslearn.utils.geometry import Projection, STGeometry
+from rslearn.utils.raster_format import NumpyRasterFormat
+
+ERA5_TEST_BANDS = ["t2m", "tp"]
+
+
+def _write_temporal_stack_zarr(tmp_path: Path) -> Path:
+    """Write a small ERA5-like local Zarr with 5 daily timesteps."""
+    valid_time = np.array(
+        ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"],
+        dtype="datetime64[ns]",
+    )
+    latitude = np.array([1.0, 0.9], dtype=np.float64)
+    longitude = np.array([0.0, 0.1], dtype=np.float64)
+
+    # Spatially constant values keep these tests focused on temporal compositing.
+    t2m = np.stack(
+        [np.full((2, 2), 280 + t, dtype=np.float32) for t in range(5)], axis=0
+    )
+    tp = np.stack(
+        [np.full((2, 2), t / 1000, dtype=np.float32) for t in range(5)], axis=0
+    )
+
+    zarr_ds = xr.Dataset(
+        data_vars=dict(
+            t2m=(("valid_time", "latitude", "longitude"), t2m),
+            tp=(("valid_time", "latitude", "longitude"), tp),
+        ),
+        coords=dict(valid_time=valid_time, latitude=latitude, longitude=longitude),
+    )
+    zarr_path = tmp_path / "era5_temporal_stack.zarr"
+    zarr_ds.to_zarr(
+        zarr_path,
+        mode="w",
+        encoding={
+            "t2m": {"chunks": (5, 2, 2)},
+            "tp": {"chunks": (5, 2, 2)},
+        },
+    )
+    return zarr_path
+
+
+def _make_numpy_era5_dataset_config(
+    zarr_path: Path,
+    compositing_method: str,
+) -> dict:
+    """Build a dataset config for ERA5 daily materialized via NumpyRasterFormat."""
+    return {
+        "layers": {
+            "era5": {
+                "type": "raster",
+                "compositing_method": compositing_method,
+                "band_sets": [
+                    {
+                        "dtype": "float32",
+                        "bands": ERA5_TEST_BANDS,
+                        "nodata_value": ERA5LandDailyUTCv1.NODATA_VALUE,
+                        "spatial_size": [1, 1],
+                        "format": {
+                            "class_path": "rslearn.utils.raster_format.NumpyRasterFormat"
+                        },
+                    }
+                ],
+                "data_source": {
+                    "class_path": "rslearn.data_sources.earthdatahub.ERA5LandDailyUTCv1",
+                    "init_args": {
+                        "band_names": ERA5_TEST_BANDS,
+                        "zarr_url": str(zarr_path),
+                        "trust_env": False,
+                    },
+                    "query_config": {
+                        "space_mode": "SINGLE_COMPOSITE",
+                    },
+                },
+            }
+        }
+    }
+
+
+def _materialize_numpy_era5_window(
+    tmp_path: Path,
+    zarr_path: Path,
+    compositing_method: str,
+) -> tuple[Dataset, Window]:
+    """Run prepare/ingest/materialize for a 3-day ERA5 window."""
+    ds_path = UPath(tmp_path / f"dataset_{compositing_method.lower()}")
+    ds_path.mkdir()
+    with (ds_path / "config.json").open("w") as f:
+        json.dump(
+            _make_numpy_era5_dataset_config(zarr_path, compositing_method),
+            f,
+        )
+
+    dataset = Dataset(ds_path)
+    window_projection = Projection(CRS.from_epsg(WGS84_EPSG), 0.001, -0.001)
+    lon = 0.05
+    lat = 0.95
+    window = Window(
+        storage=dataset.storage,
+        group="default",
+        name="era5_numpy",
+        projection=window_projection,
+        bounds=(
+            int(lon / window_projection.x_resolution),
+            int(lat / window_projection.y_resolution),
+            int(lon / window_projection.x_resolution) + 1,
+            int(lat / window_projection.y_resolution) + 1,
+        ),
+        time_range=(
+            datetime(2020, 1, 2, tzinfo=UTC),
+            datetime(2020, 1, 5, tzinfo=UTC),
+        ),
+    )
+    window.save()
+
+    windows = dataset.load_windows()
+    prepare_dataset_windows(dataset, windows)
+    ingest_dataset_windows(dataset, windows)
+    materialize_dataset_windows(dataset, windows)
+    return dataset, window
+
+
+def _decode_numpy_era5_raster(dataset: Dataset, window: Window):
+    """Decode the materialized ERA5 NumPy raster."""
+    raster_dir = window.get_raster_dir("era5", ERA5_TEST_BANDS, group_idx=0)
+    assert (raster_dir / "data.npy").exists()
+    assert not (raster_dir / "geotiff.tif").exists()
+
+    band_set = dataset.layers["era5"].band_sets[0]
+    projection, bounds = band_set.get_final_projection_and_bounds(
+        window.projection, window.bounds
+    )
+    return NumpyRasterFormat().decode_raster(raster_dir, projection, bounds)
 
 
 def test_era5land_dailyutc_v1_chunk_items_and_ingest(tmp_path: Path) -> None:
@@ -81,6 +222,53 @@ def test_era5land_dailyutc_v1_chunk_items_and_ingest(tmp_path: Path) -> None:
 
     bands = ["t2m", "tp"]
     assert layer_tile_store.is_raster_ready(items[0], bands)
+
+
+def test_era5land_dailyutc_v1_materializes_temporal_stack_as_numpy(
+    tmp_path: Path,
+) -> None:
+    """Full pipeline writes one NumPy CTHW raster for a clipped temporal stack."""
+    zarr_path = _write_temporal_stack_zarr(tmp_path)
+    dataset, window = _materialize_numpy_era5_window(
+        tmp_path, zarr_path, "SPATIAL_MOSAIC_TEMPORAL_STACK"
+    )
+    raster = _decode_numpy_era5_raster(dataset, window)
+
+    assert raster.array.shape == (2, 3, 1, 1)
+    assert raster.timestamps == [
+        (datetime(2020, 1, 2, tzinfo=UTC), datetime(2020, 1, 3, tzinfo=UTC)),
+        (datetime(2020, 1, 3, tzinfo=UTC), datetime(2020, 1, 4, tzinfo=UTC)),
+        (datetime(2020, 1, 4, tzinfo=UTC), datetime(2020, 1, 5, tzinfo=UTC)),
+    ]
+    np.testing.assert_allclose(raster.array[0, :, 0, 0], [281, 282, 283])
+    np.testing.assert_allclose(raster.array[1, :, 0, 0], [0.001, 0.002, 0.003])
+
+
+@pytest.mark.parametrize(
+    ("compositing_method", "expected_values"),
+    [
+        ("TEMPORAL_MEAN", [282.0, 0.002]),
+        ("TEMPORAL_MAX", [283.0, 0.003]),
+        ("TEMPORAL_MIN", [281.0, 0.001]),
+    ],
+)
+def test_era5land_dailyutc_v1_materializes_temporal_reducer_as_numpy(
+    tmp_path: Path,
+    compositing_method: str,
+    expected_values: list[float],
+) -> None:
+    """Temporal reducer compositors write one aggregated NumPy timestep."""
+    zarr_path = _write_temporal_stack_zarr(tmp_path)
+    dataset, window = _materialize_numpy_era5_window(
+        tmp_path, zarr_path, compositing_method
+    )
+    raster = _decode_numpy_era5_raster(dataset, window)
+
+    assert raster.array.shape == (2, 1, 1, 1)
+    assert raster.timestamps == [
+        (datetime(2020, 1, 2, tzinfo=UTC), datetime(2020, 1, 5, tzinfo=UTC))
+    ]
+    np.testing.assert_allclose(raster.array[:, 0, 0, 0], expected_values)
 
 
 def test_era5land_dailyutc_v1_requires_single_composite(tmp_path: Path) -> None:

--- a/tests/unit/data_sources/test_earthdatahub_era5_land_daily.py
+++ b/tests/unit/data_sources/test_earthdatahub_era5_land_daily.py
@@ -23,6 +23,7 @@ from rslearn.dataset.manage import (
 from rslearn.dataset.window import Window
 from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
 from rslearn.utils.geometry import Projection, STGeometry
+from rslearn.utils.raster_array import RasterArray
 from rslearn.utils.raster_format import NumpyRasterFormat
 
 ERA5_TEST_BANDS = ["t2m", "tp"]
@@ -144,7 +145,7 @@ def _materialize_numpy_era5_window(
     return dataset, window
 
 
-def _decode_numpy_era5_raster(dataset: Dataset, window: Window):
+def _decode_numpy_era5_raster(dataset: Dataset, window: Window) -> RasterArray:
     """Decode the materialized ERA5 NumPy raster."""
     raster_dir = window.get_raster_dir("era5", ERA5_TEST_BANDS, group_idx=0)
     assert (raster_dir / "data.npy").exists()
@@ -240,8 +241,12 @@ def test_era5land_dailyutc_v1_materializes_temporal_stack_as_numpy(
         (datetime(2020, 1, 3, tzinfo=UTC), datetime(2020, 1, 4, tzinfo=UTC)),
         (datetime(2020, 1, 4, tzinfo=UTC), datetime(2020, 1, 5, tzinfo=UTC)),
     ]
-    np.testing.assert_allclose(raster.array[0, :, 0, 0], [281, 282, 283])
-    np.testing.assert_allclose(raster.array[1, :, 0, 0], [0.001, 0.002, 0.003])
+    assert [float(v) for v in raster.array[0, :, 0, 0].tolist()] == pytest.approx(
+        [281, 282, 283]
+    )
+    assert [float(v) for v in raster.array[1, :, 0, 0].tolist()] == pytest.approx(
+        [0.001, 0.002, 0.003]
+    )
 
 
 @pytest.mark.parametrize(
@@ -268,7 +273,9 @@ def test_era5land_dailyutc_v1_materializes_temporal_reducer_as_numpy(
     assert raster.timestamps == [
         (datetime(2020, 1, 2, tzinfo=UTC), datetime(2020, 1, 5, tzinfo=UTC))
     ]
-    np.testing.assert_allclose(raster.array[:, 0, 0, 0], expected_values)
+    assert [float(v) for v in raster.array[:, 0, 0, 0].tolist()] == pytest.approx(
+        expected_values
+    )
 
 
 def test_era5land_dailyutc_v1_requires_single_composite(tmp_path: Path) -> None:


### PR DESCRIPTION
Address https://github.com/allenai/rslearn/issues/587

- Documented the recommended ERA5 daily time-series path using SINGLE_COMPOSITE, SPATIAL_MOSAIC_TEMPORAL_STACK, and NumpyRasterFormat.
- Added guidance for temporal aggregation via TEMPORAL_MEAN, TEMPORAL_MAX, and TEMPORAL_MIN.
- Added tests covering ERA5 materialization to one CTHW NumPy raster, including clipped temporal stacks and reducer outputs.

Validation: EarthDataHub ERA5 unit tests passed locally.