### PR TITLE
[Enhancement] CHELSADaily to support bounding box filtering for item geometry and ingestion

### DIFF
--- a/docs/data_sources/chelsa_CHELSADaily.md
+++ b/docs/data_sources/chelsa_CHELSADaily.md
@@ -1,11 +1,11 @@
 ## rslearn.data_sources.chelsa.CHELSADaily
 
 CHELSA-daily is a global (~1km) climate dataset with one GeoTIFF per day and
-variable.
+variable. See the [official CHELSA-daily dataset page](https://www.chelsa-climate.org/datasets/chelsa_daily).
 
 This data source currently targets:
 - URL base: `https://os.unil.cloud.switch.ch/chelsa02/chelsa`
-- Dataset path: `{extent}/daily/{variable}/{year}/CHELSA_{variable}_{dd}_{mm}_{yyyy}_V.2.1.tif`
+- Dataset path: `global/daily/{variable}/{year}/CHELSA_{variable}_{dd}_{mm}_{yyyy}_V.2.1.tif`
 - Default time range: 1979-01-01 to 2025-08-29 (inclusive)
 
 Use `query_config.space_mode = SINGLE_COMPOSITE` so all matching daily items are
@@ -22,9 +22,6 @@ returned in one group.
     // switches URL variable by year (before 2020 -> "pr", after 2020 -> "prec",
     // overlap year 2020 preserves your requested alias).
     "band_names": ["tas", "pr"],
-
-    // URL path extent, usually "global".
-    "extent": "global",
 
     // Optional dataset bounds (inclusive). Can be date or YYYY-MM-DD string.
     // Tighten this to your actual window time range to avoid preparing extra days.
@@ -46,9 +43,9 @@ returned in one group.
 }
 ```
 
-`extent` is the CHELSA URL path segment, not a spatial filter. For regional work,
-keep `extent: "global"` and set `bounds` to the area of interest. If `bounds` is
-omitted, ingestion stores the full global source GeoTIFF for every matched day.
+CHELSA-daily is distributed as global GeoTIFFs. For regional work, set `bounds`
+to the area of interest. If `bounds` is omitted, ingestion stores the full global
+source GeoTIFF for every matched day.
 
 ### Precipitation Alias Handling
 

--- a/docs/data_sources/chelsa_CHELSADaily.md
+++ b/docs/data_sources/chelsa_CHELSADaily.md
@@ -27,8 +27,15 @@ returned in one group.
     "extent": "global",
 
     // Optional dataset bounds (inclusive). Can be date or YYYY-MM-DD string.
-    "start_date": "1979-01-01",
+    // Tighten this to your actual window time range to avoid preparing extra days.
+    "start_date": "2017-01-01",
     "end_date": "2025-08-29",
+
+    // Optional AOI as [min_lon, min_lat, max_lon, max_lat].
+    // With ingest=true this clips each daily GeoTIFF before storing it in the
+    // tile store, avoiding explicit full-global downloads/re-encoding for local
+    // projects.
+    "bounds": [-8.7, 49.8, 2.1, 60.9],
 
     // Optional override for file naming version suffix.
     "version": "V.2.1"
@@ -38,6 +45,10 @@ returned in one group.
   }
 }
 ```
+
+`extent` is the CHELSA URL path segment, not a spatial filter. For regional work,
+keep `extent: "global"` and set `bounds` to the area of interest. If `bounds` is
+omitted, ingestion stores the full global source GeoTIFF for every matched day.
 
 ### Precipitation Alias Handling
 

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -182,7 +182,9 @@ class CHELSADaily(
 
         min_lon, min_lat, max_lon, max_lat = [float(v) for v in bounds]
         if min_lon >= max_lon or min_lat >= max_lat:
-            raise ValueError("bounds must satisfy min_lon < max_lon and min_lat < max_lat")
+            raise ValueError(
+                "bounds must satisfy min_lon < max_lon and min_lat < max_lat"
+            )
         if min_lon < -180 or max_lon > 180 or min_lat < -90 or max_lat > 90:
             raise ValueError("bounds must be within WGS84 longitude/latitude limits")
         return (min_lon, min_lat, max_lon, max_lat)

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -108,7 +108,7 @@ class CHELSADaily(
         band_names: list[str] | None = None,
         start_date: date | str = DEFAULT_START_DATE,
         end_date: date | str = DEFAULT_END_DATE,
-        bounds: list[float] | None = None,
+        bounds: tuple[float, float, float, float] | None = None,
         base_url: str = BASE_URL,
         version: str = DEFAULT_VERSION,
         timeout: timedelta = timedelta(seconds=60),
@@ -121,7 +121,7 @@ class CHELSADaily(
                 context.layer_config is present, uses the unique bands from the layer.
             start_date: earliest available date (inclusive).
             end_date: latest available date (inclusive).
-            bounds: optional bounding box as [min_lon, min_lat, max_lon, max_lat].
+            bounds: optional bounding box as (min_lon, min_lat, max_lon, max_lat).
                 If specified, items and ingested rasters are clipped to this AOI.
                 If omitted, the whole source GeoTIFF is ingested.
             base_url: CHELSA base URL.
@@ -132,7 +132,7 @@ class CHELSADaily(
         self.base_url = base_url.rstrip("/")
         self.version = version
         self.timeout = timeout
-        self.bounds = self._parse_bounds(bounds)
+        self.bounds = bounds
 
         self.start_date = self._parse_date(start_date)
         self.end_date = self._parse_date(end_date)
@@ -167,24 +167,6 @@ class CHELSADaily(
         if isinstance(value, date):
             return value
         return date.fromisoformat(value)
-
-    @staticmethod
-    def _parse_bounds(
-        bounds: list[float] | None,
-    ) -> tuple[float, float, float, float] | None:
-        if bounds is None:
-            return None
-        if len(bounds) != 4:
-            raise ValueError("bounds must be [min_lon, min_lat, max_lon, max_lat]")
-
-        min_lon, min_lat, max_lon, max_lat = [float(v) for v in bounds]
-        if min_lon >= max_lon or min_lat >= max_lat:
-            raise ValueError(
-                "bounds must satisfy min_lon < max_lon and min_lat < max_lat"
-            )
-        if min_lon < -180 or max_lon > 180 or min_lat < -90 or max_lat > 90:
-            raise ValueError("bounds must be within WGS84 longitude/latitude limits")
-        return (min_lon, min_lat, max_lon, max_lat)
 
     @staticmethod
     def _to_utc(t: datetime) -> datetime:

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -316,19 +316,6 @@ class CHELSADaily(
             matched_groups = match_candidate_items_to_window(
                 geometry, items, query_config
             )
-            if (
-                self.bounds is not None
-                and not matched_groups
-                and query_config.min_matches == 0
-            ):
-                # A window outside the configured CHELSA bounds is still a valid
-                # prepared window for this layer; it should produce the layer's
-                # expected output with nodata pixels. Returning no groups would
-                # leave nothing to materialize, making the layer look missing
-                # rather than empty.
-                matched_groups = [
-                    MatchedItemGroup(items=[], request_time_range=geometry.time_range)
-                ]
             groups.append(matched_groups)
 
         return groups

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -321,10 +321,11 @@ class CHELSADaily(
                 and not matched_groups
                 and query_config.min_matches == 0
             ):
-                # A bounded CHELSA source can legitimately have no items for a
-                # window outside the configured bounds. Return one empty group so
-                # materialization writes an empty/nodata raster instead of treating
-                # the layer as having no groups to materialize.
+                # A window outside the configured CHELSA bounds is still a valid
+                # prepared window for this layer; it should produce the layer's
+                # expected output with nodata pixels. Returning no groups would
+                # leave nothing to materialize, making the layer look missing
+                # rather than empty.
                 matched_groups = [
                     MatchedItemGroup(items=[], request_time_range=geometry.time_range)
                 ]

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -77,7 +77,7 @@ class CHELSADaily(
     """Data source for CHELSA-daily global climate rasters.
 
     URL pattern:
-    ``https://os.unil.cloud.switch.ch/chelsa02/chelsa/{extent}/daily/{variable}/{year}/CHELSA_{variable}_{day}_{month}_{year}_{version}.tif``
+    ``https://os.unil.cloud.switch.ch/chelsa02/chelsa/global/daily/{variable}/{year}/CHELSA_{variable}_{day}_{month}_{year}_{version}.tif``
     """
 
     BASE_URL = "https://os.unil.cloud.switch.ch/chelsa02/chelsa"
@@ -106,7 +106,6 @@ class CHELSADaily(
     def __init__(
         self,
         band_names: list[str] | None = None,
-        extent: str = "global",
         start_date: date | str = DEFAULT_START_DATE,
         end_date: date | str = DEFAULT_END_DATE,
         bounds: list[float] | None = None,
@@ -120,7 +119,6 @@ class CHELSADaily(
         Args:
             band_names: CHELSA variable names (e.g. "tas", "pr"). If omitted and
                 context.layer_config is present, uses the unique bands from the layer.
-            extent: CHELSA extent in URL path, usually "global".
             start_date: earliest available date (inclusive).
             end_date: latest available date (inclusive).
             bounds: optional bounding box as [min_lon, min_lat, max_lon, max_lat].
@@ -131,7 +129,6 @@ class CHELSADaily(
             timeout: HTTP timeout for ingest downloads.
             context: data source context.
         """
-        self.extent = extent
         self.base_url = base_url.rstrip("/")
         self.version = version
         self.timeout = timeout
@@ -452,6 +449,6 @@ class CHELSADaily(
         resolved_variable = self._resolve_variable_for_date(asset_key, d)
 
         return (
-            f"{self.base_url}/{self.extent}/daily/{resolved_variable}/{yyyy}/"
+            f"{self.base_url}/global/daily/{resolved_variable}/{yyyy}/"
             f"CHELSA_{resolved_variable}_{dd}_{mm}_{yyyy}_{self.version}.tif"
         )

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -321,6 +321,10 @@ class CHELSADaily(
                 and not matched_groups
                 and query_config.min_matches == 0
             ):
+                # A bounded CHELSA source can legitimately have no items for a
+                # window outside the configured bounds. Return one empty group so
+                # materialization writes an empty/nodata raster instead of treating
+                # the layer as having no groups to materialize.
                 matched_groups = [
                     MatchedItemGroup(items=[], request_time_range=geometry.time_range)
                 ]

--- a/rslearn/data_sources/chelsa.py
+++ b/rslearn/data_sources/chelsa.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import math
 import os
 import tempfile
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+import rasterio
+import rasterio.warp
+import rasterio.windows
 import requests
+import shapely
+from rasterio.enums import Resampling
 from typing_extensions import override
 from upath import UPath
 
 from rslearn.config import QueryConfig, SpaceMode
+from rslearn.const import WGS84_PROJECTION
 from rslearn.data_sources.data_source import (
     DataSourceContext,
     Item,
@@ -29,6 +36,8 @@ from rslearn.utils.geometry import (
     get_global_geometry,
     get_global_raster_bounds,
 )
+from rslearn.utils.raster_array import RasterArray, RasterMetadata
+from rslearn.utils.raster_format import get_raster_projection_and_bounds
 
 
 class CHELSADailyItem(Item):
@@ -100,6 +109,7 @@ class CHELSADaily(
         extent: str = "global",
         start_date: date | str = DEFAULT_START_DATE,
         end_date: date | str = DEFAULT_END_DATE,
+        bounds: list[float] | None = None,
         base_url: str = BASE_URL,
         version: str = DEFAULT_VERSION,
         timeout: timedelta = timedelta(seconds=60),
@@ -113,6 +123,9 @@ class CHELSADaily(
             extent: CHELSA extent in URL path, usually "global".
             start_date: earliest available date (inclusive).
             end_date: latest available date (inclusive).
+            bounds: optional bounding box as [min_lon, min_lat, max_lon, max_lat].
+                If specified, items and ingested rasters are clipped to this AOI.
+                If omitted, the whole source GeoTIFF is ingested.
             base_url: CHELSA base URL.
             version: filename version segment, e.g. "V.2.1".
             timeout: HTTP timeout for ingest downloads.
@@ -122,6 +135,7 @@ class CHELSADaily(
         self.base_url = base_url.rstrip("/")
         self.version = version
         self.timeout = timeout
+        self.bounds = self._parse_bounds(bounds)
 
         self.start_date = self._parse_date(start_date)
         self.end_date = self._parse_date(end_date)
@@ -158,6 +172,22 @@ class CHELSADaily(
         return date.fromisoformat(value)
 
     @staticmethod
+    def _parse_bounds(
+        bounds: list[float] | None,
+    ) -> tuple[float, float, float, float] | None:
+        if bounds is None:
+            return None
+        if len(bounds) != 4:
+            raise ValueError("bounds must be [min_lon, min_lat, max_lon, max_lat]")
+
+        min_lon, min_lat, max_lon, max_lat = [float(v) for v in bounds]
+        if min_lon >= max_lon or min_lat >= max_lat:
+            raise ValueError("bounds must satisfy min_lon < max_lon and min_lat < max_lat")
+        if min_lon < -180 or max_lon > 180 or min_lat < -90 or max_lat > 90:
+            raise ValueError("bounds must be within WGS84 longitude/latitude limits")
+        return (min_lon, min_lat, max_lon, max_lat)
+
+    @staticmethod
     def _to_utc(t: datetime) -> datetime:
         if t.tzinfo is None:
             return t.replace(tzinfo=UTC)
@@ -180,10 +210,59 @@ class CHELSADaily(
     def _build_item(self, item_date: date) -> CHELSADailyItem:
         start = datetime(item_date.year, item_date.month, item_date.day, tzinfo=UTC)
         end = start + timedelta(days=1)
+        time_range = (start, end)
+        if self.bounds is None:
+            geometry = get_global_geometry(time_range)
+        else:
+            geometry = STGeometry(
+                WGS84_PROJECTION,
+                shapely.box(*self.bounds),
+                time_range,
+            )
         return CHELSADailyItem(
             name=self._item_name_for_date(item_date),
-            geometry=get_global_geometry((start, end)),
+            geometry=geometry,
             item_date=item_date,
+        )
+
+    def _get_configured_bounds_projection_and_pixel_bounds(
+        self, asset_url: str
+    ) -> tuple[Projection, PixelBounds]:
+        """Get source-grid projection and pixel bounds for configured WGS84 bounds."""
+        if self.bounds is None:
+            raise ValueError("bounds must be configured")
+
+        with rasterio.open(asset_url) as src:
+            if src.crs is None:
+                raise ValueError(f"CHELSA source raster has no CRS: {asset_url}")
+
+            projection, full_pixel_bounds = get_raster_projection_and_bounds(src)
+            src_bounds = rasterio.warp.transform_bounds(
+                WGS84_PROJECTION.crs,
+                src.crs,
+                *self.bounds,
+                densify_pts=21,
+            )
+            window = rasterio.windows.from_bounds(*src_bounds, transform=src.transform)
+
+            col_start = max(0, math.floor(window.col_off))
+            row_start = max(0, math.floor(window.row_off))
+            col_stop = min(src.width, math.ceil(window.col_off + window.width))
+            row_stop = min(src.height, math.ceil(window.row_off + window.height))
+
+            if col_start >= col_stop or row_start >= row_stop:
+                raise ValueError(
+                    f"configured bounds {self.bounds} do not overlap CHELSA raster"
+                )
+
+        return (
+            projection,
+            (
+                full_pixel_bounds[0] + col_start,
+                full_pixel_bounds[1] + row_start,
+                full_pixel_bounds[0] + col_stop,
+                full_pixel_bounds[1] + row_stop,
+            ),
         )
 
     @classmethod
@@ -253,9 +332,18 @@ class CHELSADaily(
                 items.append(self._build_item(day_cursor.date()))
                 day_cursor += timedelta(days=1)
 
-            groups.append(
-                match_candidate_items_to_window(geometry, items, query_config)
+            matched_groups = match_candidate_items_to_window(
+                geometry, items, query_config
             )
+            if (
+                self.bounds is not None
+                and not matched_groups
+                and query_config.min_matches == 0
+            ):
+                matched_groups = [
+                    MatchedItemGroup(items=[], request_time_range=geometry.time_range)
+                ]
+            groups.append(matched_groups)
 
         return groups
 
@@ -300,6 +388,32 @@ class CHELSADaily(
                     continue
 
                 asset_url = self.get_asset_url(item, asset_key)
+
+                if self.bounds is not None:
+                    projection, pixel_bounds = (
+                        self._get_configured_bounds_projection_and_pixel_bounds(
+                            asset_url
+                        )
+                    )
+                    raw_data, src_nodata = self._read_raster_from_url(
+                        asset_url,
+                        projection,
+                        pixel_bounds,
+                        Resampling.nearest,
+                    )
+                    raster = RasterArray(
+                        chw_array=raw_data,
+                        time_range=item.geometry.time_range,
+                        metadata=RasterMetadata(nodata_value=src_nodata),
+                    )
+                    tile_store.write_raster(
+                        item,
+                        band_names,
+                        projection,
+                        pixel_bounds,
+                        raster,
+                    )
+                    continue
 
                 with tempfile.TemporaryDirectory() as tmp_dir:
                     local_fname = os.path.join(

--- a/tests/unit/data_sources/test_chelsa_daily.py
+++ b/tests/unit/data_sources/test_chelsa_daily.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,10 @@ def test_chelsa_daily_get_asset_url() -> None:
         "https://os.unil.cloud.switch.ch/chelsa02/chelsa/global/daily/tas/2023/"
         "CHELSA_tas_16_06_2023_V.2.1.tif"
     )
+
+
+def test_chelsa_daily_has_no_extent_init_arg() -> None:
+    assert "extent" not in inspect.signature(CHELSADaily.__init__).parameters
 
 
 def test_chelsa_daily_precipitation_alias_switches_for_pr_band() -> None:

--- a/tests/unit/data_sources/test_chelsa_daily.py
+++ b/tests/unit/data_sources/test_chelsa_daily.py
@@ -180,6 +180,44 @@ def test_chelsa_daily_item_serialization_roundtrip() -> None:
     assert restored.geometry.serialize() == item.geometry.serialize()
 
 
+def test_chelsa_daily_bounds_limit_item_geometry() -> None:
+    data_source = CHELSADaily(
+        band_names=["tas"],
+        bounds=[-8.0, 49.0, 2.0, 61.0],
+    )
+    item = data_source.get_item_by_name("chelsa_daily_20190907")
+
+    assert item.geometry.to_projection(WGS84_PROJECTION).shp.bounds == pytest.approx(
+        (-8.0, 49.0, 2.0, 61.0)
+    )
+
+
+def test_chelsa_daily_get_items_outside_bounds_returns_empty_group() -> None:
+    data_source = CHELSADaily(
+        band_names=["tas"],
+        bounds=[-8.0, 49.0, 2.0, 61.0],
+    )
+    time_range = (
+        datetime(2023, 6, 16, 0, tzinfo=UTC),
+        datetime(2023, 6, 17, 0, tzinfo=UTC),
+    )
+    geometry = STGeometry(
+        WGS84_PROJECTION,
+        shapely.box(10.0, 49.0, 11.0, 50.0),
+        time_range,
+    )
+
+    groups = data_source.get_items(
+        [geometry],
+        query_config=QueryConfig(space_mode=SpaceMode.SINGLE_COMPOSITE),
+    )
+
+    assert len(groups) == 1
+    assert len(groups[0]) == 1
+    assert groups[0][0].items == []
+    assert groups[0][0].request_time_range == geometry.time_range
+
+
 def test_chelsa_daily_get_raster_bounds_global_item_local_crs() -> None:
     data_source = CHELSADaily(band_names=["tas"])
     item = data_source.get_item_by_name("chelsa_daily_20190907")
@@ -237,6 +275,57 @@ def test_chelsa_daily_read_raster_window_from_tiles_local_crs(
     assert raster is not None
     assert raster.array.shape == (1, 1, 96, 96)
     assert np.all(raster.array == 1.0)
+
+
+def test_chelsa_daily_ingest_with_bounds_writes_spatial_subset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    src_transform = from_origin(0.0, 2.0, 0.5, 0.5)
+    src_crs = CRS.from_epsg(4326)
+    arr = np.arange(16, dtype=np.uint16).reshape(1, 4, 4)
+    src_path = tmp_path / "chelsa_source.tif"
+    with rasterio.open(
+        src_path,
+        "w",
+        driver="GTiff",
+        width=arr.shape[2],
+        height=arr.shape[1],
+        count=1,
+        dtype="uint16",
+        crs=src_crs,
+        transform=src_transform,
+        nodata=65535,
+    ) as dst:
+        dst.write(arr)
+
+    data_source = CHELSADaily(
+        band_names=["tas"],
+        start_date="2020-03-28",
+        end_date="2020-03-28",
+        bounds=[0.5, 0.5, 1.5, 1.5],
+    )
+    item = data_source.get_item_by_name("chelsa_daily_20200328")
+    monkeypatch.setattr(
+        data_source, "get_asset_url", lambda item, asset_key: str(src_path)
+    )
+    monkeypatch.setattr(
+        "rslearn.data_sources.chelsa.requests.get",
+        lambda *args, **kwargs: pytest.fail("bounded ingest should not download file"),
+    )
+
+    tile_store = DefaultTileStore(convert_rasters_to_cogs=True)
+    tile_store.set_dataset_path(UPath(tmp_path / "ds"))
+    layer_store = TileStoreWithLayer(tile_store, "chelsa")
+    data_source.ingest(layer_store, [item], geometries=[[]])
+
+    stored_path = tile_store._get_raster_fname("chelsa", item.name, ["tas"])
+    with rasterio.open(stored_path) as stored:
+        assert stored.width == 2
+        assert stored.height == 2
+        assert stored.transform == from_origin(0.5, 1.5, 0.5, 0.5)
+        assert stored.nodata == 65535
+        np.testing.assert_array_equal(stored.read(), arr[:, 1:3, 1:3])
 
 
 def test_chelsa_daily_ingest_preserves_nodata_and_temporal_reducers_ignore_it(

--- a/tests/unit/data_sources/test_chelsa_daily.py
+++ b/tests/unit/data_sources/test_chelsa_daily.py
@@ -1,4 +1,3 @@
-import inspect
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -40,10 +39,6 @@ def test_chelsa_daily_get_asset_url() -> None:
         "https://os.unil.cloud.switch.ch/chelsa02/chelsa/global/daily/tas/2023/"
         "CHELSA_tas_16_06_2023_V.2.1.tif"
     )
-
-
-def test_chelsa_daily_has_no_extent_init_arg() -> None:
-    assert "extent" not in inspect.signature(CHELSADaily.__init__).parameters
 
 
 def test_chelsa_daily_precipitation_alias_switches_for_pr_band() -> None:

--- a/tests/unit/data_sources/test_chelsa_daily.py
+++ b/tests/unit/data_sources/test_chelsa_daily.py
@@ -188,7 +188,7 @@ def test_chelsa_daily_item_serialization_roundtrip() -> None:
 def test_chelsa_daily_bounds_limit_item_geometry() -> None:
     data_source = CHELSADaily(
         band_names=["tas"],
-        bounds=[-8.0, 49.0, 2.0, 61.0],
+        bounds=(-8.0, 49.0, 2.0, 61.0),
     )
     item = data_source.get_item_by_name("chelsa_daily_20190907")
 
@@ -200,7 +200,7 @@ def test_chelsa_daily_bounds_limit_item_geometry() -> None:
 def test_chelsa_daily_get_items_outside_bounds_returns_empty_group() -> None:
     data_source = CHELSADaily(
         band_names=["tas"],
-        bounds=[-8.0, 49.0, 2.0, 61.0],
+        bounds=(-8.0, 49.0, 2.0, 61.0),
     )
     time_range = (
         datetime(2023, 6, 16, 0, tzinfo=UTC),
@@ -308,7 +308,7 @@ def test_chelsa_daily_ingest_with_bounds_writes_spatial_subset(
         band_names=["tas"],
         start_date="2020-03-28",
         end_date="2020-03-28",
-        bounds=[0.5, 0.5, 1.5, 1.5],
+        bounds=(0.5, 0.5, 1.5, 1.5),
     )
     item = data_source.get_item_by_name("chelsa_daily_20200328")
     monkeypatch.setattr(

--- a/tests/unit/data_sources/test_chelsa_daily.py
+++ b/tests/unit/data_sources/test_chelsa_daily.py
@@ -192,7 +192,7 @@ def test_chelsa_daily_bounds_limit_item_geometry() -> None:
     )
 
 
-def test_chelsa_daily_get_items_outside_bounds_returns_empty_group() -> None:
+def test_chelsa_daily_get_items_outside_bounds_returns_no_groups() -> None:
     data_source = CHELSADaily(
         band_names=["tas"],
         bounds=(-8.0, 49.0, 2.0, 61.0),
@@ -213,9 +213,7 @@ def test_chelsa_daily_get_items_outside_bounds_returns_empty_group() -> None:
     )
 
     assert len(groups) == 1
-    assert len(groups[0]) == 1
-    assert groups[0][0].items == []
-    assert groups[0][0].request_time_range == geometry.time_range
+    assert groups[0] == []
 
 
 def test_chelsa_daily_get_raster_bounds_global_item_local_crs() -> None:


### PR DESCRIPTION
Address https://github.com/allenai/rslearn/issues/635

For small AOI verified speedup using the introduced `bounds` arg:

[bounded] 0.70s, 921.0 B written
[full] 32.99s, 180.0 MiB written
bounded speedup: 46.9x faster; stored output: 204930.3x smaller

For a larger 45 window comparison, this PR speeds up chelsa by a factor of x2

## Summary

- Added `bounds` support to CHELSADaily for AOI-limited ingest from global CHELSA daily GeoTIFFs.
- Removed the `extent` arg since this is the only data available currently; CHELSA daily URLs now always use the global path.
- Updated CHELSA docs with the official dataset link, bounds guidance, and no extent config.
- Added unit coverage for bounded item geometry, outside-bounds empty groups, bounded ingest cropping, and absence of the extent arg.
