### PR TITLE
[New feature] Add GeoParquet support for Sentinel2 from PC

### DIFF
--- a/docs/data_sources/planetary_computer_Sentinel2.md
+++ b/docs/data_sources/planetary_computer_Sentinel2.md
@@ -18,12 +18,46 @@ Sentinel-2 satellite images from https://planetarycomputer.microsoft.com/dataset
     "query": null,
     "sort_by": null,
     "sort_ascending": true,
+    // Metadata backend for scene discovery. The default "stac" uses the Planetary
+    // Computer STAC API. Set "geoparquet" to query the collection's GeoParquet item
+    // table instead, which avoids per-window STAC search requests during prepare.
+    "metadata_backend": "stac",
+    // Optional cache directory for GeoParquet partition listings and local query
+    // result subsets. Relative paths are resolved against the dataset root.
+    "metadata_cache_dir": null,
+    // Optional explicit GeoParquet href. If omitted with metadata_backend="geoparquet",
+    // rslearn resolves the collection-level "geoparquet-items" asset.
+    "geoparquet_href": null,
     "timeout_seconds": 10
   }
 }
 ```
 
 This data source supports direct materialization (`"ingest": false`).
+
+### GeoParquet Metadata Backend
+
+For large batches of windows, Planetary Computer STAC searches can hit API rate limits.
+Set `metadata_backend` to `"geoparquet"` to perform one bulk metadata query over the
+Sentinel-2 L2A GeoParquet item table for each `get_items` call. During
+`rslearn dataset prepare`, rslearn already passes all windows that need a layer into
+one `get_items` call, so the backend infers the aggregate spatial bounds and time range
+from the windows and then filters exact per-window matches locally.
+
+```jsonc
+{
+  "class_path": "rslearn.data_sources.planetary_computer.Sentinel2",
+  "init_args": {
+    "harmonize": true,
+    "sort_by": "eo:cloud_cover",
+    "metadata_backend": "geoparquet",
+    "metadata_cache_dir": "cache/planetary_computer/sentinel2_l2a"
+  }
+}
+```
+
+The GeoParquet backend requires the optional `duckdb` dependency, included in
+rslearn's `extra` optional dependencies.
 
 ### Available Bands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 # These are requirements that are specific to a subset of data sources or models.
 extra = [
     "cdsapi>=0.7.6",
+    "duckdb>=1.3",
     "earthdaily[platform]>=1.9.0",
     "earthengine-api>=1.6.3",
     "einops>=0.8",

--- a/rslearn/data_sources/planetary_computer.py
+++ b/rslearn/data_sources/planetary_computer.py
@@ -1,18 +1,24 @@
 """Data on Planetary Computer."""
 
+import hashlib
+import json
 import os
+import re
 import tempfile
 import warnings
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 import numpy.typing as npt
 import planetary_computer
 import rasterio
 import requests
+import shapely
 import xarray as xr
 from typing_extensions import override
 from upath import UPath
@@ -23,13 +29,15 @@ from rslearn.data_sources.direct_materialize_data_source import (
     DirectMaterializeDataSource,
 )
 from rslearn.data_sources.stac import SourceItem, StacDataSource
+from rslearn.data_sources.utils import MatchedItemGroup, match_candidate_items_to_window
 from rslearn.log_utils import get_logger
 from rslearn.tile_stores import TileStoreWithLayer
+from rslearn.utils.fsspec import join_upath
 from rslearn.utils.geometry import STGeometry
 from rslearn.utils.interpolation import NODATA_VALUE, interpolate_to_grid
 from rslearn.utils.raster_array import RasterArray, RasterMetadata
 from rslearn.utils.raster_format import get_raster_projection_and_bounds
-from rslearn.utils.stac import StacClient, StacItem
+from rslearn.utils.stac import StacAsset, StacClient, StacItem
 
 from .copernicus import get_harmonize_callback
 
@@ -37,6 +45,585 @@ logger = get_logger(__name__)
 
 # Max limit accepted by Planetary Computer API.
 PLANETARY_COMPUTER_LIMIT = 1000
+
+
+class PlanetaryComputerMetadataBackend(StrEnum):
+    """Metadata backend for Planetary Computer item discovery."""
+
+    STAC = "stac"
+    GEOPARQUET = "geoparquet"
+
+
+def _datetime_to_utc(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _quote_duckdb_identifier(identifier: str) -> str:
+    """Quote a DuckDB identifier."""
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _quote_duckdb_string(value: str) -> str:
+    """Quote a DuckDB string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+class PlanetaryComputerGeoParquetClient:
+    """A STAC-like client that searches Planetary Computer STAC GeoParquet items.
+
+    Planetary Computer exposes collection-level ``geoparquet-items`` assets for bulk
+    item metadata queries. For large prepare jobs this avoids one STAC API request per
+    window, which can otherwise hit Planetary Computer API rate limits.
+    """
+
+    GEOPARQUET_ASSET_KEY = "geoparquet-items"
+    _PARTITION_RE = re.compile(
+        r"/part-\d+_"
+        r"(?P<start>\d{4}-\d{2}-\d{2}T[^_]+)"
+        r"_"
+        r"(?P<end>\d{4}-\d{2}-\d{2}T[^_]+)"
+        r"\.parquet$"
+    )
+    _SENTINEL2_ID_TIME_RE = re.compile(r"_MSIL2A_(?P<date>\d{8})T\d{6}_")
+
+    def __init__(
+        self,
+        endpoint: str,
+        collection_name: str,
+        required_assets: list[str] | None,
+        query_properties: list[str],
+        timeout: timedelta,
+        metadata_cache_dir: UPath | None = None,
+        geoparquet_href: str | None = None,
+    ) -> None:
+        """Create a GeoParquet-backed client.
+
+        Args:
+            endpoint: Planetary Computer STAC endpoint.
+            collection_name: STAC collection name.
+            required_assets: asset keys that must exist on returned items.
+            query_properties: STAC property columns needed for filtering/sorting.
+            timeout: HTTP timeout for collection metadata and Azure listing requests.
+            metadata_cache_dir: optional directory for file-list and query-result cache.
+            geoparquet_href: optional explicit GeoParquet asset href.
+        """
+        self.endpoint = endpoint
+        self.collection_name = collection_name
+        self.required_assets = required_assets
+        self.query_properties = query_properties
+        self.timeout = timeout
+        self.metadata_cache_dir = metadata_cache_dir
+        self.geoparquet_href = geoparquet_href
+
+        self._resolved_geoparquet_url: str | None = None
+        self._partition_blob_names: list[str] | None = None
+        self._items_by_name: dict[str, StacItem] = {}
+
+        if self.metadata_cache_dir is not None:
+            self.metadata_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def search(
+        self,
+        collections: list[str] | None = None,
+        bbox: tuple[float, float, float, float] | None = None,
+        intersects: dict[str, Any] | None = None,
+        date_time: datetime | tuple[datetime, datetime] | None = None,
+        ids: list[str] | None = None,
+        limit: int | None = None,
+        query: dict[str, Any] | None = None,
+        sortby: list[dict[str, str]] | None = None,
+    ) -> list[StacItem]:
+        """Execute a STAC-like item search against STAC GeoParquet rows."""
+        del limit
+
+        if collections is not None and self.collection_name not in collections:
+            return []
+
+        if (
+            ids is not None
+            and bbox is None
+            and intersects is None
+            and date_time is None
+            and query is None
+            and sortby is None
+            and all(item_id in self._items_by_name for item_id in ids)
+        ):
+            return [self._items_by_name[item_id] for item_id in ids]
+
+        if bbox is None and intersects is not None:
+            bbox = shapely.geometry.shape(intersects).bounds
+
+        search_time_range = self._normalize_search_time_range(date_time)
+        if search_time_range is None and ids is not None:
+            search_time_range = self._infer_time_range_from_sentinel2_ids(ids)
+
+        rows = self._read_geoparquet_rows(
+            bbox=bbox,
+            date_time=search_time_range,
+            ids=ids,
+            query=query,
+            sortby=sortby,
+        )
+        stac_items = [self._row_to_stac_item(row) for row in rows]
+        for stac_item in stac_items:
+            self._items_by_name[stac_item.id] = stac_item
+        return stac_items
+
+    def _normalize_search_time_range(
+        self, date_time: datetime | tuple[datetime, datetime] | None
+    ) -> tuple[datetime, datetime] | None:
+        """Normalize a STAC search datetime argument to a range."""
+        if date_time is None:
+            return None
+        if isinstance(date_time, tuple):
+            return (_datetime_to_utc(date_time[0]), _datetime_to_utc(date_time[1]))
+        dt = _datetime_to_utc(date_time)
+        return (dt, dt)
+
+    def _infer_time_range_from_sentinel2_ids(
+        self, ids: list[str]
+    ) -> tuple[datetime, datetime] | None:
+        """Infer a coarse time range from Sentinel-2 item IDs."""
+        dates: list[datetime] = []
+        for item_id in ids:
+            match = self._SENTINEL2_ID_TIME_RE.search(item_id)
+            if match is None:
+                continue
+            dates.append(
+                datetime.strptime(match.group("date"), "%Y%m%d").replace(tzinfo=UTC)
+            )
+        if not dates:
+            return None
+        return (min(dates), max(dates) + timedelta(days=1))
+
+    def _get_duckdb(self) -> Any:
+        """Import duckdb lazily so GeoParquet support is optional."""
+        try:
+            import duckdb
+        except (
+            ImportError
+        ) as e:  # pragma: no cover - exercised only without optional dep
+            raise ImportError(
+                "Planetary Computer GeoParquet metadata requires the optional "
+                "'duckdb' dependency. Install rslearn with the 'extra' extras or "
+                "install duckdb separately."
+            ) from e
+        return duckdb
+
+    def _resolve_geoparquet_url(self) -> str:
+        """Resolve the configured or collection-level GeoParquet href to HTTPS."""
+        if self._resolved_geoparquet_url is not None:
+            return self._resolved_geoparquet_url
+
+        href = self.geoparquet_href
+        storage_account: str | None = None
+        if href is None:
+            response = requests.get(
+                f"{self.endpoint}/collections/{self.collection_name}",
+                timeout=self.timeout.total_seconds(),
+            )
+            response.raise_for_status()
+            collection = response.json()
+            asset = collection.get("assets", {}).get(self.GEOPARQUET_ASSET_KEY)
+            if asset is None:
+                raise ValueError(
+                    f"Planetary Computer collection {self.collection_name!r} has no "
+                    f"{self.GEOPARQUET_ASSET_KEY!r} asset"
+                )
+            href = asset["href"]
+            storage_account = asset.get("table:storage_options", {}).get("account_name")
+
+        parsed = urlparse(href)
+        if parsed.scheme in ("http", "https", "file"):
+            self._resolved_geoparquet_url = href
+            return href
+        if parsed.scheme == "abfs":
+            if not storage_account:
+                raise ValueError(
+                    f"GeoParquet href {href!r} requires table:storage_options.account_name"
+                )
+            container = parsed.netloc
+            blob = parsed.path.lstrip("/")
+            self._resolved_geoparquet_url = (
+                f"https://{storage_account}.blob.core.windows.net/{container}/{blob}"
+            )
+            return self._resolved_geoparquet_url
+
+        raise ValueError(f"unsupported GeoParquet href scheme in {href!r}")
+
+    def _get_signed_query_string(self, base_url: str) -> str:
+        """Return a Planetary Computer SAS query string for an HTTPS Blob URL."""
+        signed = planetary_computer.sign(base_url)
+        if "?" not in signed:
+            return ""
+        return signed.split("?", 1)[1]
+
+    def _list_partition_blob_names(self) -> list[str]:
+        """List partition parquet blob names under the GeoParquet directory."""
+        if self._partition_blob_names is not None:
+            return self._partition_blob_names
+
+        cache_path = None
+        if self.metadata_cache_dir is not None:
+            cache_path = self.metadata_cache_dir / "geoparquet_partitions.json"
+            if cache_path.exists():
+                with cache_path.open() as f:
+                    self._partition_blob_names = json.load(f)
+                return self._partition_blob_names
+
+        base_url = self._resolve_geoparquet_url()
+        parsed = urlparse(base_url)
+        if parsed.scheme == "file" or parsed.scheme == "":
+            self._partition_blob_names = [base_url]
+            return self._partition_blob_names
+        if parsed.scheme != "https":
+            raise ValueError(f"expected HTTPS GeoParquet URL, got {base_url!r}")
+
+        account_url = f"{parsed.scheme}://{parsed.netloc}"
+        path_parts = parsed.path.lstrip("/").split("/", 1)
+        if len(path_parts) != 2:
+            raise ValueError(f"invalid Azure Blob GeoParquet URL {base_url!r}")
+        container, blob_prefix = path_parts
+
+        query_string = self._get_signed_query_string(base_url)
+        names: list[str] = []
+        marker = ""
+        while True:
+            list_url = (
+                f"{account_url}/{container}?restype=container&comp=list"
+                f"&prefix={blob_prefix}/&maxresults=5000"
+            )
+            if marker:
+                list_url += f"&marker={marker}"
+            if query_string:
+                list_url += f"&{query_string}"
+            response = requests.get(list_url, timeout=self.timeout.total_seconds())
+            response.raise_for_status()
+
+            root = ET.fromstring(response.content)
+            for name_el in root.findall(".//Blob/Name"):
+                if name_el.text and name_el.text.endswith(".parquet"):
+                    names.append(name_el.text)
+
+            marker_el = root.find("NextMarker")
+            if marker_el is None or not marker_el.text:
+                break
+            marker = marker_el.text
+
+        self._partition_blob_names = names
+        if cache_path is not None:
+            with cache_path.open("w") as f:
+                json.dump(names, f)
+        return names
+
+    def _partition_time_range(
+        self, blob_name_or_url: str
+    ) -> tuple[datetime, datetime] | None:
+        """Parse the time range encoded in a Planetary Computer partition filename."""
+        match = self._PARTITION_RE.search(blob_name_or_url)
+        if match is None:
+            return None
+        return (
+            datetime.fromisoformat(match.group("start")),
+            datetime.fromisoformat(match.group("end")),
+        )
+
+    def _get_parquet_files(
+        self, date_time: tuple[datetime, datetime] | None
+    ) -> list[str]:
+        """Return signed Parquet files relevant to the requested time range."""
+        base_url = self._resolve_geoparquet_url()
+        parsed = urlparse(base_url)
+        if parsed.scheme == "file" or parsed.scheme == "":
+            return [base_url]
+
+        path_parts = parsed.path.lstrip("/").split("/", 1)
+        if len(path_parts) != 2:
+            raise ValueError(f"invalid Azure Blob GeoParquet URL {base_url!r}")
+        container, _ = path_parts
+        account_url = f"{parsed.scheme}://{parsed.netloc}"
+        query_string = self._get_signed_query_string(base_url)
+
+        files = []
+        for blob_name in self._list_partition_blob_names():
+            partition_time_range = self._partition_time_range(blob_name)
+            if date_time is not None and partition_time_range is not None:
+                if (
+                    partition_time_range[1] < date_time[0]
+                    or partition_time_range[0] > date_time[1]
+                ):
+                    continue
+            url = f"{account_url}/{container}/{blob_name}"
+            if query_string:
+                url += f"?{query_string}"
+            files.append(url)
+        return files
+
+    def _cache_path(
+        self,
+        *,
+        bbox: tuple[float, float, float, float] | None,
+        date_time: tuple[datetime, datetime] | None,
+        ids: list[str] | None,
+        query: dict[str, Any] | None,
+        sortby: list[dict[str, str]] | None,
+    ) -> UPath | None:
+        """Return a local cache path for a GeoParquet query result."""
+        if self.metadata_cache_dir is None:
+            return None
+        parsed_cache = urlparse(str(self.metadata_cache_dir))
+        if parsed_cache.scheme not in ("", "file"):
+            return None
+        key_payload = {
+            "collection": self.collection_name,
+            "geoparquet_url": self._resolve_geoparquet_url(),
+            "bbox": bbox,
+            "date_time": [dt.isoformat() for dt in date_time] if date_time else None,
+            "ids": sorted(ids) if ids else None,
+            "query": query,
+            "sortby": sortby,
+            "required_assets": self.required_assets,
+            "query_properties": self.query_properties,
+            "version": 1,
+        }
+        key = hashlib.sha256(
+            json.dumps(key_payload, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        query_cache_dir = self.metadata_cache_dir / "queries"
+        query_cache_dir.mkdir(parents=True, exist_ok=True)
+        return query_cache_dir / f"{key}.parquet"
+
+    def _query_condition_sql(
+        self, query: dict[str, Any] | None, params: list[Any]
+    ) -> list[str]:
+        """Translate supported STAC query predicates to DuckDB SQL."""
+        if query is None:
+            return []
+
+        conditions = []
+        op_to_sql = {
+            "eq": "=",
+            "lt": "<",
+            "lte": "<=",
+            "gt": ">",
+            "gte": ">=",
+        }
+        for prop_name, predicate in query.items():
+            column = _quote_duckdb_identifier(prop_name)
+            if not isinstance(predicate, dict):
+                conditions.append(f"{column} = ?")
+                params.append(predicate)
+                continue
+            for op, value in predicate.items():
+                if op in op_to_sql:
+                    conditions.append(f"{column} {op_to_sql[op]} ?")
+                    params.append(value)
+                elif op == "in":
+                    if not isinstance(value, list) or len(value) == 0:
+                        raise ValueError(
+                            f"STAC query operator 'in' for {prop_name!r} requires a non-empty list"
+                        )
+                    placeholders = ", ".join("?" for _ in value)
+                    conditions.append(f"{column} IN ({placeholders})")
+                    params.extend(value)
+                else:
+                    raise ValueError(
+                        f"unsupported STAC query operator {op!r} for GeoParquet backend"
+                    )
+        return conditions
+
+    def _build_select_sql(
+        self,
+        files_expr: str,
+        *,
+        bbox: tuple[float, float, float, float] | None,
+        date_time: tuple[datetime, datetime] | None,
+        ids: list[str] | None,
+        query: dict[str, Any] | None,
+        sortby: list[dict[str, str]] | None,
+        params: list[Any],
+    ) -> str:
+        """Build a DuckDB SELECT over STAC GeoParquet files."""
+        property_columns = []
+        for prop_name in self.query_properties:
+            if prop_name == "datetime" or prop_name in property_columns:
+                continue
+            property_columns.append(prop_name)
+
+        select_columns = [
+            "id",
+            "bbox",
+            "datetime",
+            "collection",
+            "assets",
+            "geometry",
+            *[_quote_duckdb_identifier(prop) for prop in property_columns],
+        ]
+        conditions = ["collection = ?"]
+        params.append(self.collection_name)
+
+        if date_time is not None:
+            conditions.append("datetime >= ? AND datetime <= ?")
+            params.extend(date_time)
+        if bbox is not None:
+            west, south, east, north = bbox
+            conditions.append(
+                "bbox.xmin < ? AND bbox.xmax > ? AND bbox.ymin < ? AND bbox.ymax > ?"
+            )
+            params.extend([east, west, north, south])
+        if ids is not None:
+            if len(ids) == 0:
+                conditions.append("FALSE")
+            else:
+                placeholders = ", ".join("?" for _ in ids)
+                conditions.append(f"id IN ({placeholders})")
+                params.extend(ids)
+        if self.required_assets is not None:
+            for asset_key in self.required_assets:
+                conditions.append(
+                    f"assets.{_quote_duckdb_identifier(asset_key)}.href IS NOT NULL"
+                )
+
+        conditions.extend(self._query_condition_sql(query, params))
+
+        order_by = ""
+        if sortby is not None:
+            order_clauses = []
+            for spec in sortby:
+                direction = spec.get("direction", "asc").upper()
+                if direction not in ("ASC", "DESC"):
+                    raise ValueError(f"invalid sort direction {direction!r}")
+                order_clauses.append(
+                    f"{_quote_duckdb_identifier(spec['field'])} {direction}"
+                )
+            if order_clauses:
+                order_by = " ORDER BY " + ", ".join(order_clauses)
+
+        return (
+            f"SELECT {', '.join(select_columns)} FROM read_parquet({files_expr}) "
+            f"WHERE {' AND '.join(conditions)}{order_by}"
+        )
+
+    def _fetch_rows(
+        self, con: Any, sql: str, params: list[Any]
+    ) -> list[dict[str, Any]]:
+        """Fetch DuckDB query results as dictionaries."""
+        cursor = con.execute(sql, params)
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    def _read_geoparquet_rows(
+        self,
+        *,
+        bbox: tuple[float, float, float, float] | None,
+        date_time: tuple[datetime, datetime] | None,
+        ids: list[str] | None,
+        query: dict[str, Any] | None,
+        sortby: list[dict[str, str]] | None,
+    ) -> list[dict[str, Any]]:
+        """Read matching rows from local cache or remote GeoParquet partitions."""
+        cache_path = self._cache_path(
+            bbox=bbox, date_time=date_time, ids=ids, query=query, sortby=sortby
+        )
+        duckdb = self._get_duckdb()
+        con = duckdb.connect()
+
+        if (
+            cache_path is not None
+            and cache_path.exists()
+            and (cache_path.parent / f"{cache_path.name}.done").exists()
+        ):
+            return self._fetch_rows(
+                con, "SELECT * FROM read_parquet(?)", [str(cache_path)]
+            )
+
+        parquet_files = self._get_parquet_files(date_time)
+        if not parquet_files:
+            return []
+
+        params: list[Any] = [parquet_files]
+        select_sql = self._build_select_sql(
+            "?",
+            bbox=bbox,
+            date_time=date_time,
+            ids=ids,
+            query=query,
+            sortby=sortby,
+            params=params,
+        )
+
+        if cache_path is None:
+            return self._fetch_rows(con, select_sql, params)
+
+        tmp_cache_path = cache_path.parent / f"{cache_path.name}.tmp"
+        done_path = cache_path.parent / f"{cache_path.name}.done"
+        if tmp_cache_path.exists():
+            tmp_cache_path.unlink()
+        copy_sql = (
+            f"COPY ({select_sql}) TO {_quote_duckdb_string(str(tmp_cache_path))} "
+            "(FORMAT PARQUET)"
+        )
+        con.execute(copy_sql, params)
+        tmp_cache_path.rename(cache_path)
+        done_path.touch()
+        return self._fetch_rows(con, "SELECT * FROM read_parquet(?)", [str(cache_path)])
+
+    def _row_to_stac_item(self, row: dict[str, Any]) -> StacItem:
+        """Convert a GeoParquet row to the local StacItem representation."""
+        bbox_dict = row.get("bbox")
+        bbox = None
+        if bbox_dict is not None:
+            bbox = (
+                bbox_dict["xmin"],
+                bbox_dict["ymin"],
+                bbox_dict["xmax"],
+                bbox_dict["ymax"],
+            )
+
+        geometry_wkb = row.get("geometry")
+        if geometry_wkb is not None:
+            geometry = shapely.geometry.mapping(shapely.from_wkb(geometry_wkb))
+        elif bbox is not None:
+            geometry = shapely.geometry.mapping(shapely.box(*bbox))
+        else:
+            geometry = None
+
+        raw_datetime = row["datetime"]
+        if isinstance(raw_datetime, str):
+            item_datetime = datetime.fromisoformat(raw_datetime.replace("Z", "+00:00"))
+        else:
+            item_datetime = raw_datetime
+        item_datetime = _datetime_to_utc(item_datetime)
+
+        assets = {}
+        for asset_key, asset_dict in row.get("assets", {}).items():
+            if asset_dict is None or asset_dict.get("href") is None:
+                continue
+            assets[asset_key] = StacAsset(
+                href=asset_dict["href"],
+                title=asset_dict.get("title"),
+                type=asset_dict.get("type"),
+                roles=asset_dict.get("roles"),
+            )
+
+        properties = {"datetime": item_datetime.isoformat()}
+        for key, value in row.items():
+            if key in {"id", "bbox", "datetime", "collection", "assets", "geometry"}:
+                continue
+            properties[key] = value
+
+        return StacItem(
+            id=row["id"],
+            properties=properties,
+            collection=row.get("collection"),
+            bbox=bbox,
+            geometry=geometry,
+            assets=assets,
+            time_range=(item_datetime, item_datetime),
+        )
 
 
 class PlanetaryComputerStacClient(StacClient):
@@ -155,6 +742,9 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
         timeout: timedelta = timedelta(seconds=10),
         skip_items_missing_assets: bool = False,
         cache_dir: str | None = None,
+        metadata_backend: PlanetaryComputerMetadataBackend = PlanetaryComputerMetadataBackend.STAC,
+        metadata_cache_dir: str | None = None,
+        geoparquet_href: str | None = None,
         context: DataSourceContext = DataSourceContext(),
     ):
         """Initialize a new PlanetaryComputer instance.
@@ -171,6 +761,14 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
                 assets in asset_bands during get_items.
             cache_dir: deprecated, no longer used. Item data is now passed to
                 materialization functions so caching in the data source is unnecessary.
+            metadata_backend: item metadata backend, either "stac" or "geoparquet".
+                The GeoParquet backend performs one bulk query per get_items call and
+                avoids repeated Planetary Computer STAC API search requests.
+            metadata_cache_dir: optional directory for GeoParquet partition-list and
+                query-result caches. Relative paths are resolved against the dataset
+                path when available.
+            geoparquet_href: optional explicit GeoParquet asset href. If omitted, the
+                GeoParquet backend resolves the collection's "geoparquet-items" asset.
             context: the data source context.
         """
         if cache_dir is not None:
@@ -180,6 +778,8 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
                 FutureWarning,
                 stacklevel=2,
             )
+
+        self.metadata_backend = PlanetaryComputerMetadataBackend(metadata_backend)
 
         # Initialize the DirectMaterializeDataSource with asset_bands
         DirectMaterializeDataSource.__init__(self, asset_bands=asset_bands)
@@ -199,8 +799,41 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
             required_assets=required_assets,
         )
 
-        # Replace the client with PlanetaryComputerStacClient to handle PC's pagination limits.
-        self.client = PlanetaryComputerStacClient(self.STAC_ENDPOINT)
+        self.collection_name = (
+            collection_name if isinstance(collection_name, str) else None
+        )
+
+        if self.metadata_backend == PlanetaryComputerMetadataBackend.STAC:
+            # Replace the client with PlanetaryComputerStacClient to handle PC's
+            # pagination limits.
+            self.client = PlanetaryComputerStacClient(self.STAC_ENDPOINT)
+        elif self.metadata_backend == PlanetaryComputerMetadataBackend.GEOPARQUET:
+            if not isinstance(collection_name, str):
+                raise ValueError("GeoParquet metadata backend requires one collection")
+            query_properties = []
+            if query is not None:
+                query_properties.extend(query.keys())
+            if sort_by is not None and sort_by not in query_properties:
+                query_properties.append(sort_by)
+            metadata_cache_path = None
+            if metadata_cache_dir is not None:
+                if context.ds_path is not None:
+                    metadata_cache_path = join_upath(
+                        context.ds_path, metadata_cache_dir
+                    )
+                else:
+                    metadata_cache_path = UPath(metadata_cache_dir)
+            self.client = PlanetaryComputerGeoParquetClient(
+                endpoint=self.STAC_ENDPOINT,
+                collection_name=collection_name,
+                required_assets=required_assets,
+                query_properties=query_properties,
+                timeout=timeout,
+                metadata_cache_dir=metadata_cache_path,
+                geoparquet_href=geoparquet_href,
+            )
+        else:
+            raise ValueError(f"unsupported metadata_backend {metadata_backend!r}")
 
         self.timeout = timeout
         self.skip_items_missing_assets = skip_items_missing_assets
@@ -297,6 +930,131 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
                     item.name,
                     asset_key,
                 )
+
+    def _get_aggregate_search_time_range(
+        self, geometries: list[STGeometry]
+    ) -> tuple[datetime, datetime] | None:
+        """Return the aggregate search time range for a batch of windows."""
+        min_time = None
+        max_time = None
+        for geometry in geometries:
+            search_time_range = self._get_search_time_range(geometry)
+            if search_time_range is None:
+                continue
+            if isinstance(search_time_range, tuple):
+                start, end = search_time_range
+            else:
+                start = end = search_time_range
+            min_time = start if min_time is None else min(min_time, start)
+            max_time = end if max_time is None else max(max_time, end)
+        if min_time is None or max_time is None:
+            return None
+        return (min_time, max_time)
+
+    def _get_aggregate_search_bbox(
+        self, geometries: list[STGeometry]
+    ) -> tuple[float, float, float, float] | None:
+        """Return the aggregate WGS84 bbox for a batch of windows."""
+        min_west = None
+        min_south = None
+        max_east = None
+        max_north = None
+        for geometry in geometries:
+            west, south, east, north = geometry.shp.bounds
+            min_west = west if min_west is None else min(min_west, west)
+            min_south = south if min_south is None else min(min_south, south)
+            max_east = east if max_east is None else max(max_east, east)
+            max_north = north if max_north is None else max(max_north, north)
+        if (
+            min_west is None
+            or min_south is None
+            or max_east is None
+            or max_north is None
+        ):
+            return None
+        return (min_west, min_south, max_east, max_north)
+
+    def _get_items_geoparquet(
+        self, geometries: list[STGeometry], query_config: Any
+    ) -> list[list[MatchedItemGroup[SourceItem]]]:
+        """Get items using one batched GeoParquet metadata query."""
+        wgs84_geometries = [geometry.to_wgs84() for geometry in geometries]
+        aggregate_bbox = self._get_aggregate_search_bbox(wgs84_geometries)
+        aggregate_time_range = self._get_aggregate_search_time_range(wgs84_geometries)
+
+        stac_items = self.client.search(
+            collections=self.collection_names,
+            bbox=aggregate_bbox,
+            date_time=aggregate_time_range,
+            query=self.query,
+            limit=self.limit,
+        )
+        logger.debug("GeoParquet search yielded %d items", len(stac_items))
+
+        if self.required_assets is not None:
+            good_stac_items = []
+            for stac_item in stac_items:
+                if stac_item.assets is None:
+                    raise ValueError(f"got STAC item {stac_item.id} with no assets")
+
+                good = True
+                for asset_key in self.required_assets:
+                    if asset_key in stac_item.assets:
+                        continue
+                    good = False
+                    break
+                if good:
+                    good_stac_items.append(stac_item)
+            logger.debug(
+                "required_assets filter from %d to %d items",
+                len(stac_items),
+                len(good_stac_items),
+            )
+            stac_items = good_stac_items
+
+        if self.sort_by is not None:
+            stac_items.sort(
+                key=self._get_sort_key,
+                reverse=not self.sort_ascending,
+            )
+
+        candidate_items = []
+        for stac_item in stac_items:
+            candidate_item = self._stac_item_to_item(stac_item)
+            if not self._should_include_item(candidate_item):
+                continue
+            candidate_items.append(candidate_item)
+
+        groups = []
+        for geometry, wgs84_geometry in zip(geometries, wgs84_geometries):
+            cur_candidate_items = []
+            for item in candidate_items:
+                if (
+                    wgs84_geometry.time_range is not None
+                    and not wgs84_geometry.intersects_time_range(
+                        item.geometry.time_range
+                    )
+                ):
+                    continue
+                if not wgs84_geometry.shp.intersects(item.geometry.shp):
+                    continue
+                cur_candidate_items.append(item)
+
+            cur_groups = match_candidate_items_to_window(
+                geometry, cur_candidate_items, query_config
+            )
+            groups.append(cur_groups)
+
+        return groups
+
+    @override
+    def get_items(
+        self, geometries: list[STGeometry], query_config: Any
+    ) -> list[list[MatchedItemGroup[SourceItem]]]:
+        """Get items intersecting the given geometries."""
+        if self.metadata_backend == PlanetaryComputerMetadataBackend.GEOPARQUET:
+            return self._get_items_geoparquet(geometries, query_config)
+        return super().get_items(geometries, query_config)
 
 
 class Sentinel2(PlanetaryComputer):

--- a/rslearn/data_sources/planetary_computer.py
+++ b/rslearn/data_sources/planetary_computer.py
@@ -731,7 +731,6 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
     """
 
     STAC_ENDPOINT = "https://planetarycomputer.microsoft.com/api/stac/v1"
-    client: StacClient | PlanetaryComputerGeoParquetClient
 
     def __init__(
         self,
@@ -824,7 +823,7 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
                     )
                 else:
                     metadata_cache_path = UPath(metadata_cache_dir)
-            self.client = PlanetaryComputerGeoParquetClient(
+            self.client = PlanetaryComputerGeoParquetClient(  # type: ignore[assignment]
                 endpoint=self.STAC_ENDPOINT,
                 collection_name=collection_name,
                 required_assets=required_assets,

--- a/rslearn/data_sources/planetary_computer.py
+++ b/rslearn/data_sources/planetary_computer.py
@@ -731,6 +731,7 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
     """
 
     STAC_ENDPOINT = "https://planetarycomputer.microsoft.com/api/stac/v1"
+    client: StacClient | PlanetaryComputerGeoParquetClient
 
     def __init__(
         self,
@@ -810,7 +811,7 @@ class PlanetaryComputer(DirectMaterializeDataSource[SourceItem], StacDataSource)
         elif self.metadata_backend == PlanetaryComputerMetadataBackend.GEOPARQUET:
             if not isinstance(collection_name, str):
                 raise ValueError("GeoParquet metadata backend requires one collection")
-            query_properties = []
+            query_properties: list[str] = []
             if query is not None:
                 query_properties.extend(query.keys())
             if sort_by is not None and sort_by not in query_properties:

--- a/tests/unit/data_sources/test_planetary_computer.py
+++ b/tests/unit/data_sources/test_planetary_computer.py
@@ -5,7 +5,14 @@ from unittest.mock import patch
 import pytest
 import shapely
 
-from rslearn.config import BandSetConfig, DType, LayerConfig, LayerType, QueryConfig
+from rslearn.config import (
+    BandSetConfig,
+    DType,
+    LayerConfig,
+    LayerType,
+    QueryConfig,
+    SpaceMode,
+)
 from rslearn.const import WGS84_PROJECTION
 from rslearn.data_sources import DataSourceContext
 from rslearn.data_sources.planetary_computer import (
@@ -281,7 +288,9 @@ def test_sentinel2_geoparquet_batches_prepare_window_metadata(
         data_source.client, "_read_geoparquet_rows", fake_read_geoparquet_rows
     )
 
-    groups = data_source.get_items([geom1, geom2], QueryConfig(space_mode="INTERSECTS"))
+    groups = data_source.get_items(
+        [geom1, geom2], QueryConfig(space_mode=SpaceMode.INTERSECTS)
+    )
 
     assert captured["bbox"] == (-5.0, 50.0, 0.0, 56.0)
     assert captured["date_time"] == (

--- a/tests/unit/data_sources/test_planetary_computer.py
+++ b/tests/unit/data_sources/test_planetary_computer.py
@@ -1,10 +1,12 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import cast
 from unittest.mock import patch
 
 import pytest
+import shapely
 
-from rslearn.config import BandSetConfig, DType, LayerConfig, LayerType
+from rslearn.config import BandSetConfig, DType, LayerConfig, LayerType, QueryConfig
+from rslearn.const import WGS84_PROJECTION
 from rslearn.data_sources import DataSourceContext
 from rslearn.data_sources.planetary_computer import (
     CopDemGlo30,
@@ -16,6 +18,7 @@ from rslearn.data_sources.planetary_computer import (
     Sentinel3SlstrLST,
 )
 from rslearn.data_sources.stac import SourceItem
+from rslearn.utils.geometry import STGeometry
 from rslearn.utils.stac import StacAsset, StacItem
 
 
@@ -187,6 +190,147 @@ def test_sentinel2_get_read_callback_skips_scl_harmonization() -> None:
         callback = data_source.get_read_callback(item=item, asset_key="SCL")
 
     assert callback is None
+
+
+def _make_geoparquet_row(
+    *,
+    item_id: str,
+    shp: shapely.Geometry,
+    dt: datetime,
+    cloud_cover: float = 0,
+) -> dict:
+    """Create a mock Planetary Computer STAC GeoParquet row."""
+    west, south, east, north = shp.bounds
+    return {
+        "id": item_id,
+        "bbox": {"xmin": west, "ymin": south, "xmax": east, "ymax": north},
+        "datetime": dt,
+        "collection": Sentinel2.COLLECTION_NAME,
+        "geometry": shapely.to_wkb(shp),
+        "assets": {
+            "B04": {
+                "href": f"https://example.com/{item_id}/B04.tif",
+                "title": "Band 4",
+                "type": "image/tiff",
+                "roles": ["data"],
+            },
+            "product-metadata": {
+                "href": f"https://example.com/{item_id}/metadata.xml",
+                "title": "Product metadata",
+                "type": "application/xml",
+                "roles": ["metadata"],
+            },
+        },
+        "eo:cloud_cover": cloud_cover,
+    }
+
+
+def test_sentinel2_geoparquet_batches_prepare_window_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_source = Sentinel2(
+        assets=["B04"],
+        metadata_backend="geoparquet",
+        geoparquet_href="file:///unused.parquet",
+        sort_by="eo:cloud_cover",
+    )
+
+    geom1 = STGeometry(
+        WGS84_PROJECTION,
+        shapely.box(-1, 50, 0, 51),
+        (
+            datetime(2020, 1, 1, tzinfo=UTC),
+            datetime(2021, 1, 1, tzinfo=UTC),
+        ),
+    )
+    geom2 = STGeometry(
+        WGS84_PROJECTION,
+        shapely.box(-5, 55, -4, 56),
+        (
+            datetime(2021, 1, 1, tzinfo=UTC),
+            datetime(2022, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+    captured = {}
+
+    def fake_read_geoparquet_rows(**kwargs: object) -> list[dict]:
+        captured.update(kwargs)
+        return [
+            _make_geoparquet_row(
+                item_id="S2A_MSIL2A_20200601T000000_R000_T30UXB_20200601T000000",
+                shp=shapely.box(-1, 50, 0, 51),
+                dt=datetime(2020, 6, 1, tzinfo=UTC),
+                cloud_cover=80,
+            ),
+            _make_geoparquet_row(
+                item_id="S2A_MSIL2A_20200602T000000_R000_T30UXB_20200602T000000",
+                shp=shapely.box(-1, 50, 0, 51),
+                dt=datetime(2020, 6, 2, tzinfo=UTC),
+                cloud_cover=5,
+            ),
+            _make_geoparquet_row(
+                item_id="S2A_MSIL2A_20210601T000000_R000_T30UWA_20210601T000000",
+                shp=shapely.box(-5, 55, -4, 56),
+                dt=datetime(2021, 6, 1, tzinfo=UTC),
+                cloud_cover=10,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        data_source.client, "_read_geoparquet_rows", fake_read_geoparquet_rows
+    )
+
+    groups = data_source.get_items([geom1, geom2], QueryConfig(space_mode="INTERSECTS"))
+
+    assert captured["bbox"] == (-5.0, 50.0, 0.0, 56.0)
+    assert captured["date_time"] == (
+        datetime(2020, 1, 1, tzinfo=UTC),
+        datetime(2022, 1, 1, tzinfo=UTC),
+    )
+    assert len(groups) == 2
+    assert groups[0][0].items[0].name == (
+        "S2A_MSIL2A_20200602T000000_R000_T30UXB_20200602T000000"
+    )
+    assert groups[1][0].items[0].name == (
+        "S2A_MSIL2A_20210601T000000_R000_T30UWA_20210601T000000"
+    )
+
+
+def test_sentinel2_geoparquet_get_item_by_name_infers_time_from_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_source = Sentinel2(
+        assets=["B04"],
+        metadata_backend="geoparquet",
+        geoparquet_href="file:///unused.parquet",
+    )
+    item_id = "S2A_MSIL2A_20200718T130301_R038_T27VVL_20210515T015108"
+    captured = {}
+
+    def fake_read_geoparquet_rows(**kwargs: object) -> list[dict]:
+        captured.update(kwargs)
+        return [
+            _make_geoparquet_row(
+                item_id=item_id,
+                shp=shapely.box(-23, 63, -21, 64),
+                dt=datetime(2020, 7, 18, 13, 3, 1, tzinfo=UTC),
+            )
+        ]
+
+    monkeypatch.setattr(
+        data_source.client, "_read_geoparquet_rows", fake_read_geoparquet_rows
+    )
+
+    item = data_source.get_item_by_name(item_id)
+
+    assert captured["ids"] == [item_id]
+    assert captured["date_time"] == (
+        datetime(2020, 7, 18, tzinfo=UTC),
+        datetime(2020, 7, 19, tzinfo=UTC),
+    )
+    assert item.name == item_id
+    assert item.asset_urls["B04"] == f"https://example.com/{item_id}/B04.tif"
 
 
 def test_hls2_s30_defaults_to_reflectance_bands() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
@@ -954,6 +954,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/00/d579dcb2a536b6ea3a2563cdad6844f77d81a9b2d4b22a858097f2468acf/duckdb-1.5.3.tar.gz", hash = "sha256:df39428eb130faa35ae96fd35245bdeae6ecf43936250b116b5fead568eb9f16", size = 18026640, upload-time = "2026-05-20T11:55:31.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/fc/a8a89c6c73f31c2b58c6abbc2f543e0b736042dd5ef7cc1784c24ec31428/duckdb-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:341a2672e2551ba51c95c1898f0ade983e76675e79038ccb16342c3d6cfb82d7", size = 32583465, upload-time = "2026-05-20T11:54:13.132Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f1/3423a2f523dd034e505d4a5dd8e210ae577212e152598dc13b6a5e736e1b/duckdb-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c9e8fa408705081160ede7ead238d16e73a36b8561b700f2bf2d650ae48e7b92", size = 17278520, upload-time = "2026-05-20T11:54:16.368Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1a/7bf5ba1b7ea520557e6b2dbee1c85abab016bdac0c1779d9d0ef76c87300/duckdb-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:70a18f932cf6d87bd0e554613657a515c1443a1724aacfc7ec5137dd28698b03", size = 15424794, upload-time = "2026-05-20T11:54:19.891Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/16/ce4b1e386e45fab0268edbf1b85bace20e9437589e9edb2bd5f9a226fa44/duckdb-1.5.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e80eb4d0fb59869cb2c7d7ef494c07fb92014fe8e77d96c170cd1ebc1488a708", size = 19306666, upload-time = "2026-05-20T11:54:22.77Z" },
+    { url = "https://files.pythonhosted.org/packages/99/1f/651f8453f26931e8061b7e27b3090f868868185814ecb9216d0bd71ec8ef/duckdb-1.5.3-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3248b49cd835ea322574bc6aac0ae7a83be85547f49d4f5f5777cb380ee6627f", size = 21418306, upload-time = "2026-05-20T11:54:25.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/64/e1ffebf010b1631a6fef8d1508f46d4eab3e97c18729af986bb796fa8452/duckdb-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f4eff89c12c3a362efa012262e57b7b4ab904a7f79bad9178fe365510077abe8", size = 13101423, upload-time = "2026-05-20T11:54:28.107Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/42/b1d4e34f9658cc0e13d7aae581ab82643f50a548d5aee8767f0c587cc3a4/duckdb-1.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:75d13308c9da3ee431d1e72b8ab720aa74a1b3e9159d4124cb62435924496334", size = 13951740, upload-time = "2026-05-20T11:54:30.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/2e34929b16c8d544ef664fad8f7f3a2a9db05746aae1e7c8c4ee3a8b23e4/duckdb-1.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ff11a457258148337ef9a392148a8cdbd1069b6c27c21958816c7b67fe6c542d", size = 32626494, upload-time = "2026-05-20T11:54:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/53/3af681793d03771365ae3e2215331151c196a3ac8193f613344840694671/duckdb-1.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fd25f533cb1b6b2c84cc767a9a9bab7769bb1aa44571a2a0bfc91ac3e4a38ac", size = 17301121, upload-time = "2026-05-20T11:54:36.928Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/c80af1eac2ab5d35fc2c372ef0a84668842e549fbbf7799277b3fccf3e39/duckdb-1.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10960400ed60cdf0fe05bab2086fa8eb733889cb0ceca18d07ff9a00c0e0be7b", size = 15449283, upload-time = "2026-05-20T11:54:39.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/c63af233c9f761bf5178a5210437e1bc6bcb30fa8a9073de6398cfb12c03/duckdb-1.5.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5f18e7561403054433706c187589e86629a7af09a7efc23a06a8b308e6acc68", size = 19332762, upload-time = "2026-05-20T11:54:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/2d77af4fff86012f334ef82e6d54a995a86c8745e58074f1218ed7d25171/duckdb-1.5.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fb7516255a8764545e30f7efacea408cc847764a3027b3b0b3e7d1a7bebbc5c", size = 21453290, upload-time = "2026-05-20T11:54:45.272Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5e/9bc4817a98feb4dab83e56f2245cd3a30d00ee646d4dec7926464e2b3f28/duckdb-1.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:8001eccbc28be244dfd04d708526f34ddd6460b47a8aeb5d0e39d6f7f9e3fe15", size = 13118308, upload-time = "2026-05-20T11:54:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/81/35/e3f32e4e53e2450ddb1db8312a17d1ce455d60cc4941b6ad2cfc908794b0/duckdb-1.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:6d2835e39bb6af73891f73c0f8d4324f98afe00d0b00c6d34b2a582c2256cbb0", size = 13927187, upload-time = "2026-05-20T11:54:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/a528eb09d8be51954c485864bd06753e616939a080cbc3dd4417e8c94a57/duckdb-1.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e75a6122c12579a99848517f6f00a4e342aebda3590c30fe9b5cc5f39d5e6afc", size = 32626254, upload-time = "2026-05-20T11:54:53.65Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/3c/1534c0a6db347c05eb7d0f6ecfb7aefbe74cbff398e4892a8fd1903a20e8/duckdb-1.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fd3963c1cb9d9567777f4a898a9dbe388a2fe9724681801b1e7d6d93eecf1b76", size = 17300917, upload-time = "2026-05-20T11:54:56.628Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fa/beafb91e6e152d2161c4a9cbc472334c87607eb61ad7104b5a7fa8d8d7b1/duckdb-1.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3d5db8c0b55e072cf437948ebb5d7e23d7b9d03d905fa5f9145583e65aa447f7", size = 15449411, upload-time = "2026-05-20T11:54:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/49b6fe04e2fcd63729eb607dadd44818dde77342a4f5ce086c6c92f1dd4d/duckdb-1.5.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ce80aed7a538422129a57eaca9141e3afb51f8bf562b1908b1576c9725b5b22", size = 19333120, upload-time = "2026-05-20T11:55:01.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4c/0907c3f76adb9dd90e67610b31e0304a35814e65c4c41a354a262c09b885/duckdb-1.5.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787df63824f07bf18022dbc3b8ca4b2bfab0ebe616464f55c6e8cd0f59ea762e", size = 21453266, upload-time = "2026-05-20T11:55:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9c/d2f23a7803ddbbd9413f7572ecf66a15120ed5ced7ce5c73e698c1406b76/duckdb-1.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:bb5bb5dcdd09d62ee60f0ddbbef918e71cce304ffe28428b1131949d39ffaabf", size = 13118640, upload-time = "2026-05-20T11:55:07.389Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d5/7ba2316415bcdab6edd765bbbe35c2ca8a3800f2fe695cd70e3cdb997f09/duckdb-1.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2fa17ecdd5d3db122836cb71bb93601c2106a3be883c17dffddc02fbf3fa7888", size = 13926409, upload-time = "2026-05-20T11:55:10.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/c2/d4b6f8a5e4d3bc25773be6da76a99d9661ebbf3552c007c460d2dd59dbf8/duckdb-1.5.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4bfa9a4dadf71e83e2c4eaca2f9421c82a54defecc1b0b4c0be95e2389dec4fe", size = 32636685, upload-time = "2026-05-20T11:55:13.158Z" },
+    { url = "https://files.pythonhosted.org/packages/42/58/e835c8298979d29db7a62cb5acc29e9b57aeaca7cdde2fcd3ac980f5cb18/duckdb-1.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aea7baf67ad7e1829ac76f67d7dcbd7fb1f57c3eb179d55ac30952df4709ae30", size = 17308134, upload-time = "2026-05-20T11:55:16.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/617b51363f5613418c8b224b3cce16b58e6dde80904566bec232579c1d4e/duckdb-1.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b0b4f088a65d77e1217ce5d7eff889e63fedc44281200d899ff47c84d8ff836", size = 15449891, upload-time = "2026-05-20T11:55:18.687Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/72/354146656e8d9ba3853d3a5ee80a481b8c5f70edfc3d5ae80a8c4479c967/duckdb-1.5.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe8d0c1f6a120aa03fa6e0d03897c71a1842e6cf7afd31d181348391f7108fe1", size = 19338499, upload-time = "2026-05-20T11:55:21.34Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
 ]
 
 [[package]]
@@ -4850,6 +4886,7 @@ dev = [
 extra = [
     { name = "aiobotocore" },
     { name = "cdsapi" },
+    { name = "duckdb" },
     { name = "earthdaily", extra = ["platform"] },
     { name = "earthengine-api" },
     { name = "einops" },
@@ -4887,6 +4924,7 @@ requires-dist = [
     { name = "aiobotocore", marker = "extra == 'extra'", specifier = ">=2.19.0" },
     { name = "boto3", specifier = ">=1.39" },
     { name = "cdsapi", marker = "extra == 'extra'", specifier = ">=0.7.6" },
+    { name = "duckdb", marker = "extra == 'extra'", specifier = ">=1.3" },
     { name = "earthdaily", extras = ["platform"], marker = "extra == 'extra'", specifier = ">=1.9.0" },
     { name = "earthengine-api", marker = "extra == 'extra'", specifier = ">=1.6.3" },
     { name = "einops", marker = "extra == 'extra'", specifier = ">=0.8" },


### PR DESCRIPTION
Adds a GeoParquet metadata backend to the Planetary Computer data sources. Previously, scene discovery during dataset prepare always used the Planetary Computer STAC API, making one search request per window, which can hit API rate limits on large jobs.

```
Retrying after catching error in retry loop: 503 Server Error: Operations per second is over the account limit.
```

The new backend queries the collection-level GeoParquet item table (hosted on Azure Blob Storage) using DuckDB. It downloads only the relevant date-range partitions, runs a spatial and temporal filter locally, and returns matching items in a single bulk operation per `get_items`call. Because rslearn already batches all windows into one `get_items` call during prepare, this effectively replaces N per-window STAC requests with one bulk query.

The feature is opt-in via a new metadata_backend parameter (default "stac", new option "geoparquet") on the PlanetaryComputer base class and all its subclasses including Sentinel2. An optional `metadata_cache_dir` can be set to cache the partition file list and query results between runs. DuckDB is required and is included in the existing `extra` optional dependencies.

- Implemented functions to create mock GeoParquet rows for Sentinel2.
- Added tests for batch preparation of window metadata and item retrieval by name.
- Updated `uv.lock` to include duckdb version 1.5.3 and incremented revision number.
- Added duckdb as an extra dependency for the project.

**Note:** I need to apply this to a large-scale dataset to see if there is a significant speedup