### PR TITLE
[New Data Source] Add EarthDaily Sentinel-2 EDA cloud mask data source and documentation

### DIFF
--- a/docs/DataSources.md
+++ b/docs/DataSources.md
@@ -22,6 +22,7 @@ detailed page with configuration options and available bands. See
 | [copernicus.Sentinel2](data_sources/copernicus.md#rslearndatasourcescopernicussentinel2) | ESA Copernicus OData API | L1C and L2A |
 | [earthdaily.Sentinel2L2A](data_sources/earthdaily_Sentinel2L2A.md) | EarthDaily | PC-compatible L2A (`sentinel-2-l2a`), same band names as `planetary_computer.Sentinel2` |
 | [earthdaily.Sentinel2C1L2A](data_sources/earthdaily_Sentinel2C1L2A.md) | EarthDaily | Collection 1 L2A (`sentinel-2-c1-l2a`), scale/offset reflectance |
+| [earthdaily.Sentinel2EDACloudMask](data_sources/earthdaily_Sentinel2EDACloudMask.md) | EarthDaily | Sentinel-2 EDA cloud mask (`sentinel-2-eda-cloud-mask`), categorical cloud-mask band |
 | [gcp_public_data.Sentinel2](data_sources/gcp_public_data_Sentinel2.md) | Google Cloud Storage | L1C scenes |
 
 #### Sentinel-1

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -28,3 +28,6 @@ Examples
   on a location and time range of interest.
 - [EarthDailySentinel2Biophysical](examples/EarthDailySentinel2Biophysical.md): align
   EarthDaily Sentinel-2 scenes with derived LAI/FAPAR/FCOVER products.
+- [EarthDailyCloudMaskClearCover](examples/EarthDailyCloudMaskClearCover.md): rank
+  EarthDaily Sentinel-2 EDA cloud masks by AOI clear cover, then retrieve the related
+  Sentinel-2 L2A scene.

--- a/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
+++ b/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
@@ -9,6 +9,10 @@ The source exposes the first band of the `cloud-mask` STAC asset as a single-ban
 categorical raster. Use `resampling_method: "nearest"` for this layer to preserve
 class values.
 
+For a workflow that ranks cloud-mask items by AOI clear cover and then retrieves the
+related Sentinel-2 L2A item, see
+[EarthDaily Cloud-Mask Clear-Cover Selection](../examples/EarthDailyCloudMaskClearCover.md).
+
 ### Configuration
 
 ```jsonc

--- a/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
+++ b/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
@@ -5,9 +5,9 @@ platform using the `sentinel-2-eda-cloud-mask` collection.
 
 See [EarthDaily Setup](earthdaily.md) for required dependency/credentials.
 
-The source exposes the first band of the `cloud-mask` STAC asset as a single-band
-categorical raster. Use `resampling_method: "nearest"` for this layer to preserve
-class values.
+By default, the source exposes both thematic bands from the `cloud-mask` STAC asset:
+`cloud-mask` and `cirrus-mask`. Use `resampling_method: "nearest"` for this layer to
+preserve class values.
 
 For a workflow that ranks cloud-mask items by AOI clear cover and then retrieves the
 related Sentinel-2 L2A item, see
@@ -23,6 +23,9 @@ related Sentinel-2 L2A item, see
     // If null and the layer config is available, assets are inferred from the layer's
     // requested band names. The only supported asset is "cloud-mask".
     "assets": null,
+    // Optional: ordered rslearn names for bands to retain from the cloud-mask GeoTIFF.
+    // The first name maps to GeoTIFF band 1; the second maps to GeoTIFF band 2.
+    "band_names": ["cloud-mask", "cirrus-mask"],
     // Optional: maximum cloud cover (%) to filter items at search time. If set,
     // injects an `eo:cloud_cover` upper bound into the STAC query.
     "cloud_cover_max": null,
@@ -67,7 +70,7 @@ Example layer snippet:
 }
 ```
 
-### Available Band
+### Available Bands
 
 The `cloud-mask` band contains categorical cloud-mask values:
 
@@ -76,6 +79,15 @@ The `cloud-mask` band contains categorical cloud-mask values:
 - `2`: cloud
 - `3`: cloud shadow
 - `4`: thin cloud
+
+The `cirrus-mask` band contains categorical cirrus-mask values:
+
+- `0`: nodata
+- `1`: non-cirrus
+- `2`: cirrus
+
+If you only need the first band, request `["cloud-mask"]` in the layer band set or
+set `band_names: ["cloud-mask"]`.
 
 The STAC items include `eda:derived_from_collection_id` and
 `eda:derived_from_item_id` properties that identify the source Sentinel-2 item.

--- a/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
+++ b/docs/data_sources/earthdaily_Sentinel2EDACloudMask.md
@@ -1,0 +1,77 @@
+## rslearn.data_sources.earthdaily.Sentinel2EDACloudMask
+
+Sentinel-2 EDA cloud-mask data on the [EarthDaily](https://earthdaily.com/)
+platform using the `sentinel-2-eda-cloud-mask` collection.
+
+See [EarthDaily Setup](earthdaily.md) for required dependency/credentials.
+
+The source exposes the first band of the `cloud-mask` STAC asset as a single-band
+categorical raster. Use `resampling_method: "nearest"` for this layer to preserve
+class values.
+
+### Configuration
+
+```jsonc
+{
+  "class_path": "rslearn.data_sources.earthdaily.Sentinel2EDACloudMask",
+  "init_args": {
+    // Optional: EarthDaily STAC asset keys to fetch (default null).
+    // If null and the layer config is available, assets are inferred from the layer's
+    // requested band names. The only supported asset is "cloud-mask".
+    "assets": null,
+    // Optional: maximum cloud cover (%) to filter items at search time. If set,
+    // injects an `eo:cloud_cover` upper bound into the STAC query.
+    "cloud_cover_max": null,
+    // Maximum number of STAC items to fetch per window before rslearn grouping/matching.
+    "search_max_items": 500,
+    // Optional ordering of items before grouping (useful with SpaceMode.COMPOSITE +
+    // CompositingMethod.FIRST_VALID): "cloud_cover" (default), "datetime", or null.
+    "sort_items_by": "cloud_cover",
+    // Optional: STAC API `query` filter passed to searches.
+    "query": null,
+    // Optional: STAC item property to sort by before grouping/matching (default null).
+    // If set, it takes precedence over sort_items_by.
+    "sort_by": null,
+    // Whether to sort ascending when sort_by is set (default true).
+    "sort_ascending": true,
+    // Optional cache directory for cached item metadata.
+    "cache_dir": null,
+    // Timeout for HTTP asset downloads.
+    "timeout": "10s",
+    // Retry settings for EarthDaily API client requests (search/get item).
+    "max_retries": 3,
+    "retry_backoff_factor": 5.0
+  }
+}
+```
+
+Example layer snippet:
+
+```jsonc
+{
+  "type": "raster",
+  "band_sets": [{
+    "bands": ["cloud-mask"],
+    "dtype": "uint8",
+    "nodata_value": 0,
+    "zoom_offset": 0
+  }],
+  "resampling_method": "nearest",
+  "data_source": {
+    "class_path": "rslearn.data_sources.earthdaily.Sentinel2EDACloudMask"
+  }
+}
+```
+
+### Available Band
+
+The `cloud-mask` band contains categorical cloud-mask values:
+
+- `0`: nodata
+- `1`: clear
+- `2`: cloud
+- `3`: cloud shadow
+- `4`: thin cloud
+
+The STAC items include `eda:derived_from_collection_id` and
+`eda:derived_from_item_id` properties that identify the source Sentinel-2 item.

--- a/docs/examples/EarthDailyCloudMaskClearCover.md
+++ b/docs/examples/EarthDailyCloudMaskClearCover.md
@@ -1,0 +1,169 @@
+## EarthDaily Cloud-Mask Clear-Cover Selection
+
+This example shows how to integrate EarthDaily EDA cloud-mask ranking into the normal
+rslearn `prepare` → `ingest` → `materialize` workflow.
+
+The Sentinel-2 imagery and EDA cloud masks are separate EarthDaily STAC collections.
+Prepare both layers first, then run a small selection step that scores the prepared
+cloud-mask candidates over each window AOI. The script rewrites the prepared
+Sentinel-2 layer to the related L2A item with the highest clear cover. After that,
+normal rslearn ingest/materialize commands operate on the selected item.
+
+The workflow is:
+
+1. Configure a Sentinel-2 layer and a cloud-mask layer.
+2. Run `rslearn dataset prepare`.
+3. Score the prepared cloud-mask candidates and rewrite the Sentinel-2 prepared item
+   group to the clearest related image.
+4. Run `rslearn dataset ingest` if the selected layers use `ingest: true`.
+5. Run `rslearn dataset materialize`.
+
+The EDA cloud-mask class values are:
+
+- `0`: nodata
+- `1`: clear
+- `2`: cloud
+- `3`: cloud shadow
+- `4`: thin cloud
+
+### Layers
+
+Here is a representative dataset configuration snippet. The cloud-mask layer uses
+`INTERSECTS` and a higher `max_matches` so prepare keeps multiple candidate masks for
+the post-prepare selection step.
+
+```jsonc
+{
+  "layers": {
+    "sentinel2": {
+      "type": "raster",
+      "band_sets": [
+        {
+          "bands": ["B02", "B03", "B04", "B08"],
+          "dtype": "uint16",
+          "nodata_value": 0
+        }
+      ],
+      "resampling_method": "bilinear",
+      "data_source": {
+        "class_path": "rslearn.data_sources.earthdaily.Sentinel2L2A",
+        "init_args": {
+          "assets": ["B02", "B03", "B04", "B08"],
+          "harmonize": true
+        },
+        "query_config": {
+          "space_mode": "INTERSECTS",
+          "max_matches": 1
+        },
+        "ingest": false
+      }
+    },
+    "cloud_mask": {
+      "type": "raster",
+      "band_sets": [
+        {
+          "bands": ["cloud-mask"],
+          "dtype": "uint8",
+          "nodata_value": 0
+        }
+      ],
+      "resampling_method": "nearest",
+      "data_source": {
+        "class_path": "rslearn.data_sources.earthdaily.Sentinel2EDACloudMask",
+        "init_args": {
+          "assets": ["cloud-mask"],
+          "cloud_cover_max": 80,
+          "sort_items_by": "datetime"
+        },
+        "query_config": {
+          "space_mode": "INTERSECTS",
+          "max_matches": 20
+        },
+        "ingest": false
+      }
+    }
+  }
+}
+```
+
+This example uses `Sentinel2L2A` because the EDA cloud-mask products point to
+`sentinel-2-l2a` through `eda:derived_from_collection_id`.
+
+### Workflow
+
+First prepare the dataset normally:
+
+```bash
+rslearn dataset prepare --root ./dataset
+```
+
+At this point each window has prepared candidate groups for `cloud_mask`. Each
+candidate is a cloud-mask item intersecting the window and time range. Run the
+selection helper:
+
+```bash
+python docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py \
+  --root ./dataset \
+  --cloud-mask-layer cloud_mask \
+  --sentinel2-layer sentinel2 \
+  --dry-run
+```
+
+The script scores each prepared cloud-mask candidate over the exact rslearn window
+projection and bounds:
+
+```text
+clear_cover = count(cloud-mask == 1) / total_window_pixels
+valid_cover = count(cloud-mask != 0) / total_window_pixels
+```
+
+Candidates are sorted by `clear_cover`, then `valid_cover`, then raw clear pixel count.
+The script reads `eda:derived_from_collection_id` and `eda:derived_from_item_id` from
+the selected cloud-mask STAC item, fetches that related Sentinel-2 item, and rewrites
+the prepared `sentinel2` layer to contain only that selected item group.
+
+Run it without `--dry-run` to update the prepared window metadata:
+
+```bash
+python docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py \
+  --root ./dataset \
+  --cloud-mask-layer cloud_mask \
+  --sentinel2-layer sentinel2
+```
+
+By default the helper also rewrites the `cloud_mask` layer to the selected cloud-mask
+item, so materializing both layers yields the chosen Sentinel-2 image and the mask used
+to choose it. Add `--keep-cloud-mask-candidates` if you only want to rewrite the
+Sentinel-2 layer.
+
+If your layers use `ingest: true`, ingest after the selection step so rslearn only
+downloads the selected items:
+
+```bash
+rslearn dataset ingest --root ./dataset
+```
+
+Finally materialize:
+
+```bash
+rslearn dataset materialize --root ./dataset
+```
+
+### Selection Helper
+
+The helper script is available at
+[`docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py`](select_earthdaily_sentinel2_by_cloud_mask.py).
+
+Useful options:
+
+- `--min-clear-cover 0.8`: reject windows where the clearest candidate has less than
+  80% clear cover over the AOI.
+- `--groups` and `--windows`: restrict updates to specific prepared windows.
+- `--keep-cloud-mask-candidates`: leave the cloud-mask layer's prepared candidates
+  untouched and only rewrite the Sentinel-2 layer.
+- `--env-file .env`: load EarthDaily credentials from a dotenv file.
+
+The script expects each cloud-mask prepared group to contain one item, so configure the
+cloud-mask layer with `query_config.space_mode: "INTERSECTS"`. It validates that the
+selected cloud-mask item derives from the same EarthDaily collection used by the
+configured Sentinel-2 layer.

--- a/docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py
+++ b/docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py
@@ -1,0 +1,282 @@
+"""Select EarthDaily Sentinel-2 items using prepared EDA cloud-mask clear cover.
+
+Run this after ``rslearn dataset prepare`` and before ``rslearn dataset ingest`` or
+``rslearn dataset materialize``. It scores prepared cloud-mask candidates for each
+window, selects the clearest candidate over the window AOI, resolves the related
+Sentinel-2 L2A item from STAC metadata, and rewrites the prepared Sentinel-2 layer to
+that single selected item group.
+"""
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime
+
+from dotenv import load_dotenv
+from earthdaily import EDSClient, EDSConfig
+from rasterio.enums import Resampling
+from upath import UPath
+
+from rslearn.data_sources.earthdaily import Sentinel2EDACloudMask
+from rslearn.dataset import Dataset, Window, WindowLayerData
+
+
+@dataclass
+class ScoredCloudMask:
+    """Clear-cover score for a prepared cloud-mask item."""
+
+    serialized_group: list[dict]
+    group_time_range: tuple[datetime, datetime] | None
+    cloud_mask_item_name: str
+    source_collection: str
+    source_item_id: str
+    clear_cover: float
+    valid_cover: float
+    clear_pixels: int
+    valid_pixels: int
+    total_pixels: int
+
+
+def score_cloud_mask_item(
+    *,
+    cloud_mask_source: Sentinel2EDACloudMask,
+    cloud_mask_collection,
+    window: Window,
+    serialized_group: list[dict],
+    group_time_range: tuple[datetime, datetime] | None,
+) -> ScoredCloudMask:
+    """Score a prepared cloud-mask group over a window."""
+    if len(serialized_group) != 1:
+        raise ValueError(
+            "expected each cloud-mask candidate group to contain one item; configure "
+            "the cloud-mask layer with query_config.space_mode='INTERSECTS'"
+        )
+
+    item = cloud_mask_source.deserialize_item(serialized_group[0])
+    raster = cloud_mask_source.read_raster(
+        layer_name="cloud_mask",
+        item=item,
+        bands=["cloud-mask"],
+        projection=window.projection,
+        bounds=window.bounds,
+        resampling=Resampling.nearest,
+    )
+    cloud_mask = raster.get_chw_array()[0]
+
+    total_pixels = cloud_mask.size
+    valid_pixels = int((cloud_mask != 0).sum())
+    clear_pixels = int((cloud_mask == 1).sum())
+    clear_cover = clear_pixels / total_pixels if total_pixels else 0.0
+    valid_cover = valid_pixels / total_pixels if total_pixels else 0.0
+
+    stac_item = cloud_mask_collection.get_item(item.name)
+    if stac_item is None:
+        raise KeyError(f"cloud-mask STAC item not found: {item.name}")
+
+    source_collection = stac_item.properties.get("eda:derived_from_collection_id")
+    source_item_id = stac_item.properties.get("eda:derived_from_item_id")
+    if not isinstance(source_collection, str) or not source_collection:
+        raise ValueError(f"cloud-mask item {item.name} missing source collection")
+    if not isinstance(source_item_id, str) or not source_item_id:
+        raise ValueError(f"cloud-mask item {item.name} missing source item id")
+
+    return ScoredCloudMask(
+        serialized_group=serialized_group,
+        group_time_range=group_time_range,
+        cloud_mask_item_name=item.name,
+        source_collection=source_collection,
+        source_item_id=source_item_id,
+        clear_cover=clear_cover,
+        valid_cover=valid_cover,
+        clear_pixels=clear_pixels,
+        valid_pixels=valid_pixels,
+        total_pixels=total_pixels,
+    )
+
+
+def score_window_cloud_masks(
+    *,
+    cloud_mask_source: Sentinel2EDACloudMask,
+    cloud_mask_collection,
+    window: Window,
+    cloud_mask_data: WindowLayerData,
+) -> list[ScoredCloudMask]:
+    """Score all prepared cloud-mask candidates for a window."""
+    scored = []
+    for group_idx, serialized_group in enumerate(
+        cloud_mask_data.serialized_item_groups
+    ):
+        group_time_range = (
+            cloud_mask_data.group_time_ranges[group_idx]
+            if cloud_mask_data.group_time_ranges is not None
+            else None
+        )
+        scored.append(
+            score_cloud_mask_item(
+                cloud_mask_source=cloud_mask_source,
+                cloud_mask_collection=cloud_mask_collection,
+                window=window,
+                serialized_group=serialized_group,
+                group_time_range=group_time_range,
+            )
+        )
+
+    scored.sort(
+        key=lambda candidate: (
+            candidate.clear_cover,
+            candidate.valid_cover,
+            candidate.clear_pixels,
+        ),
+        reverse=True,
+    )
+    return scored
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Select prepared EarthDaily Sentinel-2 item groups by scoring prepared "
+            "sentinel-2-eda-cloud-mask candidates over each window."
+        )
+    )
+    parser.add_argument(
+        "--root", required=True, help="Path to the rslearn dataset root."
+    )
+    parser.add_argument(
+        "--cloud-mask-layer",
+        default="cloud_mask",
+        help="Prepared cloud-mask layer name.",
+    )
+    parser.add_argument(
+        "--sentinel2-layer",
+        default="sentinel2",
+        help="Prepared Sentinel-2 layer name to rewrite.",
+    )
+    parser.add_argument(
+        "--groups",
+        nargs="*",
+        default=None,
+        help="Optional window groups to process.",
+    )
+    parser.add_argument(
+        "--windows",
+        nargs="*",
+        default=None,
+        help="Optional window names to process.",
+    )
+    parser.add_argument(
+        "--min-clear-cover",
+        type=float,
+        default=None,
+        help="Optional minimum clear-cover fraction required to select a scene.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report selected scenes without writing prepared item groups.",
+    )
+    parser.add_argument(
+        "--keep-cloud-mask-candidates",
+        action="store_true",
+        help=(
+            "Only rewrite the Sentinel-2 layer. By default the cloud-mask layer is "
+            "also rewritten to the selected cloud-mask item so it can be materialized "
+            "alongside the selected Sentinel-2 scene."
+        ),
+    )
+    parser.add_argument(
+        "--env-file",
+        default=".env",
+        help="Optional dotenv file containing EarthDaily credentials.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run cloud-mask clear-cover selection."""
+    args = get_parser().parse_args()
+    load_dotenv(args.env_file)
+
+    dataset = Dataset(UPath(args.root))
+    if args.sentinel2_layer not in dataset.layers:
+        raise ValueError(f"dataset has no layer named {args.sentinel2_layer!r}")
+    if args.cloud_mask_layer not in dataset.layers:
+        raise ValueError(f"dataset has no layer named {args.cloud_mask_layer!r}")
+
+    cloud_mask_source = Sentinel2EDACloudMask(assets=["cloud-mask"], cache_dir=None)
+    cloud_mask_collection = EDSClient(
+        EDSConfig()
+    ).platform.pystac_client.get_collection(Sentinel2EDACloudMask.COLLECTION_NAME)
+    sentinel2_source = dataset.layers[args.sentinel2_layer].instantiate_data_source(
+        dataset.path
+    )
+
+    windows = dataset.load_windows(groups=args.groups, names=args.windows)
+    updated = 0
+    for window in windows:
+        layer_datas = window.load_layer_datas()
+        if args.cloud_mask_layer not in layer_datas:
+            raise ValueError(
+                f"window {window.group}/{window.name} is missing prepared layer "
+                f"{args.cloud_mask_layer}"
+            )
+
+        scored = score_window_cloud_masks(
+            cloud_mask_source=cloud_mask_source,
+            cloud_mask_collection=cloud_mask_collection,
+            window=window,
+            cloud_mask_data=layer_datas[args.cloud_mask_layer],
+        )
+        if not scored:
+            raise ValueError(
+                f"window {window.group}/{window.name} has no cloud-mask candidates"
+            )
+
+        best = scored[0]
+        if args.min_clear_cover is not None and best.clear_cover < args.min_clear_cover:
+            raise ValueError(
+                f"window {window.group}/{window.name} best clear_cover "
+                f"{best.clear_cover:.3f} is below {args.min_clear_cover:.3f}"
+            )
+
+        if getattr(sentinel2_source, "collection_name", None) != best.source_collection:
+            raise ValueError(
+                f"selected cloud-mask item {best.cloud_mask_item_name} derives from "
+                f"{best.source_collection}, but layer {args.sentinel2_layer} uses "
+                f"{getattr(sentinel2_source, 'collection_name', None)}"
+            )
+
+        sentinel2_item = sentinel2_source.get_item_by_name(best.source_item_id)
+        sentinel2_time_range = sentinel2_item.geometry.time_range
+
+        print(
+            f"{window.group}/{window.name}: selected {best.source_item_id} from "
+            f"{best.cloud_mask_item_name} clear_cover={best.clear_cover:.3f} "
+            f"valid_cover={best.valid_cover:.3f}"
+        )
+
+        if args.dry_run:
+            continue
+
+        layer_datas[args.sentinel2_layer] = WindowLayerData(
+            layer_name=args.sentinel2_layer,
+            serialized_item_groups=[[sentinel2_item.serialize()]],
+            group_time_ranges=[sentinel2_time_range],
+            materialized=False,
+        )
+        if not args.keep_cloud_mask_candidates:
+            layer_datas[args.cloud_mask_layer] = WindowLayerData(
+                layer_name=args.cloud_mask_layer,
+                serialized_item_groups=[best.serialized_group],
+                group_time_ranges=[best.group_time_range],
+                materialized=False,
+            )
+        window.save_layer_datas(layer_datas)
+        updated += 1
+
+    action = "would update" if args.dry_run else "updated"
+    print(f"{action} {updated if not args.dry_run else len(windows)} windows")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py
+++ b/docs/examples/select_earthdaily_sentinel2_by_cloud_mask.py
@@ -10,6 +10,7 @@ that single selected item group.
 import argparse
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from dotenv import load_dotenv
 from earthdaily import EDSClient, EDSConfig
@@ -39,7 +40,7 @@ class ScoredCloudMask:
 def score_cloud_mask_item(
     *,
     cloud_mask_source: Sentinel2EDACloudMask,
-    cloud_mask_collection,
+    cloud_mask_collection: Any,
     window: Window,
     serialized_group: list[dict],
     group_time_range: tuple[datetime, datetime] | None,
@@ -96,7 +97,7 @@ def score_cloud_mask_item(
 def score_window_cloud_masks(
     *,
     cloud_mask_source: Sentinel2EDACloudMask,
-    cloud_mask_collection,
+    cloud_mask_collection: Any,
     window: Window,
     cloud_mask_data: WindowLayerData,
 ) -> list[ScoredCloudMask]:
@@ -207,9 +208,9 @@ def main() -> None:
     cloud_mask_collection = EDSClient(
         EDSConfig()
     ).platform.pystac_client.get_collection(Sentinel2EDACloudMask.COLLECTION_NAME)
-    sentinel2_source = dataset.layers[args.sentinel2_layer].instantiate_data_source(
-        dataset.path
-    )
+    sentinel2_source: Any = dataset.layers[
+        args.sentinel2_layer
+    ].instantiate_data_source(dataset.path)
 
     windows = dataset.load_windows(groups=args.groups, names=args.windows)
     updated = 0

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -1218,6 +1218,156 @@ class Sentinel2L2A(EarthDaily):
                     )
 
 
+class Sentinel2EDACloudMask(EarthDaily):
+    """EarthDaily Sentinel-2 EDA cloud mask (`sentinel-2-eda-cloud-mask`) source.
+
+    The first band of the `cloud-mask` STAC asset is exposed as the rslearn band
+    `cloud-mask`: 0 nodata, 1 clear, 2 cloud, 3 cloud shadow, 4 thin cloud.
+    """
+
+    COLLECTION_NAME = "sentinel-2-eda-cloud-mask"
+
+    ASSET_BANDS = {
+        "cloud-mask": ["cloud-mask"],
+    }
+
+    def __init__(
+        self,
+        assets: list[str] | None = None,
+        cloud_cover_max: float | None = None,
+        search_max_items: int = 500,
+        sort_items_by: Literal["cloud_cover", "datetime"] | None = "cloud_cover",
+        query: dict[str, Any] | None = None,
+        sort_by: str | None = None,
+        sort_ascending: bool = True,
+        timeout: timedelta = timedelta(seconds=10),
+        cache_dir: str | None = None,
+        max_retries: int = 3,
+        retry_backoff_factor: float = 5.0,
+        context: DataSourceContext = DataSourceContext(),
+    ) -> None:
+        """Initialize an EarthDaily Sentinel-2 EDA cloud mask data source.
+
+        Args:
+            assets: optional list of EarthDaily cloud-mask STAC asset keys. The only
+                supported asset is `cloud-mask`. If omitted and a LayerConfig is
+                provided via context, assets are inferred from that layer's band sets.
+            cloud_cover_max: max cloud cover (%) applied in searches. If set, injects
+                an `eo:cloud_cover` upper bound into the STAC query.
+            search_max_items: max number of STAC items to fetch per window before
+                rslearn's grouping/matching logic runs.
+            sort_items_by: optional ordering applied before grouping; useful when
+                using `SpaceMode.COMPOSITE` with `CompositingMethod.FIRST_VALID`.
+            query: optional STAC API `query` filter passed to searches.
+            sort_by: optional STAC item property to sort by before grouping/matching.
+                If set, it takes precedence over sort_items_by.
+            sort_ascending: whether to sort ascending when sort_by is set.
+            timeout: timeout for HTTP asset downloads (when ingesting).
+            cache_dir: optional directory to cache item metadata by item id.
+            max_retries: max retries for EarthDaily API client (search/get item).
+            retry_backoff_factor: backoff factor for EarthDaily API client retries.
+            context: rslearn data source context.
+        """
+        if context.layer_config is not None and assets is None:
+            asset_bands: dict[str, list[str]] = {}
+            wanted_bands: set[str] = set()
+            for band_set in context.layer_config.band_sets:
+                wanted_bands.update(band_set.bands)
+            for asset_key, band_names in self.ASSET_BANDS.items():
+                if wanted_bands.intersection(set(band_names)):
+                    asset_bands[asset_key] = band_names
+        elif assets is not None:
+            unknown_assets = [
+                asset_key for asset_key in assets if asset_key not in self.ASSET_BANDS
+            ]
+            if unknown_assets:
+                raise ValueError(
+                    f"unknown EarthDaily Sentinel-2 EDA cloud mask assets "
+                    f"{unknown_assets}; supported assets are "
+                    f"{sorted(self.ASSET_BANDS.keys())}"
+                )
+            asset_bands = {
+                asset_key: self.ASSET_BANDS[asset_key] for asset_key in assets
+            }
+        else:
+            asset_bands = dict(self.ASSET_BANDS)
+
+        super().__init__(
+            collection_name=self.COLLECTION_NAME,
+            asset_bands=asset_bands,
+            query=query,
+            sort_by=sort_by,
+            sort_ascending=sort_ascending,
+            cloud_cover_max=cloud_cover_max,
+            search_max_items=search_max_items,
+            sort_items_by=sort_items_by,
+            timeout=timeout,
+            skip_items_missing_assets=True,
+            cache_dir=cache_dir,
+            max_retries=max_retries,
+            retry_backoff_factor=retry_backoff_factor,
+            read_scale_offsets=False,
+            context=context,
+        )
+
+    def read_raster(
+        self,
+        layer_name: str,
+        item: Item,
+        bands: list[str],
+        projection: Projection,
+        bounds: PixelBounds,
+        resampling: Resampling = Resampling.bilinear,
+    ) -> RasterArray:
+        """Read only the first band of the cloud-mask asset."""
+        raster = super().read_raster(
+            layer_name, item, bands, projection, bounds, resampling=resampling
+        )
+        return RasterArray(
+            array=raster.array[:1, :, :, :],
+            timestamps=raster.timestamps,
+            metadata=raster.metadata,
+        )
+
+    def ingest(
+        self,
+        tile_store: TileStoreWithLayer,
+        items: list[EarthDailyItem],
+        geometries: list[list[STGeometry]],
+    ) -> None:
+        """Ingest only the first band of the cloud-mask asset."""
+        for item in items:
+            band_names = self.asset_bands.get("cloud-mask")
+            if band_names is None:
+                continue
+            asset_url = item.asset_urls.get("cloud-mask")
+            if asset_url is None:
+                continue
+            if tile_store.is_raster_ready(item, band_names):
+                continue
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                local_fname = self._download_asset_to_tmp(
+                    asset_url, tmp_dir, "cloud-mask", item.name
+                )
+                with rasterio.open(local_fname) as src:
+                    array = src.read(indexes=[1])
+                    src_nodata = src.nodata
+                    projection, bounds = get_raster_projection_and_bounds(src)
+
+                tile_store.write_raster(
+                    item,
+                    band_names,
+                    projection,
+                    bounds,
+                    RasterArray(
+                        chw_array=array,
+                        time_range=item.geometry.time_range,
+                        metadata=RasterMetadata(nodata_value=src_nodata),
+                    ),
+                )
+
+
 class Biophysical(EarthDaily):
     """Biophysical variables on EarthDaily platform (EDAgro layers).
 

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -1221,19 +1221,23 @@ class Sentinel2L2A(EarthDaily):
 class Sentinel2EDACloudMask(EarthDaily):
     """EarthDaily Sentinel-2 EDA cloud mask (`sentinel-2-eda-cloud-mask`) source.
 
-    The first band of the `cloud-mask` STAC asset is exposed as the rslearn band
-    `cloud-mask`: 0 nodata, 1 clear, 2 cloud, 3 cloud shadow, 4 thin cloud.
+    The `cloud-mask` STAC asset contains two thematic bands. They are exposed as
+    `cloud-mask` (0 nodata, 1 clear, 2 cloud, 3 cloud shadow, 4 thin cloud) and
+    `cirrus-mask` (0 nodata, 1 non-cirrus, 2 cirrus).
     """
 
     COLLECTION_NAME = "sentinel-2-eda-cloud-mask"
+    ASSET_KEY = "cloud-mask"
+    DEFAULT_BAND_NAMES = ["cloud-mask", "cirrus-mask"]
 
     ASSET_BANDS = {
-        "cloud-mask": ["cloud-mask"],
+        ASSET_KEY: DEFAULT_BAND_NAMES,
     }
 
     def __init__(
         self,
         assets: list[str] | None = None,
+        band_names: list[str] | None = None,
         cloud_cover_max: float | None = None,
         search_max_items: int = 500,
         sort_items_by: Literal["cloud_cover", "datetime"] | None = "cloud_cover",
@@ -1252,6 +1256,10 @@ class Sentinel2EDACloudMask(EarthDaily):
             assets: optional list of EarthDaily cloud-mask STAC asset keys. The only
                 supported asset is `cloud-mask`. If omitted and a LayerConfig is
                 provided via context, assets are inferred from that layer's band sets.
+            band_names: ordered rslearn names for bands to expose from the
+                `cloud-mask` GeoTIFF asset. The default is `["cloud-mask",
+                "cirrus-mask"]`. The first name maps to GeoTIFF band 1, the second
+                name maps to GeoTIFF band 2.
             cloud_cover_max: max cloud cover (%) applied in searches. If set, injects
                 an `eo:cloud_cover` upper bound into the STAC query.
             search_max_items: max number of STAC items to fetch per window before
@@ -1268,29 +1276,45 @@ class Sentinel2EDACloudMask(EarthDaily):
             retry_backoff_factor: backoff factor for EarthDaily API client retries.
             context: rslearn data source context.
         """
-        if context.layer_config is not None and assets is None:
-            asset_bands: dict[str, list[str]] = {}
-            wanted_bands: set[str] = set()
-            for band_set in context.layer_config.band_sets:
-                wanted_bands.update(band_set.bands)
-            for asset_key, band_names in self.ASSET_BANDS.items():
-                if wanted_bands.intersection(set(band_names)):
-                    asset_bands[asset_key] = band_names
-        elif assets is not None:
+        if band_names is not None:
+            if not band_names:
+                raise ValueError("band_names must contain at least one band")
+            if len(set(band_names)) != len(band_names):
+                raise ValueError(f"band_names must be unique, got {band_names}")
+
+        if assets is not None:
             unknown_assets = [
-                asset_key for asset_key in assets if asset_key not in self.ASSET_BANDS
+                asset_key for asset_key in assets if asset_key != self.ASSET_KEY
             ]
             if unknown_assets:
                 raise ValueError(
                     f"unknown EarthDaily Sentinel-2 EDA cloud mask assets "
-                    f"{unknown_assets}; supported assets are "
-                    f"{sorted(self.ASSET_BANDS.keys())}"
+                    f"{unknown_assets}; supported assets are [{self.ASSET_KEY!r}]"
                 )
-            asset_bands = {
-                asset_key: self.ASSET_BANDS[asset_key] for asset_key in assets
-            }
+
+        if context.layer_config is not None and assets is None and band_names is None:
+            supported_bands = set(self.DEFAULT_BAND_NAMES)
+            wanted_bands: list[str] = []
+            for band_set in context.layer_config.band_sets:
+                for band in band_set.bands:
+                    if band not in supported_bands:
+                        continue
+                    if band in wanted_bands:
+                        continue
+                    wanted_bands.append(band)
+            source_ordered_bands = [
+                band for band in self.DEFAULT_BAND_NAMES if band in wanted_bands
+            ]
+            asset_bands = (
+                {self.ASSET_KEY: source_ordered_bands} if source_ordered_bands else {}
+            )
         else:
-            asset_bands = dict(self.ASSET_BANDS)
+            if assets == []:
+                asset_bands = {}
+            else:
+                asset_bands = {
+                    self.ASSET_KEY: list(band_names or self.DEFAULT_BAND_NAMES)
+                }
 
         super().__init__(
             collection_name=self.COLLECTION_NAME,
@@ -1310,6 +1334,45 @@ class Sentinel2EDACloudMask(EarthDaily):
             context=context,
         )
 
+        self.cloud_mask_source_band_names = list(band_names or self.DEFAULT_BAND_NAMES)
+
+    def _get_asset_by_band(self, bands: list[str]) -> str:
+        """Get the cloud-mask asset for exact or subset band requests."""
+        configured_bands = self.asset_bands.get(self.ASSET_KEY)
+        if configured_bands is not None and all(
+            band in configured_bands for band in bands
+        ):
+            return self.ASSET_KEY
+        return super()._get_asset_by_band(bands)
+
+    def _source_band_indexes_for_bands(self, bands: list[str]) -> list[int]:
+        """Return 0-based source GeoTIFF band indexes for configured rslearn bands."""
+        indexes: list[int] = []
+        for band in bands:
+            try:
+                indexes.append(self.cloud_mask_source_band_names.index(band))
+            except ValueError as e:
+                raise ValueError(
+                    f"band {band!r} is not configured for EarthDaily "
+                    f"{self.ASSET_KEY} asset bands {self.cloud_mask_source_band_names}"
+                ) from e
+        return indexes
+
+    def _validate_asset_band_count(
+        self,
+        item: EarthDailyItem,
+        asset_key: str,
+        raster_band_count: int,
+        source_band_indexes: list[int],
+    ) -> None:
+        required_count = max(source_band_indexes, default=-1) + 1
+        if raster_band_count < required_count:
+            raise ValueError(
+                f"EarthDaily item {item.name} asset {asset_key} has "
+                f"{raster_band_count} raster bands but configured bands "
+                f"{self.asset_bands[asset_key]} require source band {required_count}"
+            )
+
     def read_raster(
         self,
         layer_name: str,
@@ -1319,12 +1382,19 @@ class Sentinel2EDACloudMask(EarthDaily):
         bounds: PixelBounds,
         resampling: Resampling = Resampling.bilinear,
     ) -> RasterArray:
-        """Read only the first band of the cloud-mask asset."""
+        """Read configured bands from the cloud-mask asset."""
+        if not isinstance(item, EarthDailyItem):
+            raise TypeError(f"expected EarthDailyItem, got {type(item)}")
         raster = super().read_raster(
             layer_name, item, bands, projection, bounds, resampling=resampling
         )
+        asset_key = self._get_asset_by_band(bands)
+        source_band_indexes = self._source_band_indexes_for_bands(bands)
+        self._validate_asset_band_count(
+            item, asset_key, raster.array.shape[0], source_band_indexes
+        )
         return RasterArray(
-            array=raster.array[:1, :, :, :],
+            array=raster.array[source_band_indexes, :, :, :],
             timestamps=raster.timestamps,
             metadata=raster.metadata,
         )
@@ -1335,12 +1405,12 @@ class Sentinel2EDACloudMask(EarthDaily):
         items: list[EarthDailyItem],
         geometries: list[list[STGeometry]],
     ) -> None:
-        """Ingest only the first band of the cloud-mask asset."""
+        """Ingest configured bands from the cloud-mask asset."""
         for item in items:
-            band_names = self.asset_bands.get("cloud-mask")
+            band_names = self.asset_bands.get(self.ASSET_KEY)
             if band_names is None:
                 continue
-            asset_url = item.asset_urls.get("cloud-mask")
+            asset_url = item.asset_urls.get(self.ASSET_KEY)
             if asset_url is None:
                 continue
             if tile_store.is_raster_ready(item, band_names):
@@ -1348,10 +1418,17 @@ class Sentinel2EDACloudMask(EarthDaily):
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 local_fname = self._download_asset_to_tmp(
-                    asset_url, tmp_dir, "cloud-mask", item.name
+                    asset_url, tmp_dir, self.ASSET_KEY, item.name
                 )
                 with rasterio.open(local_fname) as src:
-                    array = src.read(indexes=[1])
+                    source_band_indexes = self._source_band_indexes_for_bands(
+                        band_names
+                    )
+                    self._validate_asset_band_count(
+                        item, self.ASSET_KEY, src.count, source_band_indexes
+                    )
+                    indexes = [index + 1 for index in source_band_indexes]
+                    array = src.read(indexes=indexes)
                     src_nodata = src.nodata
                     projection, bounds = get_raster_projection_and_bounds(src)
 

--- a/tests/unit/data_sources/test_earthdaily_cloud_mask.py
+++ b/tests/unit/data_sources/test_earthdaily_cloud_mask.py
@@ -22,7 +22,7 @@ def test_sentinel2_eda_cloud_mask_defaults() -> None:
     ds = Sentinel2EDACloudMask(cache_dir=None)
 
     assert ds.collection_name == "sentinel-2-eda-cloud-mask"
-    assert ds.asset_bands == {"cloud-mask": ["cloud-mask"]}
+    assert ds.asset_bands == {"cloud-mask": ["cloud-mask", "cirrus-mask"]}
     assert ds.read_scale_offsets is False
 
 
@@ -31,6 +31,15 @@ def test_sentinel2_eda_cloud_mask_rejects_unknown_assets() -> None:
         ValueError, match="unknown EarthDaily Sentinel-2 EDA cloud mask assets"
     ):
         Sentinel2EDACloudMask(assets=["cirrus"], cache_dir=None)
+
+
+def test_sentinel2_eda_cloud_mask_accepts_additional_ordered_bands() -> None:
+    ds = Sentinel2EDACloudMask(
+        band_names=["cloud-mask", "custom-cirrus"],
+        cache_dir=None,
+    )
+
+    assert ds.asset_bands == {"cloud-mask": ["cloud-mask", "custom-cirrus"]}
 
 
 def test_sentinel2_eda_cloud_mask_infers_asset_from_layer_config() -> None:
@@ -45,6 +54,20 @@ def test_sentinel2_eda_cloud_mask_infers_asset_from_layer_config() -> None:
     )
 
     assert ds.asset_bands == {"cloud-mask": ["cloud-mask"]}
+
+
+def test_sentinel2_eda_cloud_mask_infers_cirrus_asset_from_layer_config() -> None:
+    layer_cfg = LayerConfig(
+        type=LayerType.RASTER,
+        band_sets=[BandSetConfig(dtype=DType.UINT8, bands=["cirrus-mask"])],
+    )
+
+    ds = Sentinel2EDACloudMask(
+        context=DataSourceContext(layer_config=layer_cfg),
+        cache_dir=None,
+    )
+
+    assert ds.asset_bands == {"cloud-mask": ["cirrus-mask"]}
 
 
 def test_sentinel2_eda_cloud_mask_read_raster(tmp_path: Path) -> None:
@@ -98,6 +121,115 @@ def test_sentinel2_eda_cloud_mask_read_raster(tmp_path: Path) -> None:
     np.testing.assert_array_equal(out.get_chw_array(), raw[:1])
 
 
+def test_sentinel2_eda_cloud_mask_read_raster_keeps_configured_bands(
+    tmp_path: Path,
+) -> None:
+    tif_path = tmp_path / "cloud-mask.tif"
+
+    crs = CRS.from_epsg(3857)
+    transform = Affine(1, 0, 0, 0, -1, 0)
+    raw = np.array(
+        [
+            [[0, 1], [2, 4]],
+            [[9, 8], [7, 6]],
+        ],
+        dtype=np.uint8,
+    )
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=2,
+        dtype=str(raw.dtype),
+        crs=crs,
+        transform=transform,
+    ) as dst:
+        dst.write(raw)
+
+    geom = STGeometry(
+        Projection(crs, 1, -1),
+        shapely.box(0, 0, 2, 2),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+    )
+    item = EarthDailyItem(
+        name="item1",
+        geometry=geom,
+        asset_urls={"cloud-mask": str(tif_path)},
+    )
+    ds = Sentinel2EDACloudMask(
+        cache_dir=None,
+    )
+
+    out = ds.read_raster(
+        layer_name="layer",
+        item=item,
+        bands=["cloud-mask", "cirrus-mask"],
+        projection=Projection(crs, 1, -1),
+        bounds=(0, 0, 2, 2),
+    )
+
+    np.testing.assert_array_equal(out.get_chw_array(), raw)
+
+
+def test_sentinel2_eda_cloud_mask_read_raster_keeps_cirrus_band_only(
+    tmp_path: Path,
+) -> None:
+    tif_path = tmp_path / "cloud-mask.tif"
+
+    crs = CRS.from_epsg(3857)
+    transform = Affine(1, 0, 0, 0, -1, 0)
+    raw = np.array(
+        [
+            [[0, 1], [2, 4]],
+            [[0, 1], [1, 2]],
+        ],
+        dtype=np.uint8,
+    )
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=2,
+        dtype=str(raw.dtype),
+        crs=crs,
+        transform=transform,
+    ) as dst:
+        dst.write(raw)
+
+    geom = STGeometry(
+        Projection(crs, 1, -1),
+        shapely.box(0, 0, 2, 2),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+    )
+    item = EarthDailyItem(
+        name="item1",
+        geometry=geom,
+        asset_urls={"cloud-mask": str(tif_path)},
+    )
+    layer_cfg = LayerConfig(
+        type=LayerType.RASTER,
+        band_sets=[BandSetConfig(dtype=DType.UINT8, bands=["cirrus-mask"])],
+    )
+    ds = Sentinel2EDACloudMask(
+        context=DataSourceContext(layer_config=layer_cfg),
+        cache_dir=None,
+    )
+
+    out = ds.read_raster(
+        layer_name="layer",
+        item=item,
+        bands=["cirrus-mask"],
+        projection=Projection(crs, 1, -1),
+        bounds=(0, 0, 2, 2),
+    )
+
+    np.testing.assert_array_equal(out.get_chw_array(), raw[1:2])
+
+
 def test_sentinel2_eda_cloud_mask_ingest_writes_first_band_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -137,7 +269,7 @@ def test_sentinel2_eda_cloud_mask_ingest_writes_first_band_only(
         geometry=geom,
         asset_urls={"cloud-mask": "https://example.com/cloud-mask.tif"},
     )
-    ds = Sentinel2EDACloudMask(cache_dir=None)
+    ds = Sentinel2EDACloudMask(band_names=["cloud-mask"], cache_dir=None)
     monkeypatch.setattr(
         ds,
         "_download_asset_to_tmp",
@@ -158,3 +290,66 @@ def test_sentinel2_eda_cloud_mask_ingest_writes_first_band_only(
         (0, 0, 2, 2),
     )
     np.testing.assert_array_equal(out.get_chw_array(), raw[:1])
+
+
+def test_sentinel2_eda_cloud_mask_ingest_writes_configured_bands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tif_path = tmp_path / "cloud-mask.tif"
+
+    crs = CRS.from_epsg(3857)
+    transform = Affine(1, 0, 0, 0, -1, 0)
+    raw = np.array(
+        [
+            [[0, 1], [2, 4]],
+            [[9, 8], [7, 6]],
+        ],
+        dtype=np.uint8,
+    )
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=2,
+        dtype=str(raw.dtype),
+        crs=crs,
+        transform=transform,
+    ) as dst:
+        dst.write(raw)
+
+    geom = STGeometry(
+        Projection(crs, 1, -1),
+        shapely.box(0, 0, 2, 2),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+    )
+    item = EarthDailyItem(
+        name="item1",
+        geometry=geom,
+        asset_urls={"cloud-mask": "https://example.com/cloud-mask.tif"},
+    )
+    ds = Sentinel2EDACloudMask(
+        cache_dir=None,
+    )
+    monkeypatch.setattr(
+        ds,
+        "_download_asset_to_tmp",
+        lambda _asset_url, _tmp_dir, _asset_key, _item_name: str(tif_path),
+    )
+
+    tile_store = DefaultTileStore(convert_rasters_to_cogs=False)
+    tile_store.set_dataset_path(UPath(tmp_path / "ds"))
+    layer_tile_store = TileStoreWithLayer(tile_store, "cloud")
+
+    ds.ingest(layer_tile_store, [item], [[geom]])
+
+    out = tile_store.read_raster(
+        "cloud",
+        item,
+        ["cloud-mask", "cirrus-mask"],
+        Projection(crs, 1, -1),
+        (0, 0, 2, 2),
+    )
+    np.testing.assert_array_equal(out.get_chw_array(), raw)

--- a/tests/unit/data_sources/test_earthdaily_cloud_mask.py
+++ b/tests/unit/data_sources/test_earthdaily_cloud_mask.py
@@ -1,0 +1,160 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+import shapely
+from rasterio.crs import CRS
+from rasterio.transform import Affine
+from upath import UPath
+
+pytest.importorskip("earthdaily")
+
+from rslearn.config import BandSetConfig, DType, LayerConfig, LayerType
+from rslearn.data_sources import DataSourceContext
+from rslearn.data_sources.earthdaily import EarthDailyItem, Sentinel2EDACloudMask
+from rslearn.tile_stores import DefaultTileStore, TileStoreWithLayer
+from rslearn.utils.geometry import Projection, STGeometry
+
+
+def test_sentinel2_eda_cloud_mask_defaults() -> None:
+    ds = Sentinel2EDACloudMask(cache_dir=None)
+
+    assert ds.collection_name == "sentinel-2-eda-cloud-mask"
+    assert ds.asset_bands == {"cloud-mask": ["cloud-mask"]}
+    assert ds.read_scale_offsets is False
+
+
+def test_sentinel2_eda_cloud_mask_rejects_unknown_assets() -> None:
+    with pytest.raises(
+        ValueError, match="unknown EarthDaily Sentinel-2 EDA cloud mask assets"
+    ):
+        Sentinel2EDACloudMask(assets=["cirrus"], cache_dir=None)
+
+
+def test_sentinel2_eda_cloud_mask_infers_asset_from_layer_config() -> None:
+    layer_cfg = LayerConfig(
+        type=LayerType.RASTER,
+        band_sets=[BandSetConfig(dtype=DType.UINT8, bands=["cloud-mask"])],
+    )
+
+    ds = Sentinel2EDACloudMask(
+        context=DataSourceContext(layer_config=layer_cfg),
+        cache_dir=None,
+    )
+
+    assert ds.asset_bands == {"cloud-mask": ["cloud-mask"]}
+
+
+def test_sentinel2_eda_cloud_mask_read_raster(tmp_path: Path) -> None:
+    tif_path = tmp_path / "cloud-mask.tif"
+
+    crs = CRS.from_epsg(3857)
+    transform = Affine(1, 0, 0, 0, -1, 0)
+    raw = np.array(
+        [
+            [[0, 1], [2, 4]],
+            [[0, 1], [1, 2]],
+        ],
+        dtype=np.uint8,
+    )
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=2,
+        dtype=str(raw.dtype),
+        crs=crs,
+        transform=transform,
+        nodata=0,
+    ) as dst:
+        dst.write(raw)
+
+    geom = STGeometry(
+        Projection(crs, 1, -1),
+        shapely.box(0, 0, 2, 2),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+    )
+    item = EarthDailyItem(
+        name="item1",
+        geometry=geom,
+        asset_urls={"cloud-mask": str(tif_path)},
+    )
+    ds = Sentinel2EDACloudMask(cache_dir=None)
+
+    out = ds.read_raster(
+        layer_name="layer",
+        item=item,
+        bands=["cloud-mask"],
+        projection=Projection(crs, 1, -1),
+        bounds=(0, 0, 2, 2),
+    )
+
+    assert out.metadata is not None
+    assert out.metadata.nodata_value == 0
+    np.testing.assert_array_equal(out.get_chw_array(), raw[:1])
+
+
+def test_sentinel2_eda_cloud_mask_ingest_writes_first_band_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tif_path = tmp_path / "cloud-mask.tif"
+
+    crs = CRS.from_epsg(3857)
+    transform = Affine(1, 0, 0, 0, -1, 0)
+    raw = np.array(
+        [
+            [[0, 1], [2, 4]],
+            [[0, 1], [1, 2]],
+        ],
+        dtype=np.uint8,
+    )
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=2,
+        dtype=str(raw.dtype),
+        crs=crs,
+        transform=transform,
+        nodata=0,
+    ) as dst:
+        dst.write(raw)
+
+    geom = STGeometry(
+        Projection(crs, 1, -1),
+        shapely.box(0, 0, 2, 2),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+    )
+    item = EarthDailyItem(
+        name="item1",
+        geometry=geom,
+        asset_urls={"cloud-mask": "https://example.com/cloud-mask.tif"},
+    )
+    ds = Sentinel2EDACloudMask(cache_dir=None)
+    monkeypatch.setattr(
+        ds,
+        "_download_asset_to_tmp",
+        lambda _asset_url, _tmp_dir, _asset_key, _item_name: str(tif_path),
+    )
+
+    tile_store = DefaultTileStore(convert_rasters_to_cogs=False)
+    tile_store.set_dataset_path(UPath(tmp_path / "ds"))
+    layer_tile_store = TileStoreWithLayer(tile_store, "cloud")
+
+    ds.ingest(layer_tile_store, [item], [[geom]])
+
+    out = tile_store.read_raster(
+        "cloud",
+        item,
+        ["cloud-mask"],
+        Projection(crs, 1, -1),
+        (0, 0, 2, 2),
+    )
+    np.testing.assert_array_equal(out.get_chw_array(), raw[:1])


### PR DESCRIPTION
## Data source
Adds `rslearn.data_sources.earthdaily.Sentinel2EDACloudMask` for EarthDaily’s `sentinel-2-eda-cloud-mask` collection.

The new source exposes the first band of the `cloud-mask` asset as a single categorical cloud-mask band with values for nodata, clear, cloud, cloud shadow, and thin cloud. It supports the standard EarthDaily query/sorting/cache options, strips the second STAC band during direct reads and ingest, and includes docs plus unit coverage for config, asset inference, reading, and ingest behavior.

## Adds an EarthDaily cloud-mask clear-cover selection workflow.

The new docs example shows how to prepare both Sentinel2L2A and Sentinel2EDACloudMask layers, score prepared cloud-mask candidates by AOI clear-cover pixels, rewrite the prepared Sentinel-2 item group to the clearest related sentinel-2-l2a item, and then continue with normal rslearn ingest/materialize. A helper script is included to perform the post-prepare selection step.