### PR TITLE
Harden data source ZIP extraction

### DIFF
--- a/rslearn/data_sources/climate_data_store.py
+++ b/rslearn/data_sources/climate_data_store.py
@@ -20,6 +20,7 @@ from rslearn.data_sources import DataSource, DataSourceContext, Item
 from rslearn.data_sources.utils import MatchedItemGroup
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.archive import safe_extract_zip
 from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
 from rslearn.utils.raster_array import RasterArray, RasterMetadata
 
@@ -971,7 +972,7 @@ class ERA5LandHourlyTimeseries(DataSource):
                         raise ValueError(
                             f"No NetCDF file found in downloaded zip: {local_zip_fname}"
                         )
-                    zip_ref.extractall(tmp_dir)
+                    safe_extract_zip(zip_ref, tmp_dir)
                     local_nc_paths = [
                         UPath(os.path.join(tmp_dir, nc_file)) for nc_file in nc_files
                     ]

--- a/rslearn/data_sources/copernicus.py
+++ b/rslearn/data_sources/copernicus.py
@@ -29,6 +29,7 @@ from rslearn.data_sources.data_source import DataSource, DataSourceContext, Item
 from rslearn.data_sources.utils import MatchedItemGroup, match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.archive import safe_extract_zip_member
 from rslearn.utils.fsspec import open_atomic
 from rslearn.utils.geometry import (
     FloatBounds,
@@ -601,7 +602,9 @@ class Copernicus(DataSource):
                 # Extract it to a temporary directory.
                 with tempfile.TemporaryDirectory() as tmp_dir:
                     logger.debug(f"Extracting {member_name} for bands {band_names}")
-                    local_raster_fname = zipf.extract(member_name, path=tmp_dir)
+                    local_raster_fname = safe_extract_zip_member(
+                        zipf, member_name, tmp_dir
+                    )
 
                     # Now we can ingest it.
                     logger.debug(f"Ingesting the raster for bands {band_names}")
@@ -833,7 +836,9 @@ class Sentinel2(Copernicus):
                 # Extract it to a temporary directory.
                 with tempfile.TemporaryDirectory() as tmp_dir:
                     logger.debug(f"Extracting {member_name} for bands {band_names}")
-                    local_raster_fname = zipf.extract(member_name, path=tmp_dir)
+                    local_raster_fname = safe_extract_zip_member(
+                        zipf, member_name, tmp_dir
+                    )
 
                     logger.debug(f"Ingesting the raster for bands {band_names}")
 

--- a/rslearn/data_sources/eurocrops.py
+++ b/rslearn/data_sources/eurocrops.py
@@ -16,6 +16,7 @@ from rslearn.data_sources import DataSource, DataSourceContext, Item
 from rslearn.data_sources.utils import MatchedItemGroup, match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.archive import safe_extract_zip
 from rslearn.utils.feature import Feature
 from rslearn.utils.geometry import Projection, STGeometry, get_global_geometry
 
@@ -177,7 +178,7 @@ class EuroCrops(DataSource[EuroCropsItem]):
             # Extract all of the files and look for shapefile filename.
             logger.debug(f"Extracting zip file {fname}")
             with zipfile.ZipFile(zip_fname) as zip_f:
-                zip_f.extractall(path=tmp_dir)
+                safe_extract_zip(zip_f, tmp_dir)
 
             # The shapefiles or geopackage files can appear at any level in the hierarchy.
             # Most zip files contain one but some contain multiple (one per region).

--- a/rslearn/data_sources/usda_cdl.py
+++ b/rslearn/data_sources/usda_cdl.py
@@ -16,6 +16,7 @@ from rslearn.data_sources import DataSource, DataSourceContext, Item
 from rslearn.data_sources.utils import MatchedItemGroup, match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.archive import safe_extract_zip_member
 from rslearn.utils.geometry import STGeometry
 
 logger = get_logger(__name__)
@@ -184,7 +185,9 @@ class CDL(DataSource):
                         raise ValueError(
                             f"expected CDL zip to have one .tif file but got {candidate_member_names}"
                         )
-                    local_fname = zip_f.extract(candidate_member_names[0], path=tmp_dir)
+                    local_fname = safe_extract_zip_member(
+                        zip_f, candidate_member_names[0], tmp_dir
+                    )
 
                 # Now we can ingest it.
                 logger.debug(f"Ingesting data for {item.name}")

--- a/rslearn/data_sources/worldcereal.py
+++ b/rslearn/data_sources/worldcereal.py
@@ -14,6 +14,7 @@ from upath import UPath
 from rslearn.config import LayerType
 from rslearn.data_sources.local_files import LocalFiles, RasterItemSpec
 from rslearn.log_utils import get_logger
+from rslearn.utils.archive import safe_extract_zip
 from rslearn.utils.fsspec import get_upath_local, join_upath, open_atomic
 
 from .data_source import DataSourceContext, Item
@@ -409,7 +410,7 @@ class WorldCereal(LocalFiles):
 
             with get_upath_local(zip_filepath) as local_fname:
                 with zipfile.ZipFile(local_fname) as zip_f:
-                    zip_f.extractall(local_dir)
+                    safe_extract_zip(zip_f, local_dir)
 
             # Copy it over if the tif_dir was remote.
             if not isinstance(tif_dir.fs, LocalFileSystem):

--- a/rslearn/utils/archive.py
+++ b/rslearn/utils/archive.py
@@ -1,0 +1,80 @@
+"""Archive extraction helpers."""
+
+import os
+import pathlib
+import shutil
+import stat
+import zipfile
+from collections.abc import Iterable
+
+
+def _validate_zip_member(
+    zip_info: zipfile.ZipInfo, destination: pathlib.Path
+) -> pathlib.Path:
+    """Return the extraction path for a zip member, rejecting unsafe names."""
+    member_name = zip_info.filename
+    windows_path = pathlib.PureWindowsPath(member_name)
+    posix_path = pathlib.PurePosixPath(member_name)
+
+    if (
+        windows_path.is_absolute()
+        or windows_path.drive
+        or posix_path.is_absolute()
+        or not posix_path.parts
+        or "\\" in member_name
+        or ".." in posix_path.parts
+    ):
+        raise ValueError(f"unsafe zip member path: {member_name}")
+
+    file_type = stat.S_IFMT(zip_info.external_attr >> 16)
+    if file_type == stat.S_IFLNK:
+        raise ValueError(f"refusing to extract symlink zip member: {member_name}")
+
+    target_path = (destination / pathlib.Path(*posix_path.parts)).resolve()
+    if not target_path.is_relative_to(destination.resolve()):
+        raise ValueError(f"unsafe zip member path: {member_name}")
+    return target_path
+
+
+def safe_extract_zip(
+    zip_file: zipfile.ZipFile,
+    destination: str | os.PathLike,
+    members: Iterable[str | zipfile.ZipInfo] | None = None,
+) -> list[pathlib.Path]:
+    """Safely extract zip members into a destination directory.
+
+    This rejects absolute paths, parent-directory traversal, Windows drive paths,
+    backslash-separated paths, and symlinks before writing any member.
+    """
+    destination_path = pathlib.Path(destination).resolve()
+    destination_path.mkdir(parents=True, exist_ok=True)
+
+    zip_members = members
+    if zip_members is None:
+        zip_members = zip_file.infolist()
+
+    extracted_paths = []
+    for member in zip_members:
+        zip_info = (
+            member if isinstance(member, zipfile.ZipInfo) else zip_file.getinfo(member)
+        )
+        target_path = _validate_zip_member(zip_info, destination_path)
+
+        if zip_info.is_dir():
+            target_path.mkdir(parents=True, exist_ok=True)
+        else:
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with zip_file.open(zip_info) as src, target_path.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+        extracted_paths.append(target_path)
+
+    return extracted_paths
+
+
+def safe_extract_zip_member(
+    zip_file: zipfile.ZipFile,
+    member: str | zipfile.ZipInfo,
+    destination: str | os.PathLike,
+) -> pathlib.Path:
+    """Safely extract one zip member and return its local path."""
+    return safe_extract_zip(zip_file, destination, [member])[0]

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,79 @@
+"""Tests for archive helpers."""
+
+import pathlib
+import stat
+import zipfile
+
+import pytest
+
+from rslearn.utils.archive import safe_extract_zip, safe_extract_zip_member
+
+
+def test_safe_extract_zip_extracts_nested_file(tmp_path: pathlib.Path) -> None:
+    """Verify safe extraction preserves normal nested paths."""
+    archive_path = tmp_path / "safe.zip"
+    with zipfile.ZipFile(archive_path, "w") as zip_file:
+        zip_file.writestr("nested/file.txt", "ok")
+
+    destination = tmp_path / "out"
+    with zipfile.ZipFile(archive_path) as zip_file:
+        extracted_paths = safe_extract_zip(zip_file, destination)
+
+    assert extracted_paths == [destination / "nested" / "file.txt"]
+    assert (destination / "nested" / "file.txt").read_text() == "ok"
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escape.txt",
+        "/tmp/escape.txt",
+        "C:/tmp/escape.txt",
+        "",
+        r"..\escape.txt",
+        r"nested\escape.txt",
+    ],
+)
+def test_safe_extract_zip_rejects_unsafe_paths(
+    tmp_path: pathlib.Path, member_name: str
+) -> None:
+    """Verify unsafe zip member paths are rejected before extraction."""
+    archive_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive_path, "w") as zip_file:
+        zip_file.writestr(member_name, "bad")
+
+    destination = tmp_path / "out"
+    with zipfile.ZipFile(archive_path) as zip_file:
+        with pytest.raises(ValueError, match="unsafe zip member path"):
+            safe_extract_zip(zip_file, destination)
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_safe_extract_zip_rejects_symlink_members(tmp_path: pathlib.Path) -> None:
+    """Verify symlink entries are rejected."""
+    archive_path = tmp_path / "symlink.zip"
+    zip_info = zipfile.ZipInfo("link")
+    zip_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(archive_path, "w") as zip_file:
+        zip_file.writestr(zip_info, "target")
+
+    with zipfile.ZipFile(archive_path) as zip_file:
+        with pytest.raises(ValueError, match="refusing to extract symlink"):
+            safe_extract_zip(zip_file, tmp_path / "out")
+
+
+def test_safe_extract_zip_member_returns_extracted_path(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Verify single-member extraction returns the extracted path."""
+    archive_path = tmp_path / "safe.zip"
+    with zipfile.ZipFile(archive_path, "w") as zip_file:
+        zip_file.writestr("file.txt", "ok")
+
+    destination = tmp_path / "out"
+    with zipfile.ZipFile(archive_path) as zip_file:
+        extracted_path = safe_extract_zip_member(zip_file, "file.txt", destination)
+
+    assert extracted_path == destination / "file.txt"
+    assert extracted_path.read_text() == "ok"


### PR DESCRIPTION
## Summary
- add safe ZIP extraction helpers that reject absolute paths, parent traversal, Windows-drive/backslash paths, and symlink members
- use the helper in remote ZIP ingestion paths for EuroCrops, WorldCereal, CDS timeseries, Copernicus product rasters, and USDA CDL
- add unit coverage for normal nested extraction and unsafe member rejection

## Validation
- `uv run --extra dev --extra extra pytest tests/test_archive_utils.py tests/integration/data_sources/test_worldcereal.py -q`
- `uv run --extra dev --extra extra ruff check rslearn/utils/archive.py tests/test_archive_utils.py rslearn/data_sources/eurocrops.py rslearn/data_sources/worldcereal.py rslearn/data_sources/climate_data_store.py rslearn/data_sources/copernicus.py rslearn/data_sources/usda_cdl.py`
- `uv run --extra dev --extra extra ruff format --check rslearn/utils/archive.py tests/test_archive_utils.py rslearn/data_sources/eurocrops.py rslearn/data_sources/worldcereal.py rslearn/data_sources/climate_data_store.py rslearn/data_sources/copernicus.py rslearn/data_sources/usda_cdl.py`

Note: I also ran `uv run --extra dev --extra extra pytest tests/test_archive_utils.py tests/integration/data_sources/test_worldcereal.py tests/integration/data_sources/test_climate_data_store.py -q`. The new archive tests and WorldCereal passed, but two existing climate-data-store assertions failed because rasterio rewrote source value `0` to `1e-45` to avoid NoData. That appears unrelated to this extraction change.
