### PR TITLE
bump version to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rslearn"
-version = "0.1.10"
+version = "0.1.11"
 description = "A library for developing remote sensing datasets and models"
 authors = [
     { name = "OlmoEarth Team" },

--- a/uv.lock
+++ b/uv.lock
@@ -4811,7 +4811,7 @@ wheels = [
 
 [[package]]
 name = "rslearn"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Release v0.1.11. Bumps the version in pyproject.toml (and uv.lock) for the next PyPI release per docs/Releasing.md.