### PR TITLE
Atomic reads for AEF csv

### DIFF
--- a/rslearn/data_sources/aws_google_satellite_embedding_v1.py
+++ b/rslearn/data_sources/aws_google_satellite_embedding_v1.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -31,11 +32,14 @@ from rslearn.data_sources.direct_materialize_data_source import (
     DirectMaterializeDataSource,
 )
 from rslearn.data_sources.utils import MatchedItemGroup
-from rslearn.utils.fsspec import join_upath
+from rslearn.log_utils import get_logger
+from rslearn.utils.fsspec import join_upath, open_atomic
 from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
 from rslearn.utils.grid_index import GridIndex
 from rslearn.utils.raster_array import RasterArray, RasterMetadata
 from rslearn.utils.raster_format import get_raster_projection_and_bounds
+
+logger = get_logger(__name__)
 
 # Band names for the 64 embedding channels
 BANDS = [f"A{idx:02d}" for idx in range(64)]
@@ -141,9 +145,36 @@ class GoogleSatelliteEmbeddingV1(
             region_name="us-west-2",
         )
 
-        # Lazy-loaded grid index
+        # Lazy-loaded grid index, guarded by a lock so that concurrent readers
+        # (e.g. threads in a materialization pool) download and parse the index
+        # only once.
+        self._index_lock = threading.Lock()
         self._grid_index: GridIndex | None = None
         self._items_by_name: dict[str, GoogleSatelliteEmbeddingV1Item] | None = None
+
+    def _download_index_csv(self, cache_file: UPath) -> None:
+        """Download the index CSV from S3 to the cache file.
+
+        The download is streamed via open_atomic so a killed or concurrent run
+        cannot leave a partial file at the final path, and the resulting size
+        is validated against the S3 object size (deleting the file on
+        mismatch) to catch truncated response bodies.
+
+        Args:
+            cache_file: the final path to place the index CSV at.
+        """
+        response = self.s3_client.get_object(Bucket=BUCKET_NAME, Key=INDEX_KEY)
+        expected_size = response["ContentLength"]
+        with open_atomic(cache_file, "wb") as f:
+            for chunk in response["Body"].iter_chunks(chunk_size=8 * 1024 * 1024):
+                f.write(chunk)
+        actual_size = cache_file.stat().st_size
+        if actual_size != expected_size:
+            cache_file.unlink()
+            raise OSError(
+                f"AEF index download was truncated: got {actual_size} bytes, "
+                f"expected {expected_size}"
+            )
 
     def _read_index_csv(self) -> pd.DataFrame:
         """Read the index CSV, downloading from S3 if not cached.
@@ -153,12 +184,20 @@ class GoogleSatelliteEmbeddingV1(
         """
         cache_file = self.metadata_cache_dir / "aef_index.csv"
         if not cache_file.exists():
-            response = self.s3_client.get_object(Bucket=BUCKET_NAME, Key=INDEX_KEY)
-            content = response["Body"].read()
-            with cache_file.open("wb") as f:
-                f.write(content)
+            self._download_index_csv(cache_file)
 
-        return pd.read_csv(cache_file)
+        try:
+            return pd.read_csv(cache_file)
+        except (pd.errors.EmptyDataError, pd.errors.ParserError):
+            # A pre-existing cache file may be empty or truncated (e.g. written
+            # by an older version that did not download atomically); discard it
+            # and re-download once.
+            logger.warning(
+                f"Cached AEF index at {cache_file} is corrupt; re-downloading."
+            )
+            cache_file.unlink()
+            self._download_index_csv(cache_file)
+            return pd.read_csv(cache_file)
 
     def _load_index(
         self,
@@ -168,39 +207,40 @@ class GoogleSatelliteEmbeddingV1(
         Returns:
             Tuple of (grid_index, items_by_name dict).
         """
-        if self._grid_index is not None and self._items_by_name is not None:
-            return self._grid_index, self._items_by_name
+        with self._index_lock:
+            if self._grid_index is not None and self._items_by_name is not None:
+                return self._grid_index, self._items_by_name
 
-        df = self._read_index_csv()
+            df = self._read_index_csv()
 
-        grid_index = GridIndex(GRID_SIZE)
-        items_by_name: dict[str, GoogleSatelliteEmbeddingV1Item] = {}
+            grid_index = GridIndex(GRID_SIZE)
+            items_by_name: dict[str, GoogleSatelliteEmbeddingV1Item] = {}
 
-        for _, row in df.iterrows():
-            shp = shapely.wkt.loads(row["WKT"])
+            for _, row in df.iterrows():
+                shp = shapely.wkt.loads(row["WKT"])
 
-            year = int(row["year"])
-            time_range = (
-                datetime(year, 1, 1, tzinfo=UTC),
-                datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC),
-            )
+                year = int(row["year"])
+                time_range = (
+                    datetime(year, 1, 1, tzinfo=UTC),
+                    datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC),
+                )
 
-            s3_path = row["path"]
-            name = s3_path.split("/")[-1].replace(".tiff", "")
+                s3_path = row["path"]
+                name = s3_path.split("/")[-1].replace(".tiff", "")
 
-            geometry = STGeometry(WGS84_PROJECTION, shp, time_range)
-            item = GoogleSatelliteEmbeddingV1Item(
-                name=name,
-                geometry=geometry,
-                s3_path=s3_path,
-            )
+                geometry = STGeometry(WGS84_PROJECTION, shp, time_range)
+                item = GoogleSatelliteEmbeddingV1Item(
+                    name=name,
+                    geometry=geometry,
+                    s3_path=s3_path,
+                )
 
-            grid_index.insert(shp.bounds, item)
-            items_by_name[name] = item
+                grid_index.insert(shp.bounds, item)
+                items_by_name[name] = item
 
-        self._grid_index = grid_index
-        self._items_by_name = items_by_name
-        return grid_index, items_by_name
+            self._grid_index = grid_index
+            self._items_by_name = items_by_name
+            return grid_index, items_by_name
 
     # --- DataSource implementation ---
 

--- a/tests/integration/data_sources/test_aws_google_satellite_embedding_v1.py
+++ b/tests/integration/data_sources/test_aws_google_satellite_embedding_v1.py
@@ -3,6 +3,8 @@
 import io
 import pathlib
 import shutil
+import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -11,6 +13,7 @@ import numpy as np
 import pytest
 import rasterio
 import shapely
+from botocore.response import StreamingBody
 from upath import UPath
 
 from rslearn.config import QueryConfig, SpaceMode
@@ -76,14 +79,25 @@ def _make_csv_content() -> bytes:
     return (header + line).encode()
 
 
+def _make_index_response(content: bytes) -> dict:
+    """Build a get_object-style response serving the given index CSV bytes."""
+    return {
+        "ContentLength": len(content),
+        "Body": StreamingBody(io.BytesIO(content), len(content)),
+    }
+
+
 def _make_mock_s3(
     test_geotiff: pathlib.Path,
 ) -> MagicMock:
     """Create a mock boto3 S3 client that serves the CSV index and test GeoTIFF."""
     # get_object serves the CSV index, and download_file copies the test GeoTIFF
     # to whatever local path the data source requests (we ignore bucket/key).
+    # A fresh response is built per call since StreamingBody is single-use.
     mock_s3 = MagicMock()
-    mock_s3.get_object.return_value = {"Body": io.BytesIO(_make_csv_content())}
+    mock_s3.get_object.side_effect = lambda **kw: _make_index_response(
+        _make_csv_content()
+    )
 
     def mock_download(bucket: str, key: str, local_path: str) -> None:
         shutil.copy(str(test_geotiff), local_path)
@@ -201,3 +215,125 @@ def test_materialize(
     )
     assert array.get_chw_array().max() == expected_value
     assert array.timestamps == [item.geometry.time_range]
+
+
+def _make_index_data_source(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> GoogleSatelliteEmbeddingV1:
+    """Create a data source with mocked S3 for index cache tests."""
+    monkeypatch.setattr(boto3, "client", lambda *a, **kw: _make_mock_s3(test_geotiff))
+    return GoogleSatelliteEmbeddingV1(metadata_cache_dir=str(tmp_path / "cache"))
+
+
+def test_index_cache_hit_skips_download(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid cached index is reused without re-downloading."""
+    data_source = _make_index_data_source(tmp_path, test_geotiff, monkeypatch)
+    data_source._read_index_csv()
+    data_source._read_index_csv()
+    assert data_source.s3_client.get_object.call_count == 1
+    # The atomic write should leave no temporary files behind.
+    cache_dir = UPath(tmp_path / "cache")
+    assert [p.name for p in cache_dir.iterdir()] == ["aef_index.csv"]
+
+
+def test_index_corrupt_cache_self_heals(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty or truncated cached index is discarded and re-downloaded."""
+    data_source = _make_index_data_source(tmp_path, test_geotiff, monkeypatch)
+    cache_dir = UPath(tmp_path / "cache")
+
+    # Empty file (e.g. a download that was killed immediately).
+    (cache_dir / "aef_index.csv").touch()
+    df = data_source._read_index_csv()
+    assert len(df) == 1
+    assert data_source.s3_client.get_object.call_count == 1
+
+
+def test_index_truncated_download_raises(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response body shorter than ContentLength errors and leaves no cache file."""
+    data_source = _make_index_data_source(tmp_path, test_geotiff, monkeypatch)
+
+    def truncated_response(**kwargs: Any) -> dict:
+        content = _make_csv_content()
+        response = _make_index_response(content[: len(content) // 2])
+        response["ContentLength"] = len(content)
+        return response
+
+    data_source.s3_client.get_object.side_effect = truncated_response
+    with pytest.raises(OSError, match="truncated"):
+        data_source._read_index_csv()
+    assert not (UPath(tmp_path / "cache") / "aef_index.csv").exists()
+
+    # A subsequent run with a healthy connection succeeds.
+    data_source.s3_client.get_object.side_effect = lambda **kw: _make_index_response(
+        _make_csv_content()
+    )
+    df = data_source._read_index_csv()
+    assert len(df) == 1
+
+
+def test_index_interrupted_download_leaves_no_cache_file(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A download that dies mid-stream must not leave a file at the cache path."""
+    data_source = _make_index_data_source(tmp_path, test_geotiff, monkeypatch)
+
+    def interrupted_response(**kwargs: Any) -> dict:
+        body = MagicMock()
+        body.iter_chunks.side_effect = ConnectionError("connection reset")
+        return {"ContentLength": len(_make_csv_content()), "Body": body}
+
+    data_source.s3_client.get_object.side_effect = interrupted_response
+    with pytest.raises(ConnectionError):
+        data_source._read_index_csv()
+    assert not (UPath(tmp_path / "cache") / "aef_index.csv").exists()
+
+
+def test_index_concurrent_load_downloads_once(
+    tmp_path: pathlib.Path,
+    test_geotiff: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent threads loading a cold index share a single slow download.
+
+    Regression test: previously a thread could observe another thread's
+    in-progress cache write as an existing (empty) file and fail with
+    pandas.errors.EmptyDataError.
+    """
+    data_source = _make_index_data_source(tmp_path, test_geotiff, monkeypatch)
+
+    def slow_response(**kwargs: Any) -> dict:
+        content = _make_csv_content()
+        body = MagicMock()
+
+        def chunks(chunk_size: int) -> Any:
+            for i in range(0, len(content), 16):
+                time.sleep(0.002)
+                yield content[i : i + 16]
+
+        body.iter_chunks.side_effect = chunks
+        return {"ContentLength": len(content), "Body": body}
+
+    data_source.s3_client.get_object.side_effect = slow_response
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: data_source._load_index(), range(8)))
+
+    assert data_source.s3_client.get_object.call_count == 1
+    for _, items_by_name in results:
+        assert len(items_by_name) == 1


### PR DESCRIPTION
Previously, if I kicked off AEF downloads with multiple workers, then they'd all try to download the AEF csv (or check if it exists), and then try to read it. If it hadn't downloaded yet I would get this error:

```
Traceback (most recent call last):
  File "/weka/dfive-default/gabrielt/helios/scripts/tools/materialize_aef_supplemental_embeddings.py", line 127, in <module>
    main()
  File "/weka/dfive-default/gabrielt/helios/scripts/tools/materialize_aef_supplemental_embeddings.py", line 104, in main
    manifest = materialize_product(
               ^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/olmoearth_pretrain/evals/embedding_materializer/materialize.py", line 165, in materialize_product
    for status, window_id in outcomes:
                             ^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/concurrent/futures/_base.py", line 619, in result_iterator
    yield _result_or_cancel(fs.pop())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/concurrent/futures/_base.py", line 317, in _result_or_cancel
    return fut.result(timeout)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/opt/miniconda3/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/olmoearth_pretrain/evals/embedding_materializer/materialize.py", line 158, in run_one
    _process_window(window, fetcher, provider, year, overwrite),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/olmoearth_pretrain/evals/embedding_materializer/materialize.py", line 95, in _process_window
    array = fetcher.fetch(window.bounds, window.projection, target_year)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/olmoearth_pretrain/evals/embedding_materializer/fetchers.py", line 242, in fetch
    groups = source.get_items([geometry], query_config)[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/rslearn/rslearn/data_sources/aws_google_satellite_embedding_v1.py", line 211, in get_items
    grid_index, _ = self._load_index()
                    ^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/rslearn/rslearn/data_sources/aws_google_satellite_embedding_v1.py", line 174, in _load_index
    df = self._read_index_csv()
         ^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/rslearn/rslearn/data_sources/aws_google_satellite_embedding_v1.py", line 161, in _read_index_csv
    return pd.read_csv(cache_file)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/.venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1026, in read_csv
    return _read(filepath_or_buffer, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/.venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 620, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/.venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1620, in __init__
    self._engine = self._make_engine(f, self.engine)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/.venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1898, in _make_engine
    return mapping[engine](f, **self.options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/dfive-default/gabrielt/helios/.venv/lib/python3.12/site-packages/pandas/io/parsers/c_parser_wrapper.py", line 93, in __init__
    self._reader = parsers.TextReader(src, **kwds)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/parsers.pyx", line 581, in pandas._libs.parsers.TextReader.__cinit__
pandas.errors.EmptyDataError: No columns to parse from file
```

This fixes that using an atomic write, which is locked to avoid multiple concurrent downloads. 