### PR TITLE
Data loading speed up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.1.7"
+version = "0.1.8"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     { name = "OlmoEarth Team" },

--- a/rslearn/config/dataset.py
+++ b/rslearn/config/dataset.py
@@ -18,6 +18,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PlainSerializer,
+    PrivateAttr,
     field_validator,
     model_validator,
 )
@@ -203,6 +204,10 @@ class BandSetConfig(BaseModel):
         description="Optional (height, width) output size. Mutually exclusive with non-zero zoom_offset.",
     )
 
+    # Cached instantiated RasterFormat. We cache since it can take a few ms to
+    # instantiate.
+    _raster_format: RasterFormat | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def after_validator(self) -> "BandSetConfig":
         """Ensure the BandSetConfig is valid, and handle the num_bands field."""
@@ -332,14 +337,17 @@ class BandSetConfig(BaseModel):
 
     def instantiate_raster_format(self) -> RasterFormat:
         """Instantiate the RasterFormat specified by this BandSetConfig."""
+        if self._raster_format is not None:
+            return self._raster_format
+
         from rslearn.utils.jsonargparse import init_jsonargparse
 
         init_jsonargparse()
         parser = jsonargparse.ArgumentParser()
         parser.add_argument("--raster_format", type=RasterFormat)
         cfg = parser.parse_object({"raster_format": self.format})
-        raster_format = parser.instantiate_classes(cfg).raster_format
-        return raster_format
+        self._raster_format = parser.instantiate_classes(cfg).raster_format
+        return self._raster_format
 
 
 class SpaceMode(StrEnum):

--- a/rslearn/utils/array.py
+++ b/rslearn/utils/array.py
@@ -77,8 +77,8 @@ def copy_spatial_array(
         dst_offset: the (col, row) position of the top-left pixel of dst in the coordinate
             system.
     """
-    if len(src.shape) < 2:
-        raise ValueError(f"src must be at least 2-D, got shape {src.shape}")
+    if len(src.shape) < 2 or len(dst.shape) < 2:
+        raise ValueError(f"src and dst must be at least 2-D, got shape {src.shape}")
 
     src_height, src_width = src.shape[-2:]
     dst_height, dst_width = dst.shape[-2:]

--- a/rslearn/utils/array.py
+++ b/rslearn/utils/array.py
@@ -66,14 +66,20 @@ def copy_spatial_array(
     array will be copied, and other parts of the destination array will not be
     overwritten.
 
+    Supports arrays with any number of dimensions >= 2. The last two dimensions are
+    treated as (H, W); any leading dimensions (e.g. C, or C and T) are preserved.
+
     Args:
-        src: the source array (HW or CHW).
-        dst: the destination array (HW or CHW).
+        src: the source array (``...HW``).
+        dst: the destination array (``...HW``).
         src_offset: the (col, row) position of the top-left pixel of src in the coordinate
             system.
         dst_offset: the (col, row) position of the top-left pixel of dst in the coordinate
             system.
     """
+    if len(src.shape) < 2:
+        raise ValueError(f"src must be at least 2-D, got shape {src.shape}")
+
     src_height, src_width = src.shape[-2:]
     dst_height, dst_width = dst.shape[-2:]
     # The top-left position within src that intersects with dst.
@@ -87,23 +93,12 @@ def copy_spatial_array(
     col_overlap = min(src_width - src_col_offset, dst_width - dst_col_offset)
     row_overlap = min(src_height - src_row_offset, dst_height - dst_row_offset)
 
-    if len(src.shape) == 2:
-        dst[
-            dst_row_offset : dst_row_offset + row_overlap,
-            dst_col_offset : dst_col_offset + col_overlap,
-        ] = src[
-            src_row_offset : src_row_offset + row_overlap,
-            src_col_offset : src_col_offset + col_overlap,
-        ]
-    elif len(src.shape) == 3:
-        dst[
-            :,
-            dst_row_offset : dst_row_offset + row_overlap,
-            dst_col_offset : dst_col_offset + col_overlap,
-        ] = src[
-            :,
-            src_row_offset : src_row_offset + row_overlap,
-            src_col_offset : src_col_offset + col_overlap,
-        ]
-    else:
-        raise ValueError(f"Unsupported src shape: {src.shape}")
+    dst[
+        ...,
+        dst_row_offset : dst_row_offset + row_overlap,
+        dst_col_offset : dst_col_offset + col_overlap,
+    ] = src[
+        ...,
+        src_row_offset : src_row_offset + row_overlap,
+        src_col_offset : src_col_offset + col_overlap,
+    ]

--- a/rslearn/utils/array.py
+++ b/rslearn/utils/array.py
@@ -93,6 +93,10 @@ def copy_spatial_array(
     col_overlap = min(src_width - src_col_offset, dst_width - dst_col_offset)
     row_overlap = min(src_height - src_row_offset, dst_height - dst_row_offset)
 
+    # Skip copy if there's no overlap.
+    if col_overlap <= 0 or row_overlap <= 0:
+        return
+
     dst[
         ...,
         dst_row_offset : dst_row_offset + row_overlap,

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -145,6 +145,59 @@ def adjust_projection_and_bounds_for_array(
     return (adjusted_projection, adjusted_bounds)
 
 
+def _check_projection_and_crop_bounds(
+    array: npt.NDArray[Any],
+    stored_projection: dict[str, Any] | None,
+    stored_bounds: PixelBounds,
+    requested_projection: Projection,
+    requested_bounds: PixelBounds,
+    nodata_value: int | float | None,
+    format_name: str,
+) -> npt.NDArray[Any]:
+    """Verify projection matches and crop/pad array to requested bounds.
+
+    Projection must match (raises ``NotImplementedError`` on mismatch).
+    Bounds may differ: the returned array is cropped/padded to
+    ``requested_bounds`` using :func:`copy_spatial_array`.
+
+    Args:
+        array: the decoded raster array (any shape with last two dims H, W).
+        stored_projection: serialised projection dict from metadata, or None if it
+            is unknown, in which case we assume the requested projection is correct.
+        stored_bounds: pixel bounds the data was written with.
+        requested_projection: projection the caller asked for.
+        requested_bounds: bounds the caller asked for.
+        nodata_value: fill value for pixels outside the stored bounds.
+        format_name: human-readable name used in error messages.
+
+    Returns:
+        The (possibly cropped/padded) array matching ``requested_bounds``.
+    """
+    if stored_projection is not None:
+        source_proj = Projection.deserialize(stored_projection)
+        if source_proj != requested_projection:
+            raise NotImplementedError(
+                f"{format_name} does not support reprojection "
+                f"(stored={source_proj}, requested={requested_projection})"
+            )
+
+    if tuple(stored_bounds) == tuple(requested_bounds):
+        return array
+
+    shape = list(array.shape)
+    shape[-2] = requested_bounds[3] - requested_bounds[1]
+    shape[-1] = requested_bounds[2] - requested_bounds[0]
+    fill = nodata_value if nodata_value is not None else 0
+    dst = np.full(shape, fill, dtype=array.dtype)
+    copy_spatial_array(
+        array,
+        dst,
+        src_offset=(stored_bounds[0], stored_bounds[1]),
+        dst_offset=(requested_bounds[0], requested_bounds[1]),
+    )
+    return dst
+
+
 class RasterFormat:
     """An abstract class for writing raster data.
 
@@ -766,16 +819,6 @@ class SingleImageRasterFormat(RasterFormat):
         with (path / METADATA_FNAME).open() as f:
             image_metadata = SingleImageRasterMetadata.model_validate_json(f.read())
 
-        # If the projection key is set, verify that it matches the requested projection
-        # since SingleImageRasterFormat currently does not support re-projecting.
-        if image_metadata.projection is not None:
-            source_data_projection = Projection.deserialize(image_metadata.projection)
-            if projection != source_data_projection:
-                raise NotImplementedError(
-                    "not implemented to re-project source data "
-                    + f"(source projection {source_data_projection} does not match requested projection {projection})"
-                )
-
         image_fname = path / ("image." + self.get_extension())
         with image_fname.open("rb") as f:
             array = np.array(Image.open(f, formats=[self.format.upper()]))
@@ -784,20 +827,15 @@ class SingleImageRasterFormat(RasterFormat):
             array = array[:, :, None]
         array = array.transpose(2, 0, 1)
 
-        if bounds != image_metadata.bounds:
-            # Need to extract relevant portion of image.
-            shape = (array.shape[0], bounds[3] - bounds[1], bounds[2] - bounds[0])
-            if image_metadata.nodata_value is not None:
-                dst = np.full(shape, image_metadata.nodata_value, dtype=array.dtype)
-            else:
-                dst = np.zeros(shape, dtype=array.dtype)
-            copy_spatial_array(
-                array,
-                dst,
-                src_offset=(image_metadata.bounds[0], image_metadata.bounds[1]),
-                dst_offset=(bounds[0], bounds[1]),
-            )
-            array = dst
+        array = _check_projection_and_crop_bounds(
+            array=array,
+            stored_projection=image_metadata.projection,
+            stored_bounds=image_metadata.bounds,
+            requested_projection=projection,
+            requested_bounds=bounds,
+            nodata_value=image_metadata.nodata_value,
+            format_name="SingleImageRasterFormat",
+        )
 
         # Wrap as CTHW with T=1.
         return RasterArray(
@@ -874,15 +912,14 @@ class NumpyRasterFormat(RasterFormat):
     ) -> RasterArray:
         """Decode a previously stored ``data.npy`` + ``metadata.json``.
 
-        The returned array is the stored array *as-is* -- no reprojection or
-        resampling is performed. The ``projection``, ``bounds``, and
-        ``resampling`` parameters are accepted for interface conformance but
-        are not used for spatial transformation.
+        Projection must match the stored projection. If the requested bounds
+        differ from the stored bounds the array is cropped/padded accordingly
+        (out-of-bounds pixels are filled with the nodata value, or 0).
 
         Args:
             path: directory to read from.
-            projection: used to verify consistency with stored projection.
-            bounds: used to verify consistency with stored bounds.
+            projection: the projection to read the raster in.
+            bounds: the bounds to read in the given projection.
             resampling: ignored (kept for interface conformance).
 
         Returns:
@@ -891,16 +928,18 @@ class NumpyRasterFormat(RasterFormat):
         with (path / METADATA_FNAME).open() as f:
             metadata = NumpyRasterMetadata.model_validate_json(f.read())
 
-        if metadata.bounds != tuple(bounds):
-            raise ValueError(
-                f"NumpyRasterFormat: requested bounds {bounds} differ from "
-                f"stored bounds {metadata.bounds}. Unlike GeotiffRasterFormat, "
-                f"NumpyRasterFormat cannot reproject or crop to different "
-                f"bounds."
-            )
-
         with (path / self.data_fname).open("rb") as f:
             array = np.load(f)
+
+        array = _check_projection_and_crop_bounds(
+            array=array,
+            stored_projection=metadata.projection,
+            stored_bounds=metadata.bounds,
+            requested_projection=projection,
+            requested_bounds=bounds,
+            nodata_value=metadata.nodata_value,
+            format_name="NumpyRasterFormat",
+        )
 
         return RasterArray(
             array=array,

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -375,8 +375,11 @@ class ImageTileRasterFormat(RasterFormat):
             end_tile[0] * self.tile_size - bounds[2],
             end_tile[1] * self.tile_size - bounds[3],
         )
+        pad_value = nodata_value if nodata_value is not None else 0
         array = np.pad(
-            array, ((0, 0), (padding[1], padding[3]), (padding[0], padding[2]))
+            array,
+            ((0, 0), (padding[1], padding[3]), (padding[0], padding[2])),
+            constant_values=pad_value,
         )
 
         path.mkdir(parents=True, exist_ok=True)

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -161,7 +161,7 @@ def _check_projection_and_crop_bounds(
     ``requested_bounds`` using :func:`copy_spatial_array`.
 
     Args:
-        array: the decoded raster array (any shape with last two dims H, W).
+        array: the CTHW decoded raster array.
         stored_projection: serialised projection dict from metadata, or None if it
             is unknown, in which case we assume the requested projection is correct.
         stored_bounds: pixel bounds the data was written with.
@@ -171,7 +171,7 @@ def _check_projection_and_crop_bounds(
         format_name: human-readable name used in error messages.
 
     Returns:
-        The (possibly cropped/padded) array matching ``requested_bounds``.
+        The (possibly cropped/padded) CTHW array matching ``requested_bounds``.
     """
     if stored_projection is not None:
         source_proj = Projection.deserialize(stored_projection)
@@ -826,9 +826,10 @@ class SingleImageRasterFormat(RasterFormat):
         with image_fname.open("rb") as f:
             array = np.array(Image.open(f, formats=[self.format.upper()]))
 
+        # Convert HWC or HW array to CTHW.
         if len(array.shape) == 2:
             array = array[:, :, None]
-        array = array.transpose(2, 0, 1)
+        array = array.transpose(2, 0, 1)[:, np.newaxis, :, :]
 
         array = _check_projection_and_crop_bounds(
             array=array,
@@ -840,9 +841,8 @@ class SingleImageRasterFormat(RasterFormat):
             format_name="SingleImageRasterFormat",
         )
 
-        # Wrap as CTHW with T=1.
         return RasterArray(
-            array=array[:, np.newaxis, :, :],
+            array=array,
             timestamps=image_metadata.timestamps,
             metadata=RasterMetadata(nodata_value=image_metadata.nodata_value),
         )

--- a/rslearn/utils/raster_format.py
+++ b/rslearn/utils/raster_format.py
@@ -868,9 +868,9 @@ class NumpyRasterFormat(RasterFormat):
     - ``metadata.json``: projection, bounds, dtype, channel/timestep counts,
       and optional timestamps.
 
-    ``decode_raster`` returns the stored array as-is without any reprojection
-    or resampling -- data is assumed to have been materialized at the target
-    resolution already.
+    ``decode_raster`` does not support re-projection, only cropping/padding; if the
+    requested Projection does not match the Projection under which the image data was
+    stored, an exception will be raised.
     """
 
     data_fname = "data.npy"

--- a/tests/unit/utils/test_raster_format.py
+++ b/tests/unit/utils/test_raster_format.py
@@ -9,7 +9,13 @@ from upath import UPath
 
 from rslearn.utils.geometry import Projection
 from rslearn.utils.raster_array import RasterArray, RasterMetadata
-from rslearn.utils.raster_format import GeotiffRasterFormat, NumpyRasterFormat
+from rslearn.utils.raster_format import (
+    GeotiffRasterFormat,
+    ImageTileRasterFormat,
+    NumpyRasterFormat,
+    RasterFormat,
+    SingleImageRasterFormat,
+)
 
 
 def test_geotiff_tiling(tmp_path: pathlib.Path) -> None:
@@ -51,40 +57,6 @@ class TestGeotiffBoundsAndNodata:
     """Test GeotiffRasterFormat bounds and nodata handling."""
 
     PROJECTION = Projection(CRS.from_epsg(3857), 1, -1)
-
-    @pytest.fixture
-    def encoded_raster_path(self, tmp_path: pathlib.Path) -> UPath:
-        path = UPath(tmp_path)
-        array = np.ones((1, 8, 8), dtype=np.uint8)
-        GeotiffRasterFormat().encode_raster(
-            path, self.PROJECTION, (0, 0, 8, 8), RasterArray(chw_array=array)
-        )
-        return path
-
-    def test_geotiff_in_bounds(self, encoded_raster_path: UPath) -> None:
-        """In-bounds read from GeoTIFF of 1s should yield 1s."""
-        ra = GeotiffRasterFormat().decode_raster(
-            encoded_raster_path, self.PROJECTION, (2, 2, 6, 6)
-        )
-        assert ra.array.shape == (1, 1, 4, 4)
-        assert np.all(ra.array == 1)
-
-    def test_geotiff_partial_overlap(self, encoded_raster_path: UPath) -> None:
-        """Read with partial overlap should yield nodata (0) for out of bounds pixels."""
-        ra = GeotiffRasterFormat().decode_raster(
-            encoded_raster_path, self.PROJECTION, (4, 4, 12, 12)
-        )
-        assert ra.array.shape == (1, 1, 8, 8)
-        assert np.all(ra.array[:, :, 0:4, 0:4] == 1)
-        assert np.all(ra.array[:, :, 0:8, 4:8] == 0)
-
-    def test_geotiff_out_of_bounds(self, encoded_raster_path: UPath) -> None:
-        """Fully out-of-bounds read should yield nodata (0) for all pixels."""
-        ra = GeotiffRasterFormat().decode_raster(
-            encoded_raster_path, self.PROJECTION, (8, 8, 12, 12)
-        )
-        assert ra.array.shape == (1, 1, 4, 4)
-        assert np.all(ra.array == 0)
 
     def test_geotiff_write_nodata_value(self, tmp_path: pathlib.Path) -> None:
         """Test that nodata_value on metadata is correctly written to the GeoTIFF."""
@@ -385,53 +357,6 @@ class TestNumpyRasterFormat:
         assert (path / "data.npy").exists()
         assert (path / "metadata.json").exists()
 
-    def test_bounds_subset(self, tmp_path: pathlib.Path) -> None:
-        """Decoding with a subset of the stored bounds crops correctly."""
-        path = UPath(tmp_path)
-        data = np.arange(16, dtype=np.float32).reshape(1, 1, 4, 4)
-        fmt = NumpyRasterFormat()
-        fmt.encode_raster(path, self.PROJECTION, (0, 0, 4, 4), RasterArray(array=data))
-        decoded = fmt.decode_raster(path, self.PROJECTION, (1, 1, 3, 3))
-        assert decoded.array.shape == (1, 1, 2, 2)
-        np.testing.assert_array_equal(decoded.array, data[:, :, 1:3, 1:3])
-
-    def test_bounds_superset(self, tmp_path: pathlib.Path) -> None:
-        """Decoding with larger bounds pads with nodata (0 when unset)."""
-        path = UPath(tmp_path)
-        data = np.ones((1, 1, 2, 2), dtype=np.float32)
-        fmt = NumpyRasterFormat()
-        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), RasterArray(array=data))
-        decoded = fmt.decode_raster(path, self.PROJECTION, (-1, -1, 3, 3))
-        assert decoded.array.shape == (1, 1, 4, 4)
-        # Original data at offset (1,1).
-        np.testing.assert_array_equal(decoded.array[:, :, 1:3, 1:3], 1.0)
-        # Padded region should be 0.
-        assert decoded.array[:, :, 0, :].sum() == 0
-        assert decoded.array[:, :, 3, :].sum() == 0
-        assert decoded.array[:, :, :, 0].sum() == 0
-        assert decoded.array[:, :, :, 3].sum() == 0
-
-    def test_bounds_superset_nodata(self, tmp_path: pathlib.Path) -> None:
-        """Padded pixels use the stored nodata_value."""
-        path = UPath(tmp_path)
-        data = np.ones((1, 1, 2, 2), dtype=np.float32)
-        nodata = -9999.0
-        raster = RasterArray(array=data, metadata=RasterMetadata(nodata_value=nodata))
-        fmt = NumpyRasterFormat()
-        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), raster)
-        decoded = fmt.decode_raster(path, self.PROJECTION, (-1, -1, 3, 3))
-        assert decoded.array[:, :, 0, 0] == nodata
-
-    def test_bounds_no_overlap(self, tmp_path: pathlib.Path) -> None:
-        """Decoding with no overlap returns all nodata."""
-        path = UPath(tmp_path)
-        data = np.ones((1, 1, 2, 2), dtype=np.float32)
-        fmt = NumpyRasterFormat()
-        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), RasterArray(array=data))
-        decoded = fmt.decode_raster(path, self.PROJECTION, (10, 10, 12, 12))
-        assert decoded.array.shape == (1, 1, 2, 2)
-        np.testing.assert_array_equal(decoded.array, 0.0)
-
     def test_projection_mismatch_raises(self, tmp_path: pathlib.Path) -> None:
         """Decoding with a different projection should raise NotImplementedError."""
         path = UPath(tmp_path)
@@ -457,3 +382,75 @@ class TestNumpyRasterFormat:
 
         assert decoded.metadata.nodata_value == nodata_value
         np.testing.assert_array_equal(decoded.array, data)
+
+
+_ALL_RASTER_FORMATS = [
+    pytest.param(GeotiffRasterFormat(), id="geotiff"),
+    pytest.param(ImageTileRasterFormat("png"), id="image_tile_png"),
+    pytest.param(SingleImageRasterFormat("png"), id="single_image_png"),
+    pytest.param(NumpyRasterFormat(), id="numpy"),
+]
+
+_PROJECTION = Projection(CRS.from_epsg(3857), 1, -1)
+
+
+@pytest.mark.parametrize("fmt", _ALL_RASTER_FORMATS)
+class TestRasterFormatRoundTrip:
+    """Bounds crop/pad tests that apply to every RasterFormat."""
+
+    def test_in_bounds_crop(self, tmp_path: pathlib.Path, fmt: RasterFormat) -> None:
+        """Reading a strict subset of stored bounds returns only the cropped data."""
+        path = UPath(tmp_path)
+        data = np.arange(64, dtype=np.uint8).reshape(1, 8, 8)
+        fmt.encode_raster(path, _PROJECTION, (0, 0, 8, 8), RasterArray(chw_array=data))
+        decoded = fmt.decode_raster(path, _PROJECTION, (2, 2, 6, 6))
+        assert decoded.array.shape == (1, 1, 4, 4)
+        np.testing.assert_array_equal(decoded.array[0, 0], data[0, 2:6, 2:6])
+
+    def test_superset_bounds(self, tmp_path: pathlib.Path, fmt: RasterFormat) -> None:
+        """Reading with bounds larger than stored pads missing pixels with 0."""
+        path = UPath(tmp_path)
+        data = np.arange(16, dtype=np.uint8).reshape(1, 4, 4)
+        fmt.encode_raster(path, _PROJECTION, (2, 2, 6, 6), RasterArray(chw_array=data))
+        decoded = fmt.decode_raster(path, _PROJECTION, (0, 0, 8, 8))
+        assert decoded.array.shape == (1, 1, 8, 8)
+        np.testing.assert_array_equal(decoded.array[0, 0, 2:6, 2:6], data[0])
+        np.testing.assert_array_equal(decoded.array[:, :, :2, :], 0)
+        np.testing.assert_array_equal(decoded.array[:, :, 6:, :], 0)
+        np.testing.assert_array_equal(decoded.array[:, :, :, :2], 0)
+        np.testing.assert_array_equal(decoded.array[:, :, :, 6:], 0)
+
+    def test_partial_overlap(self, tmp_path: pathlib.Path, fmt: RasterFormat) -> None:
+        """Reading with partially overlapping bounds crops and pads correctly."""
+        path = UPath(tmp_path)
+        data = np.arange(64, dtype=np.uint8).reshape(1, 8, 8)
+        fmt.encode_raster(path, _PROJECTION, (0, 0, 8, 8), RasterArray(chw_array=data))
+        decoded = fmt.decode_raster(path, _PROJECTION, (4, 4, 12, 12))
+        assert decoded.array.shape == (1, 1, 8, 8)
+        np.testing.assert_array_equal(decoded.array[0, 0, :4, :4], data[0, 4:8, 4:8])
+        np.testing.assert_array_equal(decoded.array[:, :, 4:, :], 0)
+        np.testing.assert_array_equal(decoded.array[:, :, :, 4:], 0)
+
+    def test_partial_overlap_nodata(
+        self, tmp_path: pathlib.Path, fmt: RasterFormat
+    ) -> None:
+        """Out-of-bounds pixels are filled with the stored nodata value."""
+        path = UPath(tmp_path)
+        data = np.arange(64, dtype=np.uint8).reshape(1, 8, 8)
+        raster = RasterArray(chw_array=data, metadata=RasterMetadata(nodata_value=255))
+        fmt.encode_raster(path, _PROJECTION, (0, 0, 8, 8), raster)
+        decoded = fmt.decode_raster(path, _PROJECTION, (4, 4, 12, 12))
+        assert decoded.array.shape == (1, 1, 8, 8)
+        np.testing.assert_array_equal(decoded.array[0, 0, :4, :4], data[0, 4:8, 4:8])
+        np.testing.assert_array_equal(decoded.array[:, :, 4:, :], 255)
+        np.testing.assert_array_equal(decoded.array[:, :, :, 4:], 255)
+
+    def test_no_overlap_nodata(self, tmp_path: pathlib.Path, fmt: RasterFormat) -> None:
+        """Reading with zero overlap returns all nodata."""
+        path = UPath(tmp_path)
+        data = np.arange(64, dtype=np.uint8).reshape(1, 8, 8)
+        raster = RasterArray(chw_array=data, metadata=RasterMetadata(nodata_value=255))
+        fmt.encode_raster(path, _PROJECTION, (0, 0, 8, 8), raster)
+        decoded = fmt.decode_raster(path, _PROJECTION, (1000, 1000, 1004, 1004))
+        assert decoded.array.shape == (1, 1, 4, 4)
+        np.testing.assert_array_equal(decoded.array, 255)

--- a/tests/unit/utils/test_raster_format.py
+++ b/tests/unit/utils/test_raster_format.py
@@ -385,15 +385,62 @@ class TestNumpyRasterFormat:
         assert (path / "data.npy").exists()
         assert (path / "metadata.json").exists()
 
-    def test_bounds_mismatch_raises(self, tmp_path: pathlib.Path) -> None:
-        """Decoding with different bounds should raise ValueError."""
+    def test_bounds_subset(self, tmp_path: pathlib.Path) -> None:
+        """Decoding with a subset of the stored bounds crops correctly."""
+        path = UPath(tmp_path)
+        data = np.arange(16, dtype=np.float32).reshape(1, 1, 4, 4)
+        fmt = NumpyRasterFormat()
+        fmt.encode_raster(path, self.PROJECTION, (0, 0, 4, 4), RasterArray(array=data))
+        decoded = fmt.decode_raster(path, self.PROJECTION, (1, 1, 3, 3))
+        assert decoded.array.shape == (1, 1, 2, 2)
+        np.testing.assert_array_equal(decoded.array, data[:, :, 1:3, 1:3])
+
+    def test_bounds_superset(self, tmp_path: pathlib.Path) -> None:
+        """Decoding with larger bounds pads with nodata (0 when unset)."""
         path = UPath(tmp_path)
         data = np.ones((1, 1, 2, 2), dtype=np.float32)
         fmt = NumpyRasterFormat()
         fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), RasterArray(array=data))
+        decoded = fmt.decode_raster(path, self.PROJECTION, (-1, -1, 3, 3))
+        assert decoded.array.shape == (1, 1, 4, 4)
+        # Original data at offset (1,1).
+        np.testing.assert_array_equal(decoded.array[:, :, 1:3, 1:3], 1.0)
+        # Padded region should be 0.
+        assert decoded.array[:, :, 0, :].sum() == 0
+        assert decoded.array[:, :, 3, :].sum() == 0
+        assert decoded.array[:, :, :, 0].sum() == 0
+        assert decoded.array[:, :, :, 3].sum() == 0
 
-        with pytest.raises(ValueError, match="bounds .* differ"):
-            fmt.decode_raster(path, self.PROJECTION, (10, 10, 12, 12))
+    def test_bounds_superset_nodata(self, tmp_path: pathlib.Path) -> None:
+        """Padded pixels use the stored nodata_value."""
+        path = UPath(tmp_path)
+        data = np.ones((1, 1, 2, 2), dtype=np.float32)
+        nodata = -9999.0
+        raster = RasterArray(array=data, metadata=RasterMetadata(nodata_value=nodata))
+        fmt = NumpyRasterFormat()
+        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), raster)
+        decoded = fmt.decode_raster(path, self.PROJECTION, (-1, -1, 3, 3))
+        assert decoded.array[:, :, 0, 0] == nodata
+
+    def test_bounds_no_overlap(self, tmp_path: pathlib.Path) -> None:
+        """Decoding with no overlap returns all nodata."""
+        path = UPath(tmp_path)
+        data = np.ones((1, 1, 2, 2), dtype=np.float32)
+        fmt = NumpyRasterFormat()
+        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), RasterArray(array=data))
+        decoded = fmt.decode_raster(path, self.PROJECTION, (10, 10, 12, 12))
+        assert decoded.array.shape == (1, 1, 2, 2)
+        np.testing.assert_array_equal(decoded.array, 0.0)
+
+    def test_projection_mismatch_raises(self, tmp_path: pathlib.Path) -> None:
+        """Decoding with a different projection should raise NotImplementedError."""
+        path = UPath(tmp_path)
+        data = np.ones((1, 1, 2, 2), dtype=np.float32)
+        fmt = NumpyRasterFormat()
+        fmt.encode_raster(path, self.PROJECTION, (0, 0, 2, 2), RasterArray(array=data))
+        other_proj = Projection(CRS.from_epsg(4326), 1, -1)
+        with pytest.raises(NotImplementedError, match="reprojection"):
+            fmt.decode_raster(path, other_proj, (0, 0, 2, 2))
 
     def test_nodata_value_roundtrip(self, tmp_path: pathlib.Path) -> None:
         """nodata_value should round-trip through NumpyRasterFormat."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32'",
@@ -4411,7 +4411,7 @@ wheels = [
 
 [[package]]
 name = "rslearn"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
This resolved one issue and one bottleneck when using PerLayerStorage + NumpyRasterFormat.

- NumpyRasterFormat didn't previously support reading different bounds than the bounds of the stored image. It now supports this. The requested projection must still match the projection of the stored image (i.e., re-projection is not supported). SingleImageRasterFormat is updated as well to use the same helper function.
- The data loading speed is much faster with PerLayerStorage + NumpyRasterFormat, and `BandSetConfig.instantiate_raster_format` becomes the bottleneck. We resolve it by caching the instantiated RasterFormat.

Here are benchmark numbers:

```
config:
- A100 VM on GCP (12 cores)
- 32x32 inputs, batch_size=8, 12 timesteps, Sentinel-2 only (12 bands)
- These numbers are with OlmoEarth-v1-Base
- Showing the time for the read_raster_layer_groups_for_data_input function, also showing batches/sec for some configurations

one data loader worker, per item group storage, with RasterFormat caching

npy balanced: 0.0083s
npy ssd: 0.0088s
lzw balanced: 0.0315s
lzw ssd: 0.0315s
zstd balanced: 0.0302s
zstd ssd: 0.0296s
uncompressed balanced: 0.0297s
uncompressed ssd: 0.0286s

one data loader worker, per layer storage, with RasterFormat caching

npy balanced: 0.0018s
npy ssd: 0.0018s
lzw balanced: 0.0120s
lzw ssd: 0.0121s
zstd balanced: 0.0101s
zstd ssd: 0.0103s
uncompressed balanced: 0.0095s
uncompressed ssd: 0.0099s

one data loader worker, per layer storage, no RasterFormat caching

npy: 0.0037s, 7.10 batch/sec
lzw: 0.0147s, 5.64 batch/sec

8 data loader workers, per item group storage, with RasterFormat caching

npy: 0.0078s, 7.13 batch/sec
lzw:  0.0305s, 7.09 batch/sec
uncompressed: 0.0296s, 7.02 batch/sec

8 data loader workers, per layer storage, with RasterFormat caching

npy balanced: 0.0019s, 7.13 batch/sec
npy ssd: 0.0019s, 7.09 batch/sec
lzw balanced: 0.0116s, 7.09 batch/sec
lzw ssd: 0.0120s, 7.09 batch/sec
uncompressed balanced: 0.0096s, 7.06 batch/sec
uncompressed ssd: 0.0100s, 7.03 batch/sec
```