### PR TITLE
linear probe + reshape approach instead of upsampling

### DIFF
--- a/rslearn/models/pixel_shuffle.py
+++ b/rslearn/models/pixel_shuffle.py
@@ -1,0 +1,49 @@
+"""A sub-pixel (PixelShuffle) reshaping layer."""
+
+from typing import Any
+
+import torch
+
+from rslearn.train.model_context import ModelContext
+
+from .component import (
+    FeatureMaps,
+    IntermediateComponent,
+)
+
+
+class PixelShuffle(IntermediateComponent):
+    """Rearranges feature maps from (C*r^2, H, W) to (C, H*r, W*r) via sub-pixel shuffle.
+
+    This is the "reshape" alternative to interpolation-based upsampling: place a Conv
+    that outputs ``num_classes * upscale_factor^2`` channels before this layer, and each
+    1/r-resolution token's prediction is reshaped into its r-by-r block of pixels. For a
+    linear segmentation probe on patch_size=r features, this lets a single linear layer
+    predict every pixel within a patch (rather than upsampling a coarse prediction).
+    """
+
+    def __init__(self, upscale_factor: int):
+        """Initialize a PixelShuffle.
+
+        Args:
+            upscale_factor: factor to increase spatial resolution by (typically the
+                encoder patch size). Input channels must be divisible by its square.
+        """
+        super().__init__()
+        self.layer = torch.nn.PixelShuffle(upscale_factor)
+
+    def forward(self, intermediates: Any, context: ModelContext) -> FeatureMaps:
+        """Apply sub-pixel shuffle to each feature map.
+
+        Args:
+            intermediates: the previous output, which must be a FeatureMaps.
+            context: the model context.
+
+        Returns:
+            the reshaped feature maps.
+        """
+        if not isinstance(intermediates, FeatureMaps):
+            raise ValueError("input to PixelShuffle must be a FeatureMaps")
+        return FeatureMaps(
+            [self.layer(feat_map) for feat_map in intermediates.feature_maps]
+        )


### PR DESCRIPTION
I believe this is closer to the olmoearth_pretrain linear probe approach. It improved performance on the seagrass task from .5 F1 (predicting all 1 class) -> .84 F1. 
Sample training config: https://github.com/allenai/rslearn_projects/blob/0220b6f2c26c0d70d42cac8fb61e7f1d10c64846/data/seagrass/config_train_proper_splits_linprobe_dice_reshape_binary.yaml 