### PR TITLE
Built-in normalization for OlmoEarth

### DIFF
--- a/rslearn/models/olmoearth_pretrain/model.py
+++ b/rslearn/models/olmoearth_pretrain/model.py
@@ -11,6 +11,9 @@ from typing import Any
 import torch
 from einops import rearrange
 from olmoearth_pretrain_minimal import ModelID, load_model_from_id, load_model_from_path
+from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.data.normalize import (
+    load_computed_config,
+)
 from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.nn.flexi_vit import (
     TokensAndMasks,
 )
@@ -24,6 +27,7 @@ from upath import UPath
 
 from rslearn.log_utils import get_logger
 from rslearn.models.component import FeatureExtractor, FeatureMaps, TokenFeatureMaps
+from rslearn.models.olmoearth_pretrain.norm import OlmoEarthNormalize
 from rslearn.train.model_context import ModelContext, RasterImage
 
 logger = get_logger(__name__)
@@ -72,6 +76,9 @@ class OlmoEarth(FeatureExtractor):
         token_pooling: bool = True,
         use_legacy_timestamps: bool = True,
         timestamp_error_tolerance: timedelta = timedelta(days=15),
+        normalize: bool = False,
+        normalize_band_names: dict[str, list[str]] | None = None,
+        normalize_std_multiplier: float | None = 2,
     ):
         """Create a new OlmoEarth model.
 
@@ -108,6 +115,19 @@ class OlmoEarth(FeatureExtractor):
                 if the closest previous timestamp to a new image is within timestamp_error_tolerance of
                 the new image's capture time, then we reuse that timestamp; otherwise, we create a new
                 timestep.
+            normalize: whether to normalize the inputs inside the forward pass using
+                OlmoEarthNormalize. Defaults to False, in which case the inputs are
+                assumed to already be normalized (e.g. by an OlmoEarthNormalize transform
+                in the data pipeline). When True, the inputs must be the raw, un-normalized
+                values (Sentinel-1 must still be converted to decibels beforehand), and
+                they will be normalized in place at the start of forward.
+            normalize_band_names: map from modality name to the list of bands in that
+                modality in the order they are being loaded, passed through to
+                OlmoEarthNormalize. Only used when normalize=True. If None, the band
+                names are derived from the OlmoEarth modality definitions for every
+                modality that has normalization statistics.
+            normalize_std_multiplier: the std multiplier to use for normalization, passed
+                through to OlmoEarthNormalize. Only used when normalize=True.
         """
         if use_legacy_timestamps:
             warnings.warn(
@@ -168,6 +188,29 @@ class OlmoEarth(FeatureExtractor):
         self.token_pooling = token_pooling
         self.use_legacy_timestamps = use_legacy_timestamps
         self.timestamp_error_tolerance = timestamp_error_tolerance
+
+        self.normalize = normalize
+        if normalize:
+            if normalize_band_names is None:
+                # Derive the band names from the OlmoEarth modality definitions for
+                # every modality that has normalization statistics. Some modalities
+                # (e.g. openstreetmap_raster) have no stats and are left un-normalized.
+                norm_config = load_computed_config()
+                normalize_band_names = {
+                    modality: [
+                        band
+                        for band_set in Modality.get(modality).band_sets
+                        for band in band_set.bands
+                    ]
+                    for modality in MODALITY_NAMES
+                    if modality in norm_config
+                }
+            # skip_missing so modalities absent from a given sample are ignored.
+            self.normalizer = OlmoEarthNormalize(
+                band_names=normalize_band_names,
+                std_multiplier=normalize_std_multiplier,
+                skip_missing=True,
+            )
 
     def _patch_legacy_encoder_config(self, config_dict: dict) -> dict:
         """Patch checkpoint config dicts that predate use_linear_patch_embed.
@@ -656,6 +699,12 @@ class OlmoEarth(FeatureExtractor):
             a FeatureMaps consisting of one feature map, at 1/patch_size of the input
                 resolution. Embeddings will be pooled across modalities and timesteps.
         """
+        if self.normalize:
+            # Normalize each sample's inputs in place before assembling the modality
+            # tensors. The targets are not needed so we pass an empty dict.
+            for input_dict in context.inputs:
+                self.normalizer(input_dict, {})
+
         if self.use_legacy_timestamps:
             sample, present_modalities, device = self._prepare_modality_inputs_legacy(
                 context

--- a/rslearn/models/olmoearth_pretrain/model.py
+++ b/rslearn/models/olmoearth_pretrain/model.py
@@ -77,7 +77,6 @@ class OlmoEarth(FeatureExtractor):
         use_legacy_timestamps: bool = True,
         timestamp_error_tolerance: timedelta = timedelta(days=15),
         normalize: bool = False,
-        normalize_band_names: dict[str, list[str]] | None = None,
         normalize_std_multiplier: float | None = 2,
     ):
         """Create a new OlmoEarth model.
@@ -120,12 +119,9 @@ class OlmoEarth(FeatureExtractor):
                 assumed to already be normalized (e.g. by an OlmoEarthNormalize transform
                 in the data pipeline). When True, the inputs must be the raw, un-normalized
                 values (Sentinel-1 must still be converted to decibels beforehand), and
-                they will be normalized in place at the start of forward.
-            normalize_band_names: map from modality name to the list of bands in that
-                modality in the order they are being loaded, passed through to
-                OlmoEarthNormalize. Only used when normalize=True. If None, the band
-                names are derived from the OlmoEarth modality definitions for every
-                modality that has normalization statistics.
+                they will be normalized in place at the start of forward. The band order
+                is assumed to match the canonical OlmoEarth modality definitions, which is
+                the same order the rest of the model assumes for the input channels.
             normalize_std_multiplier: the std multiplier to use for normalization, passed
                 through to OlmoEarthNormalize. Only used when normalize=True.
         """
@@ -191,23 +187,24 @@ class OlmoEarth(FeatureExtractor):
 
         self.normalize = normalize
         if normalize:
-            if normalize_band_names is None:
-                # Derive the band names from the OlmoEarth modality definitions for
-                # every modality that has normalization statistics. Some modalities
-                # (e.g. openstreetmap_raster) have no stats and are left un-normalized.
-                norm_config = load_computed_config()
-                normalize_band_names = {
-                    modality: [
-                        band
-                        for band_set in Modality.get(modality).band_sets
-                        for band in band_set.bands
-                    ]
-                    for modality in MODALITY_NAMES
-                    if modality in norm_config
-                }
+            # Derive the band names from the OlmoEarth modality definitions for every
+            # modality that has normalization statistics. The input channels are already
+            # assumed to be in this canonical order (see _prepare_modality_inputs), so
+            # there is no separate band order to configure. Some modalities (e.g.
+            # openstreetmap_raster) have no stats and are left un-normalized.
+            norm_config = load_computed_config()
+            band_names = {
+                modality: [
+                    band
+                    for band_set in Modality.get(modality).band_sets
+                    for band in band_set.bands
+                ]
+                for modality in MODALITY_NAMES
+                if modality in norm_config
+            }
             # skip_missing so modalities absent from a given sample are ignored.
             self.normalizer = OlmoEarthNormalize(
-                band_names=normalize_band_names,
+                band_names=band_names,
                 std_multiplier=normalize_std_multiplier,
                 skip_missing=True,
             )

--- a/tests/unit/models/olmoearth_pretrain/test_model.py
+++ b/tests/unit/models/olmoearth_pretrain/test_model.py
@@ -938,6 +938,47 @@ def test_normal_timestamps_two_modalities_1hr_tolerance() -> None:
         )
 
 
+def test_normalize_in_forward() -> None:
+    """normalize=True should normalize the inputs in place using OlmoEarthNormalize."""
+    from rslearn.models.olmoearth_pretrain.norm import OlmoEarthNormalize
+
+    model = OlmoEarth(
+        checkpoint_path="tests/unit/models/olmoearth_pretrain/",
+        random_initialization=True,
+        patch_size=4,
+        embedding_size=128,
+        normalize=True,
+    )
+
+    T = 2
+    H = 4
+    W = 4
+    band_names = [
+        "B02", "B03", "B04", "B08", "B05", "B06",
+        "B07", "B8A", "B11", "B12", "B01", "B09",
+    ]  # fmt: skip
+    raw_image = torch.arange(12 * T * H * W, dtype=torch.float32).reshape(12, T, H, W)
+    timestamps = [(datetime(2025, x, 1), datetime(2025, x, 1)) for x in range(1, T + 1)]
+
+    inputs = [
+        {"sentinel2_l2a": RasterImage(image=raw_image.clone(), timestamps=timestamps)}
+    ]
+    model(ModelContext(inputs=inputs, metadatas=[_make_metadata((0, 0, H, W))]))
+
+    # The inputs should have been normalized in place, matching a standalone
+    # OlmoEarthNormalize applied to the same raw inputs.
+    expected = {
+        "sentinel2_l2a": RasterImage(image=raw_image.clone(), timestamps=timestamps)
+    }
+    OlmoEarthNormalize(band_names={"sentinel2_l2a": band_names})(expected, {})
+
+    assert torch.allclose(
+        inputs[0]["sentinel2_l2a"].image, expected["sentinel2_l2a"].image
+    )
+    # Sanity check that normalization actually changed the values.
+    assert not torch.allclose(inputs[0]["sentinel2_l2a"].image, raw_image)
+
+
 def test_compute_tokens_in_batch() -> None:
     """Verify token count is B*H*W*T*S summed across present modalities."""
     # H, W, T are shared across modalities; S (band sets) differs.


### PR DESCRIPTION
We had a few conversations where folks wouldn't normalize inputs before passing them to OlmoEarth via rslearn, since they assumed we did that automatically. 

This makes that an option during init. 