### PR TITLE
Remove warning about setting per_period_mosaic_reverse_time_order.

### DIFF
--- a/rslearn/config/dataset.py
+++ b/rslearn/config/dataset.py
@@ -417,12 +417,6 @@ class QueryConfig(BaseModel):
                 "2026-05-01. Use SpaceMode.MOSAIC with period_duration instead.",
                 FutureWarning,
             )
-        if "per_period_mosaic_reverse_time_order" in self.model_fields_set:
-            warnings.warn(
-                "per_period_mosaic_reverse_time_order is deprecated and will be "
-                "removed after 2026-05-01.",
-                FutureWarning,
-            )
         return self
 
     # Minimum number of item groups. If there are fewer than this many matches, then no


### PR DESCRIPTION
Currently it should always explicitly be set false. So there should not be a warning when it is explicitly set false.

The warning for it being set true is in utils.py.