### PR TITLE
Add EarthDailyCloudMaskToMask transform 

### DIFF
--- a/docs/Transforms.md
+++ b/docs/Transforms.md
@@ -193,6 +193,30 @@ The `Sentinel2SCLToMask` transform converts a Sentinel-2 Scene Classification La
             mask_value: 0
 ```
 
+## EarthDailyCloudMaskToMask
+
+The `EarthDailyCloudMaskToMask` transform converts an EarthDaily EDA cloud-mask raster
+into a binary mask image (1 = clear, 0 = masked). This can be used with `Mask` to set
+cloudy, shadowed, thin-cloud, and nodata pixels to the input image's nodata value at
+training time.
+
+```yaml
+      transforms:
+        - class_path: rslearn.train.transforms.earthdaily.EarthDailyCloudMaskToMask
+          init_args:
+            cloud_mask_selector: "cloud_mask"
+            output_selector: "mask"
+            clear_values: [1]
+        - class_path: rslearn.train.transforms.mask.Mask
+          init_args:
+            selectors: ["image"]
+            mask_selector: "mask"
+            mask_value: 0
+```
+
+By default, only EarthDaily EDA class `1` is treated as clear. Values `0` nodata, `2`
+cloud, `3` cloud shadow, and `4` thin cloud are masked out.
+
 ## Normalize
 
 The `Normalize` transform implements linear normalization of images.

--- a/docs/examples/EarthDailyCloudMaskClearCover.md
+++ b/docs/examples/EarthDailyCloudMaskClearCover.md
@@ -17,6 +17,8 @@ The workflow is:
    group to the clearest related image.
 4. Run `rslearn dataset ingest` if the selected layers use `ingest: true`.
 5. Run `rslearn dataset materialize`.
+6. In the training config, convert the materialized `cloud_mask` layer to a binary
+   mask and apply it to Sentinel-2 inputs.
 
 The EDA cloud-mask class values are:
 
@@ -148,6 +150,54 @@ Finally materialize:
 ```bash
 rslearn dataset materialize --root ./dataset
 ```
+
+### Training-Time Masking
+
+The selected `cloud_mask` layer can be used at training time to set non-clear
+Sentinel-2 pixels to the Sentinel-2 nodata value. This keeps the materialized
+Sentinel-2 raster unchanged while making the masking explicit in the training
+configuration.
+
+Configure the training inputs to load both the Sentinel-2 image and the selected
+cloud-mask raster:
+
+```yaml
+inputs:
+  image:
+    data_type: "raster"
+    layers: ["sentinel2"]
+    bands: ["B02", "B03", "B04", "B08"]
+    passthrough: true
+    dtype: FLOAT32
+  cloud_mask:
+    data_type: "raster"
+    layers: ["cloud_mask"]
+    bands: ["cloud-mask"]
+    passthrough: true
+    dtype: UINT8
+```
+
+Then convert EarthDaily EDA cloud-mask classes to a binary mask and apply it to the
+Sentinel-2 input:
+
+```yaml
+transforms:
+  - class_path: rslearn.train.transforms.earthdaily.EarthDailyCloudMaskToMask
+    init_args:
+      cloud_mask_selector: "cloud_mask"
+      output_selector: "mask"
+      # EarthDaily EDA value 1 is clear. Values 0, 2, 3, and 4 are masked out.
+      clear_values: [1]
+  - class_path: rslearn.train.transforms.mask.Mask
+    init_args:
+      selectors: ["image"]
+      mask_selector: "mask"
+      # Match the Sentinel-2 band-set nodata_value configured above.
+      mask_value: 0
+```
+
+The resulting `image` tensor keeps pixels where `cloud-mask == 1` and sets all other
+pixels (`0` nodata, `2` cloud, `3` cloud shadow, `4` thin cloud) to `mask_value`.
 
 ### Selection Helper
 

--- a/rslearn/train/transforms/earthdaily.py
+++ b/rslearn/train/transforms/earthdaily.py
@@ -1,0 +1,74 @@
+"""Transforms related to EarthDaily data."""
+
+from typing import Any
+
+import torch
+
+from rslearn.train.model_context import RasterImage
+
+from .transform import Transform, read_selector, selector_exists, write_selector
+
+
+class EarthDailyCloudMaskToMask(Transform):
+    """Convert an EarthDaily EDA cloud-mask raster into a binary mask raster.
+
+    The output mask is 1 for clear pixels and 0 for pixels that should be masked out.
+    EarthDaily EDA cloud-mask values are:
+
+    - 0: nodata
+    - 1: clear
+    - 2: cloud
+    - 3: cloud shadow
+    - 4: thin cloud
+    """
+
+    DEFAULT_CLEAR_VALUES = [1]
+
+    def __init__(
+        self,
+        cloud_mask_selector: str = "cloud_mask",
+        output_selector: str = "mask",
+        clear_values: list[int] | None = None,
+        skip_missing: bool = False,
+    ) -> None:
+        """Initialize a new EarthDailyCloudMaskToMask.
+
+        Args:
+            cloud_mask_selector: selector for the EarthDaily EDA cloud-mask image.
+            output_selector: selector to write the binary mask to.
+            clear_values: cloud-mask values to treat as clear. Defaults to [1].
+            skip_missing: if True, skip when cloud_mask_selector is missing.
+        """
+        super().__init__(skip_missing=skip_missing)
+        self.cloud_mask_selector = cloud_mask_selector
+        self.output_selector = output_selector
+        self.clear_values = (
+            list(self.DEFAULT_CLEAR_VALUES)
+            if clear_values is None
+            else list(clear_values)
+        )
+
+    def _to_mask(self, cloud_mask: RasterImage) -> RasterImage:
+        cloud_mask_tensor = cloud_mask.image
+        if cloud_mask_tensor.shape[0] != 1:
+            raise ValueError("expected EarthDaily cloud-mask image to have one band")
+
+        clear = torch.zeros_like(cloud_mask_tensor, dtype=torch.bool)
+        for value in self.clear_values:
+            clear |= cloud_mask_tensor == value
+        mask = clear.to(dtype=torch.int32)
+        return RasterImage(mask, cloud_mask.timestamps)
+
+    def forward(
+        self, input_dict: dict[str, Any], target_dict: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Write a binary mask derived from EarthDaily EDA cloud-mask values."""
+        if self.skip_missing and not selector_exists(
+            input_dict, target_dict, self.cloud_mask_selector
+        ):
+            return input_dict, target_dict
+
+        cloud_mask = read_selector(input_dict, target_dict, self.cloud_mask_selector)
+        mask = self._to_mask(cloud_mask)
+        write_selector(input_dict, target_dict, self.output_selector, mask)
+        return input_dict, target_dict

--- a/tests/unit/train/transforms/test_earthdaily_cloud_mask_to_mask.py
+++ b/tests/unit/train/transforms/test_earthdaily_cloud_mask_to_mask.py
@@ -1,0 +1,83 @@
+"""Unit tests for rslearn.train.transforms.earthdaily."""
+
+import pytest
+import torch
+
+from rslearn.train.model_context import RasterImage
+from rslearn.train.transforms.earthdaily import EarthDailyCloudMaskToMask
+from rslearn.train.transforms.mask import Mask
+
+
+def test_earthdaily_cloud_mask_to_mask() -> None:
+    cloud_mask_to_mask = EarthDailyCloudMaskToMask()
+
+    input_dict = {
+        "cloud_mask": RasterImage(
+            torch.tensor([[[[0, 1, 2], [3, 4, 1]]]], dtype=torch.uint8)
+        ),
+    }
+
+    input_dict, _ = cloud_mask_to_mask(input_dict, {})
+
+    assert torch.all(
+        input_dict["mask"].image
+        == torch.tensor([[[[0, 1, 0], [0, 0, 1]]]], dtype=torch.int32)
+    )
+
+
+def test_earthdaily_cloud_mask_to_mask_and_apply_mask() -> None:
+    cloud_mask_to_mask = EarthDailyCloudMaskToMask()
+    apply_mask = Mask(selectors=["image"], mask_selector="mask", mask_value=0)
+
+    input_dict = {
+        "image": RasterImage(torch.full((2, 2, 2, 2), 5.0)),
+        "cloud_mask": RasterImage(
+            torch.tensor([[[[1, 2], [3, 4]]]], dtype=torch.uint8)
+        ),
+    }
+
+    input_dict, _ = cloud_mask_to_mask(input_dict, {})
+    input_dict, _ = apply_mask(input_dict, {})
+
+    expected = torch.tensor(
+        [
+            [
+                [[5, 0], [0, 0]],
+                [[5, 0], [0, 0]],
+            ],
+            [
+                [[5, 0], [0, 0]],
+                [[5, 0], [0, 0]],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+    assert torch.all(input_dict["image"].image == expected)
+
+
+def test_earthdaily_cloud_mask_to_mask_custom_clear_values() -> None:
+    cloud_mask_to_mask = EarthDailyCloudMaskToMask(clear_values=[1, 4])
+
+    input_dict = {
+        "cloud_mask": RasterImage(
+            torch.tensor([[[[0, 1, 2], [3, 4, 1]]]], dtype=torch.uint8)
+        ),
+    }
+
+    input_dict, _ = cloud_mask_to_mask(input_dict, {})
+
+    assert torch.all(
+        input_dict["mask"].image
+        == torch.tensor([[[[0, 1, 0], [0, 1, 1]]]], dtype=torch.int32)
+    )
+
+
+def test_earthdaily_cloud_mask_to_mask_requires_single_band() -> None:
+    cloud_mask_to_mask = EarthDailyCloudMaskToMask()
+
+    input_dict = {
+        "cloud_mask": RasterImage(torch.zeros((2, 1, 2, 2), dtype=torch.uint8)),
+    }
+
+    with pytest.raises(ValueError, match="one band"):
+        cloud_mask_to_mask(input_dict, {})


### PR DESCRIPTION
Implemented `EarthDailyCloudMaskToMask` to convert EarthDaily EDA cloud-mask raster into a binary mask - the use case is identical to that of `Sentinel2SCLToMask`