### PR TITLE
Add layer-wise learning rate decay for olmoearth_pretrain model.

### DIFF
--- a/docs/examples/BitemporalSentinel2.md
+++ b/docs/examples/BitemporalSentinel2.md
@@ -187,7 +187,7 @@ model:
           # ground truth category.
           - class_path: rslearn.train.tasks.classification.ClassificationHead
     optimizer:
-      class_path: rslearn.train.optimizer.AdamW
+      class_path: rslearn.models.olmoearth_pretrain.optimizer.LayerDecayAdamW
       init_args:
         lr: 0.0001
 data:
@@ -240,11 +240,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # It is recommended to freeze the OlmoEarth encoder for the first few epochs.
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 10
     # Save best checkpoint based on accuracy metric.
     - class_path: rslearn.train.callbacks.checkpointing.ManagedBestLastCheckpoint
       init_args:

--- a/docs/examples/FinetuneOlmoEarth.md
+++ b/docs/examples/FinetuneOlmoEarth.md
@@ -152,7 +152,7 @@ model:
           # The SegmentationHead computes softmax and cross entropy loss.
           - class_path: rslearn.train.tasks.segmentation.SegmentationHead
     optimizer:
-      class_path: rslearn.train.optimizer.AdamW
+      class_path: rslearn.models.olmoearth_pretrain.optimizer.LayerDecayAdamW
       init_args:
         lr: 0.0001
 data:
@@ -215,13 +215,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # We find that freezing the model for the first few epochs helps to improve the
-    # performance of the fine-tuned models.
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 10
-        unfreeze_lr_factor: 10
     # The RslearnWriter is used during `model predict` to save the predicted outputs to
     # the rslearn dataset.
     - class_path: rslearn.train.prediction_writer.RslearnWriter

--- a/docs/examples/ProgrammaticWindows.md
+++ b/docs/examples/ProgrammaticWindows.md
@@ -266,7 +266,7 @@ model:
           # ground truth category.
           - class_path: rslearn.train.tasks.classification.ClassificationHead
     optimizer:
-      class_path: rslearn.train.optimizer.AdamW
+      class_path: rslearn.models.olmoearth_pretrain.optimizer.LayerDecayAdamW
       init_args:
         lr: 0.0001
 data:
@@ -313,11 +313,6 @@ data:
 trainer:
   max_epochs: 100
   callbacks:
-    # It is recommended to freeze the OlmoEarth encoder for the first few epochs.
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 10
     # Save best checkpoint based on accuracy metric.
     - class_path: rslearn.train.callbacks.checkpointing.ManagedBestLastCheckpoint
       init_args:

--- a/docs/foundation_models/OlmoEarth.md
+++ b/docs/foundation_models/OlmoEarth.md
@@ -56,6 +56,27 @@ input resolution. The embedding size depends on the `model_id`:
 - OLMOEARTH_V1_BASE: 768
 - OLMOEARTH_V1_LARGE: 1024
 
+## Fine-tuning Optimizer
+
+When fine-tuning OlmoEarth, we recommend using `LayerDecayAdamW` which applies
+per-layer learning rate decay to the encoder. Earlier layers receive a lower learning
+rate, which preserves pre-trained features while allowing the later layers and decoder
+to adapt more freely.
+
+This works well across tasks compared to the previously recommended recipe, which was
+to freeze the backbone for 10 to 20 epochs and then unfreeze with a learning rate 1/10
+of the head learning rate.
+
+```yaml
+    optimizer:
+      class_path: rslearn.models.olmoearth_pretrain.optimizer.LayerDecayAdamW
+      init_args:
+        lr: 0.0001
+```
+
+The default `layer_decay_rate` of 0.65 and `num_layers` of 12 match OlmoEarth-v1-Base.
+If using a different model size, adjust `num_layers` to match the encoder depth.
+
 ## Examples
 
 Here are some tutorials and examples of applying OlmoEarth.

--- a/rslearn/models/olmoearth_pretrain/model.py
+++ b/rslearn/models/olmoearth_pretrain/model.py
@@ -11,6 +11,9 @@ from typing import Any
 import torch
 from einops import rearrange
 from olmoearth_pretrain_minimal import ModelID, load_model_from_id, load_model_from_path
+from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.nn.flexi_vit import (
+    TokensAndMasks,
+)
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.config import Config
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.constants import Modality
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.datatypes import (

--- a/rslearn/models/olmoearth_pretrain/model.py
+++ b/rslearn/models/olmoearth_pretrain/model.py
@@ -11,10 +11,6 @@ from typing import Any
 import torch
 from einops import rearrange
 from olmoearth_pretrain_minimal import ModelID, load_model_from_id, load_model_from_path
-from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.nn.flexi_vit import (
-    Encoder,
-    TokensAndMasks,
-)
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.config import Config
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.constants import Modality
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.datatypes import (
@@ -659,20 +655,12 @@ class OlmoEarth(FeatureExtractor):
 
         with torch_context:
             # Currently we assume the provided model always returns a TokensAndMasks object.
-            tokens_and_masks: TokensAndMasks
-            if isinstance(self.model, Encoder):
-                # Encoder has a fast_pass argument to indicate mask is not needed.
-                tokens_and_masks = self.model(
-                    sample,
-                    fast_pass=not missing_tokens,
-                    patch_size=self.patch_size,
-                    **self.forward_kwargs,
-                )["tokens_and_masks"]
-            else:
-                # Other models like STEncoder do not have this option supported.
-                tokens_and_masks = self.model(
-                    sample, patch_size=self.patch_size, **self.forward_kwargs
-                )["tokens_and_masks"]
+            tokens_and_masks = self.model(
+                sample,
+                fast_pass=not missing_tokens,
+                patch_size=self.patch_size,
+                **self.forward_kwargs,
+            )["tokens_and_masks"]
 
         # Apply temporal/modality pooling so we just have one feature per patch.
         features = []

--- a/rslearn/models/olmoearth_pretrain/optimizer.py
+++ b/rslearn/models/olmoearth_pretrain/optimizer.py
@@ -51,6 +51,9 @@ class LayerDecayAdamW(OptimizerFactory):
     base_lr * layer_decay_rate ** (num_layers - i). Includes all params
     (even frozen ones) so it composes with SimpleFreeze.
 
+    num_layers should be set based on the model size (12 for tiny and base,
+    4 for nano).
+
     encoder_prefix: path from the LightningModule root to the OlmoEarth module,
         typically "model.encoder.0" when OlmoEarth is the first encoder in
         MultiTaskModel.
@@ -69,7 +72,21 @@ class LayerDecayAdamW(OptimizerFactory):
         groups: dict[int, list] = defaultdict(list)
         for name, param in lm.named_parameters():
             layer_id = get_layer_id(name, self.num_layers, self.encoder_prefix)
+            logger.debug("param %s -> layer_id %d", name, layer_id)
+            if layer_id > self.num_layers:
+                raise ValueError(
+                    f"param {name!r} mapped to layer_id={layer_id} "
+                    f"which exceeds num_layers={self.num_layers}"
+                )
             groups[layer_id].append(param)
+
+        expected = set(range(self.num_layers + 1))
+        missing = expected - groups.keys()
+        if missing:
+            raise ValueError(
+                f"layer decay expected layers 0..{self.num_layers} but "
+                f"missing layers: {sorted(missing)}"
+            )
 
         param_groups = []
         for layer_id in sorted(groups.keys()):

--- a/rslearn/models/olmoearth_pretrain/optimizer.py
+++ b/rslearn/models/olmoearth_pretrain/optimizer.py
@@ -1,0 +1,127 @@
+"""Layer-wise learning rate decay for OlmoEarth fine-tuning."""
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+
+import lightning as L
+import torch
+import torch.optim
+from lightning.pytorch import Callback, LightningModule, Trainer
+from torch.optim import Optimizer
+
+from rslearn.log_utils import get_logger
+from rslearn.train.optimizer import OptimizerFactory
+
+logger = get_logger(__name__)
+
+ENCODER_PREFIX = "model.encoder.0"
+
+
+def get_layer_id(
+    name: str, num_layers: int, encoder_prefix: str = ENCODER_PREFIX
+) -> int:
+    """Map a parameter name to its layer index for LR scaling.
+
+    encoder_prefix should be the path from the LightningModule root to the
+    OlmoEarth module (the FeatureExtractor in MultiTaskModel.encoder). OlmoEarth
+    stores the actual Encoder at `self.model`, so parameter paths under the prefix
+    look like ``<prefix>.model.blocks.3.attn.qkv.weight``.
+
+    Typically ``"model.encoder.0"`` when OlmoEarth is the first encoder in
+    MultiTaskModel.
+
+    Returns 0..num_layers-1 for encoder blocks, 0 for patch_embeddings,
+    and num_layers for everything else (norm, decoders = full LR).
+    """
+    if not name.startswith(encoder_prefix):
+        return num_layers
+    relative = name[len(encoder_prefix) + 1 :]
+    if relative.startswith("model.blocks."):
+        return int(relative.split(".")[2])
+    if relative.startswith("model.patch_embeddings"):
+        return 0
+    return num_layers
+
+
+@dataclass
+class LayerDecayAdamW(OptimizerFactory):
+    """AdamW with per-layer learning rate decay for OlmoEarth.
+
+    Creates one param group per encoder depth level. LR for layer i is
+    base_lr * layer_decay_rate ** (num_layers - i). Includes all params
+    (even frozen ones) so it composes with SimpleFreeze.
+
+    encoder_prefix: path from the LightningModule root to the OlmoEarth module,
+        typically "model.encoder.0" when OlmoEarth is the first encoder in
+        MultiTaskModel.
+    """
+
+    lr: float = 0.001
+    betas: tuple[float, float] = (0.9, 0.999)
+    eps: float | None = None
+    weight_decay: float | None = None
+    layer_decay_rate: float = 0.65
+    num_layers: int = 12
+    encoder_prefix: str = ENCODER_PREFIX
+
+    def build(self, lm: L.LightningModule) -> Optimizer:
+        """Build AdamW with per-layer param groups."""
+        groups: dict[int, list] = defaultdict(list)
+        for name, param in lm.named_parameters():
+            layer_id = get_layer_id(name, self.num_layers, self.encoder_prefix)
+            groups[layer_id].append(param)
+
+        param_groups = []
+        for layer_id in sorted(groups.keys()):
+            scale = self.layer_decay_rate ** (self.num_layers - layer_id)
+            lr = self.lr * scale
+            param_groups.append({"params": groups[layer_id], "lr": lr})
+            logger.info(
+                f"layer_decay group layer={layer_id} lr={lr:.2e} "
+                f"params={len(groups[layer_id])}"
+            )
+
+        exclude = {"lr", "layer_decay_rate", "num_layers", "encoder_prefix"}
+        adamw_kwargs = {
+            k: v for k, v in asdict(self).items() if v is not None and k not in exclude
+        }
+        return torch.optim.AdamW(param_groups, **adamw_kwargs)
+
+
+class SimpleFreeze(Callback):
+    """Freeze a module until a given epoch, then unfreeze.
+
+    Unlike BaseFinetuning/FreezeUnfreeze, this does NOT manipulate optimizer
+    param groups. It only toggles requires_grad. Designed to compose with
+    LayerDecayAdamW which already includes all params in the optimizer.
+    """
+
+    def __init__(
+        self,
+        module_selector: list[str | int],
+        unfreeze_at_epoch: int,
+    ) -> None:
+        """Create a new SimpleFreeze.
+
+        Args:
+            module_selector: the selector that identifies the model component to freeze.
+                See FreezeUnfreeze.
+            unfreeze_at_epoch: unfreeze the component at the start of this epoch.
+        """
+        super().__init__()
+        self.module_selector = module_selector
+        self.unfreeze_at_epoch = unfreeze_at_epoch
+
+    def _get_target_module(self, pl_module: LightningModule) -> torch.nn.Module:
+        target: torch.nn.Module = pl_module
+        for k in self.module_selector:
+            target = target[k] if isinstance(k, int) else getattr(target, k)
+        return target
+
+    def on_train_epoch_start(
+        self, trainer: Trainer, pl_module: LightningModule
+    ) -> None:
+        """Toggle requires_grad based on current epoch."""
+        freeze = trainer.current_epoch < self.unfreeze_at_epoch
+        for p in self._get_target_module(pl_module).parameters():
+            p.requires_grad = not freeze

--- a/tests/unit/models/olmoearth_pretrain/test_optimizer.py
+++ b/tests/unit/models/olmoearth_pretrain/test_optimizer.py
@@ -72,6 +72,18 @@ class TestLayerDecayAdamW:
         assert lrs[0] == pytest.approx(base_lr * decay**num_blocks, rel=1e-6)
         assert lrs[-1] == pytest.approx(base_lr, rel=1e-6)
 
+    def test_raises_when_num_layers_exceeds_model(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+
+        factory = LayerDecayAdamW(
+            lr=0.01,
+            layer_decay_rate=0.5,
+            num_layers=12,
+            encoder_prefix=ENCODER_PREFIX,
+        )
+        with pytest.raises(ValueError, match="missing layers"):
+            factory.build(lm)
+
     def test_includes_frozen_params(self) -> None:
         lm = FakeLightningModule(num_blocks=4)
         for p in lm.model.encoder[0].model.blocks[0].parameters():

--- a/tests/unit/models/olmoearth_pretrain/test_optimizer.py
+++ b/tests/unit/models/olmoearth_pretrain/test_optimizer.py
@@ -1,0 +1,168 @@
+"""Tests for LayerDecayAdamW and SimpleFreeze."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch.nn as nn
+
+from rslearn.models.olmoearth_pretrain.optimizer import (
+    ENCODER_PREFIX,
+    LayerDecayAdamW,
+    SimpleFreeze,
+)
+
+# ----------------------------- Helpers ------------------------------------ #
+
+
+class FakeEncoder(nn.Module):
+    """Mimics the OlmoEarth encoder structure with blocks + patch_embeddings + norm."""
+
+    def __init__(self, num_blocks: int = 4, dim: int = 8) -> None:
+        super().__init__()
+        self.patch_embeddings = nn.Linear(dim, dim)
+        self.blocks = nn.ModuleList([nn.Linear(dim, dim) for _ in range(num_blocks)])
+        self.norm = nn.LayerNorm(dim)
+
+
+class FakeOlmoEarth(nn.Module):
+    def __init__(self, num_blocks: int = 4) -> None:
+        super().__init__()
+        self.model = FakeEncoder(num_blocks=num_blocks)
+
+
+class FakeMultiTaskModel(nn.Module):
+    def __init__(self, num_blocks: int = 4) -> None:
+        super().__init__()
+        self.encoder = nn.ModuleList([FakeOlmoEarth(num_blocks=num_blocks)])
+        self.decoders = nn.ModuleDict({"head": nn.Linear(8, 2)})
+
+
+class FakeLightningModule(nn.Module):
+    """Minimal stand-in for RslearnLightningModule."""
+
+    def __init__(self, num_blocks: int = 4) -> None:
+        super().__init__()
+        self.model = FakeMultiTaskModel(num_blocks=num_blocks)
+
+
+# ----------------------------- LayerDecayAdamW ---------------------------- #
+
+
+class TestLayerDecayAdamW:
+    def test_creates_correct_param_groups(self) -> None:
+        num_blocks = 4
+        decay = 0.5
+        base_lr = 0.01
+        lm = FakeLightningModule(num_blocks=num_blocks)
+
+        factory = LayerDecayAdamW(
+            lr=base_lr,
+            layer_decay_rate=decay,
+            num_layers=num_blocks,
+            encoder_prefix=ENCODER_PREFIX,
+        )
+        optimizer = factory.build(lm)
+
+        all_param_ids = {id(p) for p in lm.parameters()}
+        tracked_ids = {id(p) for g in optimizer.param_groups for p in g["params"]}
+        assert all_param_ids == tracked_ids, "All params must be in the optimizer"
+
+        lrs = [g["lr"] for g in optimizer.param_groups]
+        assert lrs[0] < lrs[-1], "Early layers should have lower LR than decoder"
+        assert lrs[0] == pytest.approx(base_lr * decay**num_blocks, rel=1e-6)
+        assert lrs[-1] == pytest.approx(base_lr, rel=1e-6)
+
+    def test_includes_frozen_params(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+        for p in lm.model.encoder[0].model.blocks[0].parameters():
+            p.requires_grad = False
+
+        factory = LayerDecayAdamW(
+            lr=0.01,
+            layer_decay_rate=0.5,
+            num_layers=4,
+            encoder_prefix=ENCODER_PREFIX,
+        )
+        optimizer = factory.build(lm)
+
+        all_param_ids = {id(p) for p in lm.parameters()}
+        tracked_ids = {id(p) for g in optimizer.param_groups for p in g["params"]}
+        assert all_param_ids == tracked_ids, (
+            "Frozen params must still be in the optimizer for SimpleFreeze compatibility"
+        )
+
+
+# ----------------------------- SimpleFreeze ------------------------------- #
+
+
+class TestSimpleFreeze:
+    def _make_trainer(self, epoch: int) -> MagicMock:
+        trainer = MagicMock()
+        trainer.current_epoch = epoch
+        return trainer
+
+    def test_freezes_before_unfreeze_epoch(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+        cb = SimpleFreeze(module_selector=["model", "encoder"], unfreeze_at_epoch=5)
+
+        cb.on_train_epoch_start(self._make_trainer(0), lm)
+
+        encoder = lm.model.encoder
+        assert all(not p.requires_grad for p in encoder.parameters())
+
+    def test_unfreezes_at_epoch(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+        cb = SimpleFreeze(module_selector=["model", "encoder"], unfreeze_at_epoch=5)
+
+        cb.on_train_epoch_start(self._make_trainer(4), lm)
+        assert all(not p.requires_grad for p in lm.model.encoder.parameters())
+
+        cb.on_train_epoch_start(self._make_trainer(5), lm)
+        assert all(p.requires_grad for p in lm.model.encoder.parameters())
+
+    def test_stays_unfrozen_after_epoch(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+        cb = SimpleFreeze(module_selector=["model", "encoder"], unfreeze_at_epoch=5)
+
+        cb.on_train_epoch_start(self._make_trainer(10), lm)
+        assert all(p.requires_grad for p in lm.model.encoder.parameters())
+
+    def test_does_not_affect_other_modules(self) -> None:
+        lm = FakeLightningModule(num_blocks=4)
+        cb = SimpleFreeze(module_selector=["model", "encoder"], unfreeze_at_epoch=5)
+
+        cb.on_train_epoch_start(self._make_trainer(0), lm)
+
+        assert all(p.requires_grad for p in lm.model.decoders.parameters()), (
+            "Decoder params should remain trainable"
+        )
+
+    def test_composes_with_layer_decay_adamw(self) -> None:
+        """Verify that SimpleFreeze + LayerDecayAdamW work together."""
+        num_blocks = 4
+        lm = FakeLightningModule(num_blocks=num_blocks)
+        cb = SimpleFreeze(module_selector=["model", "encoder"], unfreeze_at_epoch=2)
+
+        factory = LayerDecayAdamW(
+            lr=0.01,
+            layer_decay_rate=0.5,
+            num_layers=num_blocks,
+            encoder_prefix=ENCODER_PREFIX,
+        )
+
+        cb.on_train_epoch_start(self._make_trainer(0), lm)
+        optimizer = factory.build(lm)
+
+        all_param_ids = {id(p) for p in lm.parameters()}
+        tracked_ids = {id(p) for g in optimizer.param_groups for p in g["params"]}
+        assert all_param_ids == tracked_ids
+
+        encoder = lm.model.encoder
+        assert all(not p.requires_grad for p in encoder.parameters())
+
+        num_groups_before = len(optimizer.param_groups)
+        cb.on_train_epoch_start(self._make_trainer(2), lm)
+        assert all(p.requires_grad for p in encoder.parameters())
+        assert len(optimizer.param_groups) == num_groups_before, (
+            "Param groups should not change on unfreeze"
+        )


### PR DESCRIPTION
This is implemented as a new optimizer. It is OlmoEarth-specific since it needs to know the parameter names in different layers; we could make a general-purpose one in the future if we want.

FreezeUnfreeze doesn't mesh well with the new parameter groups used by LayerDecayAdamW, so this also adds SimpleFreeze that doesn't change the parameter groups, instead it just toggles requires_grad off and back on.

The suggested approach is to use LayerDecayAdamW with default parameters (but setting encoder_prefix correctly) and NOT to do any freezing. This improves performance compared to our previous recipe (i.e., freeze for 20 epochs, then unfreeze while setting backbone learning rate to 1/10 of the head learning rate).

I also simplified model.py since STModel will soon accept the fast_pass option (it just ignores it).