### PR TITLE
Avoid intersection-sized temporaries in read_raster_window_from_tiles

### DIFF
--- a/rslearn/dataset/tile_utils.py
+++ b/rslearn/dataset/tile_utils.py
@@ -146,30 +146,35 @@ def read_raster_window_from_tiles(
         dst_col = intersection[0] - bounds[0]
         dst_row = intersection[1] - bounds[1]
 
-        src_sel = src[src_indexes, :, :, :]  # (C_sel, T, H_int, W_int)
-        if remapper:
-            src_sel = remapper(src_sel, band_dtype)
-
         out_crop = dst.array[
             :,
             :,
-            dst_row : dst_row + src_sel.shape[2],
-            dst_col : dst_col + src_sel.shape[3],
+            dst_row : dst_row + src.shape[2],
+            dst_col : dst_col + src.shape[3],
         ]  # (C, T, H_int, W_int) view
 
-        src_typed = src_sel.astype(band_dtype)
-
+        # Work band-by-band on views and write with np.copyto so that no
+        # intersection-sized temporary is ever materialized. For whole-scene
+        # windows the fancy-indexing copies (src[src_indexes], astype, the
+        # masked gathers) each cost multiple GB and dominated peak memory.
         if nodata_val is not None:
             # First-valid: only overwrite pixels where all dst bands are nodata.
-            mask = nodata_eq(out_crop[dst_indexes], nodata_val).min(
-                axis=0
-            )  # (T, H_int, W_int)
-
-            for src_index, dst_index in enumerate(dst_indexes):
-                out_crop[dst_index][mask] = src_typed[src_index][mask]
+            mask = nodata_eq(out_crop[dst_indexes[0]], nodata_val)
+            for dst_index in dst_indexes[1:]:
+                mask &= nodata_eq(out_crop[dst_index], nodata_val)
         else:
-            for src_index, dst_index in enumerate(dst_indexes):
-                out_crop[dst_index] = src_typed[src_index]
+            mask = None
+
+        for src_index, dst_index in zip(src_indexes, dst_indexes, strict=True):
+            src_band = src[src_index]  # (T, H_int, W_int) view
+            if remapper:
+                src_band = remapper(src_band, band_dtype)
+            if mask is not None:
+                # casting="unsafe" matches the astype() conversion semantics
+                # this replaces.
+                np.copyto(out_crop[dst_index], src_band, where=mask, casting="unsafe")
+            else:
+                np.copyto(out_crop[dst_index], src_band, casting="unsafe")
 
     return dst
 

--- a/rslearn/dataset/tile_utils.py
+++ b/rslearn/dataset/tile_utils.py
@@ -153,25 +153,29 @@ def read_raster_window_from_tiles(
             dst_col : dst_col + src.shape[3],
         ]  # (C, T, H_int, W_int) view
 
-        # Work band-by-band on views and write with np.copyto so that no
-        # intersection-sized temporary is ever materialized. For whole-scene
-        # windows the fancy-indexing copies (src[src_indexes], astype, the
-        # masked gathers) each cost multiple GB and dominated peak memory.
+        # Build the first-valid mask: a pixel may be written only where it is
+        # nodata in *every* destination band. Start from the first band's
+        # nodata mask and logically-and (&=) each remaining band into it, so a
+        # pixel that is already valid in any band stays False (untouched).
         if nodata_val is not None:
-            # First-valid: only overwrite pixels where all dst bands are nodata.
             mask = nodata_eq(out_crop[dst_indexes[0]], nodata_val)
             for dst_index in dst_indexes[1:]:
                 mask &= nodata_eq(out_crop[dst_index], nodata_val)
         else:
+            # nodata_val is None: every source pixel overwrites the destination.
             mask = None
 
+        # Copy one band at a time. src[src_index] is a view (no copy), and
+        # np.copyto writes straight into the destination window, so no
+        # intersection-sized temporary array is allocated.
         for src_index, dst_index in zip(src_indexes, dst_indexes, strict=True):
             src_band = src[src_index]  # (T, H_int, W_int) view
             if remapper:
                 src_band = remapper(src_band, band_dtype)
             if mask is not None:
-                # casting="unsafe" matches the astype() conversion semantics
-                # this replaces.
+                # where=mask restricts the write to first-valid pixels;
+                # casting="unsafe" converts src_band's dtype to band_dtype
+                # during the copy (e.g. uint16 -> float32).
                 np.copyto(out_crop[dst_index], src_band, where=mask, casting="unsafe")
             else:
                 np.copyto(out_crop[dst_index], src_band, casting="unsafe")

--- a/tests/unit/dataset/test_tile_utils.py
+++ b/tests/unit/dataset/test_tile_utils.py
@@ -39,23 +39,6 @@ def make_item(name: str) -> Item:
     )
 
 
-def write(
-    tile_store: DefaultTileStore,
-    item: Item,
-    bands: list[str],
-    data: np.ndarray,
-    bounds: tuple[int, int, int, int] = BOUNDS,
-) -> None:
-    tile_store.write_raster(
-        LAYER_NAME,
-        item,
-        bands,
-        PROJECTION,
-        bounds,
-        RasterArray(chw_array=data),
-    )
-
-
 def read(
     tile_store: DefaultTileStore,
     item: Item,
@@ -89,8 +72,12 @@ def test_first_valid_only_overwrites_nodata(tile_store: DefaultTileStore) -> Non
 
     item1 = make_item("item1")
     item2 = make_item("item2")
-    write(tile_store, item1, bands, array1)
-    write(tile_store, item2, bands, array2)
+    tile_store.write_raster(
+        LAYER_NAME, item1, bands, PROJECTION, BOUNDS, RasterArray(chw_array=array1)
+    )
+    tile_store.write_raster(
+        LAYER_NAME, item2, bands, PROJECTION, BOUNDS, RasterArray(chw_array=array2)
+    )
 
     dst = read(tile_store, item1, bands, nodata_val)
     assert dst is not None
@@ -115,8 +102,12 @@ def test_partially_valid_pixel_is_not_overwritten(
 
     item1 = make_item("item1")
     item2 = make_item("item2")
-    write(tile_store, item1, bands, array1)
-    write(tile_store, item2, bands, array2)
+    tile_store.write_raster(
+        LAYER_NAME, item1, bands, PROJECTION, BOUNDS, RasterArray(chw_array=array1)
+    )
+    tile_store.write_raster(
+        LAYER_NAME, item2, bands, PROJECTION, BOUNDS, RasterArray(chw_array=array2)
+    )
 
     dst = read(tile_store, item1, bands, nodata_val)
     dst = read(tile_store, item2, bands, nodata_val, dst=dst)
@@ -132,7 +123,14 @@ def test_dtype_conversion(tile_store: DefaultTileStore) -> None:
     """Stored uint8 data must be converted to the requested band_dtype."""
     bands = ["band1"]
     item = make_item("item")
-    write(tile_store, item, bands, np.full((1, 4, 4), 3, dtype=np.uint8))
+    tile_store.write_raster(
+        LAYER_NAME,
+        item,
+        bands,
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 3, dtype=np.uint8)),
+    )
 
     dst = read(tile_store, item, bands, nodata_val=0, band_dtype=np.float32)
     assert dst is not None
@@ -145,8 +143,22 @@ def test_no_nodata_overwrites_everything(tile_store: DefaultTileStore) -> None:
     bands = ["band1"]
     item1 = make_item("item1")
     item2 = make_item("item2")
-    write(tile_store, item1, bands, np.full((1, 4, 4), 5, dtype=np.uint8))
-    write(tile_store, item2, bands, np.full((1, 4, 4), 9, dtype=np.uint8))
+    tile_store.write_raster(
+        LAYER_NAME,
+        item1,
+        bands,
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 5, dtype=np.uint8)),
+    )
+    tile_store.write_raster(
+        LAYER_NAME,
+        item2,
+        bands,
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 9, dtype=np.uint8)),
+    )
 
     dst = read(tile_store, item1, bands, nodata_val=None)
     dst = read(tile_store, item2, bands, nodata_val=None, dst=dst)
@@ -157,8 +169,22 @@ def test_no_nodata_overwrites_everything(tile_store: DefaultTileStore) -> None:
 def test_band_reorder_across_band_sets(tile_store: DefaultTileStore) -> None:
     """Requested band order must be honored when bands live in separate band sets."""
     item = make_item("item")
-    write(tile_store, item, ["band1"], np.full((1, 4, 4), 1, dtype=np.uint8))
-    write(tile_store, item, ["band2"], np.full((1, 4, 4), 2, dtype=np.uint8))
+    tile_store.write_raster(
+        LAYER_NAME,
+        item,
+        ["band1"],
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 1, dtype=np.uint8)),
+    )
+    tile_store.write_raster(
+        LAYER_NAME,
+        item,
+        ["band2"],
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 2, dtype=np.uint8)),
+    )
 
     dst = read(tile_store, item, ["band2", "band1"], nodata_val=0)
     assert dst is not None
@@ -173,12 +199,13 @@ def test_partial_intersection_offset(tile_store: DefaultTileStore) -> None:
     nodata_val = 0
     item = make_item("item")
     # Item only covers the bottom-right 2x2 of the 4x4 window.
-    write(
-        tile_store,
+    tile_store.write_raster(
+        LAYER_NAME,
         item,
         bands,
-        np.full((1, 2, 2), 8, dtype=np.uint8),
-        bounds=(2, 2, 4, 4),
+        PROJECTION,
+        (2, 2, 4, 4),
+        RasterArray(chw_array=np.full((1, 2, 2), 8, dtype=np.uint8)),
     )
 
     dst = read(tile_store, item, bands, nodata_val)
@@ -193,7 +220,14 @@ def test_remapper_applied(tile_store: DefaultTileStore) -> None:
     """The remapper must be applied to source values before writing."""
     bands = ["band1"]
     item = make_item("item")
-    write(tile_store, item, bands, np.full((1, 4, 4), 100, dtype=np.uint8))
+    tile_store.write_raster(
+        LAYER_NAME,
+        item,
+        bands,
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 100, dtype=np.uint8)),
+    )
 
     remapper = LinearRemapper({"src": (0, 200), "dst": (0, 20)})
     dst = read(tile_store, item, bands, nodata_val=0, remapper=remapper)
@@ -208,8 +242,17 @@ def test_nan_nodata(tile_store: DefaultTileStore) -> None:
     item2 = make_item("item2")
     array1 = np.full((1, 4, 4), np.nan, dtype=np.float32)
     array1[0, :2, :] = 1.0
-    write(tile_store, item1, bands, array1)
-    write(tile_store, item2, bands, np.full((1, 4, 4), 2.0, dtype=np.float32))
+    tile_store.write_raster(
+        LAYER_NAME, item1, bands, PROJECTION, BOUNDS, RasterArray(chw_array=array1)
+    )
+    tile_store.write_raster(
+        LAYER_NAME,
+        item2,
+        bands,
+        PROJECTION,
+        BOUNDS,
+        RasterArray(chw_array=np.full((1, 4, 4), 2.0, dtype=np.float32)),
+    )
 
     dst = read(tile_store, item1, bands, nodata_val=float("nan"), band_dtype=np.float32)
     dst = read(

--- a/tests/unit/dataset/test_tile_utils.py
+++ b/tests/unit/dataset/test_tile_utils.py
@@ -173,7 +173,13 @@ def test_partial_intersection_offset(tile_store: DefaultTileStore) -> None:
     nodata_val = 0
     item = make_item("item")
     # Item only covers the bottom-right 2x2 of the 4x4 window.
-    write(tile_store, item, bands, np.full((1, 2, 2), 8, dtype=np.uint8), bounds=(2, 2, 4, 4))
+    write(
+        tile_store,
+        item,
+        bands,
+        np.full((1, 2, 2), 8, dtype=np.uint8),
+        bounds=(2, 2, 4, 4),
+    )
 
     dst = read(tile_store, item, bands, nodata_val)
     assert dst is not None
@@ -207,7 +213,12 @@ def test_nan_nodata(tile_store: DefaultTileStore) -> None:
 
     dst = read(tile_store, item1, bands, nodata_val=float("nan"), band_dtype=np.float32)
     dst = read(
-        tile_store, item2, bands, nodata_val=float("nan"), band_dtype=np.float32, dst=dst
+        tile_store,
+        item2,
+        bands,
+        nodata_val=float("nan"),
+        band_dtype=np.float32,
+        dst=dst,
     )
     assert dst is not None
     result = dst.get_chw_array()

--- a/tests/unit/dataset/test_tile_utils.py
+++ b/tests/unit/dataset/test_tile_utils.py
@@ -1,0 +1,215 @@
+"""Tests for rslearn.dataset.tile_utils."""
+
+import pathlib
+
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+from upath import UPath
+
+from rslearn.const import WGS84_PROJECTION
+from rslearn.data_sources.data_source import Item
+from rslearn.dataset.remap import LinearRemapper
+from rslearn.dataset.tile_utils import read_raster_window_from_tiles
+from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.tile_stores.default import DefaultTileStore
+from rslearn.utils.geometry import STGeometry
+from rslearn.utils.raster_array import RasterArray
+
+LAYER_NAME = "layer"
+BOUNDS = (0, 0, 4, 4)
+PROJECTION = WGS84_PROJECTION
+
+
+@pytest.fixture
+def tile_store(tmp_path: pathlib.Path) -> DefaultTileStore:
+    store = DefaultTileStore()
+    store.set_dataset_path(UPath(tmp_path))
+    return store
+
+
+def make_item(name: str) -> Item:
+    return Item(
+        name=name,
+        geometry=STGeometry(
+            projection=PROJECTION,
+            shp=Polygon([(0, 0), (10, 0), (10, 10), (0, 10)]),
+            time_range=None,
+        ),
+    )
+
+
+def write(
+    tile_store: DefaultTileStore,
+    item: Item,
+    bands: list[str],
+    data: np.ndarray,
+    bounds: tuple[int, int, int, int] = BOUNDS,
+) -> None:
+    tile_store.write_raster(
+        LAYER_NAME,
+        item,
+        bands,
+        PROJECTION,
+        bounds,
+        RasterArray(chw_array=data),
+    )
+
+
+def read(
+    tile_store: DefaultTileStore,
+    item: Item,
+    bands: list[str],
+    nodata_val: int | float | None,
+    band_dtype: type = np.uint8,
+    dst: RasterArray | None = None,
+    remapper: LinearRemapper | None = None,
+) -> RasterArray | None:
+    return read_raster_window_from_tiles(
+        tile_store=TileStoreWithLayer(tile_store, LAYER_NAME),
+        item=item,
+        bands=bands,
+        projection=PROJECTION,
+        bounds=BOUNDS,
+        nodata_val=nodata_val,
+        band_dtype=band_dtype,
+        remapper=remapper,
+        dst=dst,
+    )
+
+
+def test_first_valid_only_overwrites_nodata(tile_store: DefaultTileStore) -> None:
+    """A second item must only fill pixels still at nodata after the first."""
+    bands = ["band1", "band2"]
+    nodata_val = 0
+
+    array1 = np.zeros((2, 4, 4), dtype=np.uint8)
+    array1[:, :2, :] = 7  # top half valid
+    array2 = np.full((2, 4, 4), 9, dtype=np.uint8)  # fully valid
+
+    item1 = make_item("item1")
+    item2 = make_item("item2")
+    write(tile_store, item1, bands, array1)
+    write(tile_store, item2, bands, array2)
+
+    dst = read(tile_store, item1, bands, nodata_val)
+    assert dst is not None
+    dst = read(tile_store, item2, bands, nodata_val, dst=dst)
+    assert dst is not None
+
+    result = dst.get_chw_array()
+    assert np.array_equal(result[:, :2, :], np.full((2, 2, 4), 7))  # kept
+    assert np.array_equal(result[:, 2:, :], np.full((2, 2, 4), 9))  # filled
+
+
+def test_partially_valid_pixel_is_not_overwritten(
+    tile_store: DefaultTileStore,
+) -> None:
+    """First-valid masks on ALL bands being nodata: a pixel valid in one band only is kept."""
+    bands = ["band1", "band2"]
+    nodata_val = 0
+
+    array1 = np.zeros((2, 4, 4), dtype=np.uint8)
+    array1[0, :, :] = 5  # band1 valid everywhere; band2 all nodata
+    array2 = np.full((2, 4, 4), 9, dtype=np.uint8)
+
+    item1 = make_item("item1")
+    item2 = make_item("item2")
+    write(tile_store, item1, bands, array1)
+    write(tile_store, item2, bands, array2)
+
+    dst = read(tile_store, item1, bands, nodata_val)
+    dst = read(tile_store, item2, bands, nodata_val, dst=dst)
+    assert dst is not None
+
+    result = dst.get_chw_array()
+    # Pixel was not all-nodata, so item2 must not have touched either band.
+    assert np.array_equal(result[0], np.full((4, 4), 5))
+    assert np.array_equal(result[1], np.zeros((4, 4)))
+
+
+def test_dtype_conversion(tile_store: DefaultTileStore) -> None:
+    """Stored uint8 data must be converted to the requested band_dtype."""
+    bands = ["band1"]
+    item = make_item("item")
+    write(tile_store, item, bands, np.full((1, 4, 4), 3, dtype=np.uint8))
+
+    dst = read(tile_store, item, bands, nodata_val=0, band_dtype=np.float32)
+    assert dst is not None
+    assert dst.array.dtype == np.float32
+    assert np.array_equal(dst.get_chw_array(), np.full((1, 4, 4), 3.0))
+
+
+def test_no_nodata_overwrites_everything(tile_store: DefaultTileStore) -> None:
+    """With nodata_val=None every source pixel overwrites the destination."""
+    bands = ["band1"]
+    item1 = make_item("item1")
+    item2 = make_item("item2")
+    write(tile_store, item1, bands, np.full((1, 4, 4), 5, dtype=np.uint8))
+    write(tile_store, item2, bands, np.full((1, 4, 4), 9, dtype=np.uint8))
+
+    dst = read(tile_store, item1, bands, nodata_val=None)
+    dst = read(tile_store, item2, bands, nodata_val=None, dst=dst)
+    assert dst is not None
+    assert np.array_equal(dst.get_chw_array(), np.full((1, 4, 4), 9))
+
+
+def test_band_reorder_across_band_sets(tile_store: DefaultTileStore) -> None:
+    """Requested band order must be honored when bands live in separate band sets."""
+    item = make_item("item")
+    write(tile_store, item, ["band1"], np.full((1, 4, 4), 1, dtype=np.uint8))
+    write(tile_store, item, ["band2"], np.full((1, 4, 4), 2, dtype=np.uint8))
+
+    dst = read(tile_store, item, ["band2", "band1"], nodata_val=0)
+    assert dst is not None
+    result = dst.get_chw_array()
+    assert np.array_equal(result[0], np.full((4, 4), 2))
+    assert np.array_equal(result[1], np.full((4, 4), 1))
+
+
+def test_partial_intersection_offset(tile_store: DefaultTileStore) -> None:
+    """An item covering part of the window writes at the right offset, rest stays nodata."""
+    bands = ["band1"]
+    nodata_val = 0
+    item = make_item("item")
+    # Item only covers the bottom-right 2x2 of the 4x4 window.
+    write(tile_store, item, bands, np.full((1, 2, 2), 8, dtype=np.uint8), bounds=(2, 2, 4, 4))
+
+    dst = read(tile_store, item, bands, nodata_val)
+    assert dst is not None
+    result = dst.get_chw_array()
+    assert np.array_equal(result[0, 2:, 2:], np.full((2, 2), 8))
+    assert np.array_equal(result[0, :2, :], np.zeros((2, 4)))
+    assert np.array_equal(result[0, 2:, :2], np.zeros((2, 2)))
+
+
+def test_remapper_applied(tile_store: DefaultTileStore) -> None:
+    """The remapper must be applied to source values before writing."""
+    bands = ["band1"]
+    item = make_item("item")
+    write(tile_store, item, bands, np.full((1, 4, 4), 100, dtype=np.uint8))
+
+    remapper = LinearRemapper({"src": (0, 200), "dst": (0, 20)})
+    dst = read(tile_store, item, bands, nodata_val=0, remapper=remapper)
+    assert dst is not None
+    assert np.array_equal(dst.get_chw_array(), np.full((1, 4, 4), 10))
+
+
+def test_nan_nodata(tile_store: DefaultTileStore) -> None:
+    """NaN nodata sentinels must be matched by the first-valid mask."""
+    bands = ["band1"]
+    item1 = make_item("item1")
+    item2 = make_item("item2")
+    array1 = np.full((1, 4, 4), np.nan, dtype=np.float32)
+    array1[0, :2, :] = 1.0
+    write(tile_store, item1, bands, array1)
+    write(tile_store, item2, bands, np.full((1, 4, 4), 2.0, dtype=np.float32))
+
+    dst = read(tile_store, item1, bands, nodata_val=float("nan"), band_dtype=np.float32)
+    dst = read(
+        tile_store, item2, bands, nodata_val=float("nan"), band_dtype=np.float32, dst=dst
+    )
+    assert dst is not None
+    result = dst.get_chw_array()
+    assert np.array_equal(result[0, :2, :], np.full((2, 4), 1.0))
+    assert np.array_equal(result[0, 2:, :], np.full((2, 4), 2.0))


### PR DESCRIPTION
When materializing whole-scene windows (e.g. Sentinel-1 vessel detection, 25,630×20,455 px), `read_raster_window_from_tiles` allocates several multi-GB intersection-sized temporaries on top of the source and destination arrays: the `src[src_indexes]` fancy-index copy, an unconditional `astype()` copy, an `out_crop[dst_indexes]` copy in the mask computation, and per-band masked-gather copies. Materializing a two-item historical layer peaked at **26.7 GiB** anon, OOM-killing our inference container on nodes with ~26 GiB allocatable.

This rewrites the write path to work band-by-band on views: the first-valid mask is computed incrementally per band, and writes go through `np.copyto(..., where=mask, casting="unsafe")`, which converts dtype on the fly with the same semantics as the `astype()` it replaces. Peak extra allocation is now one (T, H, W) bool mask.

Verified on the production scene that triggered the OOM (target + 2 historicals, image-mode predict_pipeline from rslearn_projects, v0.0.23 image with this file patched in): peak anon dropped **26.7 → 20.4 GiB**, identical predictions (114 detections, matching lat/lon/score), ~1 min faster wall clock.

Behavior is unchanged; adds `tests/unit/dataset/test_tile_utils.py` covering first-valid masking (incl. partially-valid pixels and NaN nodata), dtype conversion, band reordering across band sets, partial intersection offsets, remapping, and the `nodata_val=None` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)