### PR TITLE
[Bugfix] Avoid double harmonization of EarthDaily Sentinel-2 COGs

### DIFF
--- a/docs/data_sources/earthdaily_Sentinel2L2A.md
+++ b/docs/data_sources/earthdaily_Sentinel2L2A.md
@@ -77,11 +77,15 @@ known archive gaps, see [earthdaily.Sentinel2C1L2A](earthdaily_Sentinel2C1L2A.md
 
 ### Harmonization
 
-Harmonization first tries to build the callback from Sentinel-2 metadata XML
-(`product_metadata`) using `get_harmonize_callback(...)` when that asset is present.
+When `harmonize=true`, rslearn first checks the STAC
+`earthsearch:boa_offset_applied` property. If it is `true`, the Earth Search COG has
+already been harmonized and no further offset is applied. Otherwise, harmonization
+tries to build the callback from Sentinel-2 metadata XML (`product_metadata`) using
+`get_harmonize_callback(...)`.
 
 If metadata is missing or cannot be read while `harmonize=true`, rslearn raises
-that error instead of silently skipping harmonization.
+that error instead of silently skipping harmonization, unless the STAC property
+already confirms that the offset was applied.
 
 If metadata XML is available but does not itself indicate whether an offset is
 present, rslearn falls back to the processing baseline encoded in STAC

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -299,9 +299,7 @@ class EarthDaily(DataSource, TileStore):
             "earthsearch:boa_offset_applied"
         )
         boa_offset_applied = (
-            raw_boa_offset_applied
-            if isinstance(raw_boa_offset_applied, bool)
-            else None
+            raw_boa_offset_applied if isinstance(raw_boa_offset_applied, bool) else None
         )
 
         return EarthDailyItem(

--- a/rslearn/data_sources/earthdaily.py
+++ b/rslearn/data_sources/earthdaily.py
@@ -51,6 +51,7 @@ class EarthDailyItem(Item):
         asset_urls: dict[str, str],
         asset_scale_offsets: dict[str, list[dict[str, float | None]]] | None = None,
         product_id: str | None = None,
+        boa_offset_applied: bool | None = None,
     ):
         """Creates a new EarthDailyItem.
 
@@ -63,11 +64,15 @@ class EarthDailyItem(Item):
                 "scale", "offset", and "nodata".
             product_id: optional Sentinel-2 product ID from STAC
                 `properties["sentinel:product_id"]`.
+            boa_offset_applied: whether the Sentinel-2 BOA offset has already been
+                applied to the COG, from STAC
+                `properties["earthsearch:boa_offset_applied"]`.
         """
         super().__init__(name, geometry)
         self.asset_urls = asset_urls
         self.asset_scale_offsets = asset_scale_offsets or {}
         self.product_id = product_id
+        self.boa_offset_applied = boa_offset_applied
 
     def serialize(self) -> dict[str, Any]:
         """Serializes the item to a JSON-encodable dictionary."""
@@ -75,6 +80,7 @@ class EarthDailyItem(Item):
         d["asset_urls"] = self.asset_urls
         d["asset_scale_offsets"] = self.asset_scale_offsets
         d["product_id"] = self.product_id
+        d["boa_offset_applied"] = self.boa_offset_applied
         return d
 
     @staticmethod
@@ -87,6 +93,7 @@ class EarthDailyItem(Item):
             asset_urls=d["asset_urls"],
             asset_scale_offsets=d.get("asset_scale_offsets") or {},
             product_id=d.get("product_id"),
+            boa_offset_applied=d.get("boa_offset_applied"),
         )
 
 
@@ -288,12 +295,22 @@ class EarthDaily(DataSource, TileStore):
                 product_id = raw_product_id
                 break
 
+        raw_boa_offset_applied = stac_item.properties.get(
+            "earthsearch:boa_offset_applied"
+        )
+        boa_offset_applied = (
+            raw_boa_offset_applied
+            if isinstance(raw_boa_offset_applied, bool)
+            else None
+        )
+
         return EarthDailyItem(
             stac_item.id,
             geom,
             asset_urls,
             asset_scale_offsets=asset_scale_offsets,
             product_id=product_id,
+            boa_offset_applied=boa_offset_applied,
         )
 
     def get_item_by_name(self, name: str) -> EarthDailyItem:
@@ -1006,6 +1023,8 @@ class Sentinel2L2A(EarthDaily):
 
         Args:
             harmonize: apply processing-baseline harmonization to reflectance values.
+                Items with `earthsearch:boa_offset_applied=true` are not modified
+                because their COG pixels have already been harmonized.
             assets: optional list of asset keys to ingest. If omitted and a LayerConfig
                 is provided via context, assets are inferred from that layer's band sets.
             cloud_cover_max: max cloud cover (%) applied in searches. If set, injects
@@ -1124,6 +1143,8 @@ class Sentinel2L2A(EarthDaily):
         self, item: EarthDailyItem, asset_key: str
     ) -> Callable[[npt.NDArray[Any]], npt.NDArray[Any]] | None:
         if not self.harmonize or asset_key in self.NON_REFLECTANCE_ASSETS:
+            return None
+        if item.boa_offset_applied is True:
             return None
         if item.name in self._harmonize_callback_cache:
             return self._harmonize_callback_cache[item.name]

--- a/rslearn/data_sources/gcp_landsat.py
+++ b/rslearn/data_sources/gcp_landsat.py
@@ -606,9 +606,7 @@ class Landsat(DirectMaterializeDataSource[LandsatItem]):
         ):
             if self.sort_by == "cloud_cover":
                 cur_items.sort(
-                    key=lambda item: (
-                        item.cloud_cover if item.cloud_cover >= 0 else 100
-                    )
+                    key=lambda item: item.cloud_cover if item.cloud_cover >= 0 else 100
                 )
             elif self.sort_by is not None:
                 raise ValueError(f"invalid sort_by setting ({self.sort_by})")

--- a/rslearn/data_sources/planet.py
+++ b/rslearn/data_sources/planet.py
@@ -135,8 +135,9 @@ class Planet(DataSource):
                     sort_by = self.sort_by
 
                 planet_items.sort(
-                    key=lambda planet_item: multiplier
-                    * planet_item["properties"][sort_by]
+                    key=lambda planet_item: (
+                        multiplier * planet_item["properties"][sort_by]
+                    )
                 )
 
             items = []

--- a/rslearn/data_sources/utils.py
+++ b/rslearn/data_sources/utils.py
@@ -336,16 +336,20 @@ def _filter_and_project_items(
         placeholder_datetime = datetime.now(UTC)
         if query_config.time_mode == TimeMode.BEFORE:
             items.sort(
-                key=lambda item: item.geometry.time_range[0]
-                if item.geometry.time_range
-                else placeholder_datetime,
+                key=lambda item: (
+                    item.geometry.time_range[0]
+                    if item.geometry.time_range
+                    else placeholder_datetime
+                ),
                 reverse=True,
             )
         elif query_config.time_mode == TimeMode.AFTER:
             items.sort(
-                key=lambda item: item.geometry.time_range[0]
-                if item.geometry.time_range
-                else placeholder_datetime,
+                key=lambda item: (
+                    item.geometry.time_range[0]
+                    if item.geometry.time_range
+                    else placeholder_datetime
+                ),
                 reverse=False,
             )
 

--- a/tests/unit/data_sources/test_earthdaily_scale_offset.py
+++ b/tests/unit/data_sources/test_earthdaily_scale_offset.py
@@ -168,7 +168,7 @@ def test_read_raster_preserves_nodata_from_metadata(tmp_path: Path) -> None:
     np.testing.assert_allclose(arr[0], expected)
 
 
-def test_earthdaily_item_serialize_roundtrip_preserves_product_id() -> None:
+def test_earthdaily_item_serialize_roundtrip_preserves_sentinel2_metadata() -> None:
     geom = STGeometry(
         Projection(CRS.from_epsg(3857), 1, -1),
         shapely.box(0, 0, 2, 2),
@@ -179,11 +179,17 @@ def test_earthdaily_item_serialize_roundtrip_preserves_product_id() -> None:
         geometry=geom,
         asset_urls={"red": "/tmp/red.tif"},
         product_id="S2A_MSIL2A_20240101T000000_N0511_R080_T15CWM_20240101T150509",
+        boa_offset_applied=True,
     )
 
     restored = EarthDailyItem.deserialize(item.serialize())
 
     assert restored.product_id == item.product_id
+    assert restored.boa_offset_applied is True
+
+    legacy_serialized = item.serialize()
+    del legacy_serialized["boa_offset_applied"]
+    assert EarthDailyItem.deserialize(legacy_serialized).boa_offset_applied is None
 
 
 def test_init_requires_float32_band_dtype_when_scale_offset_enabled() -> None:

--- a/tests/unit/data_sources/test_earthdaily_sentinel2_l2a.py
+++ b/tests/unit/data_sources/test_earthdaily_sentinel2_l2a.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
+import pystac
 import pytest
 import rasterio
 import shapely
@@ -20,6 +21,7 @@ def _make_item(
     *,
     name: str = "item1",
     product_id: str | None = None,
+    boa_offset_applied: bool | None = None,
     start_time: datetime = datetime(2024, 1, 1, tzinfo=UTC),
     end_time: datetime = datetime(2024, 1, 2, tzinfo=UTC),
 ) -> EarthDailyItem:
@@ -33,6 +35,7 @@ def _make_item(
         geometry=geom,
         asset_urls=asset_urls,
         product_id=product_id,
+        boa_offset_applied=boa_offset_applied,
     )
 
 
@@ -56,7 +59,8 @@ def test_read_raster_harmonizes_non_visual_band(
         dst.write(raw)
 
     item = _make_item(
-        {"B04": str(tif_path), "product_metadata": "https://example.com/meta.xml"}
+        {"B04": str(tif_path), "product_metadata": "https://example.com/meta.xml"},
+        boa_offset_applied=False,
     )
     ds = Sentinel2L2A(harmonize=True, assets=["B04"], cache_dir=None)
     monkeypatch.setattr(ds, "get_item_by_name", lambda _name: item)
@@ -81,6 +85,75 @@ def test_read_raster_harmonizes_non_visual_band(
     expected[(expected == 0) & (raw > 0)] = 1
     assert out.dtype == np.uint16
     np.testing.assert_array_equal(out, expected)
+
+
+def test_read_raster_skips_harmonization_when_offset_already_applied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Earth Search COGs marked as corrected must not lose another 1000 DN."""
+    tif_path = tmp_path / "B04.tif"
+    raw = np.array([[[900, 1000], [1200, 2200]]], dtype=np.uint16)
+    with rasterio.open(
+        tif_path,
+        "w",
+        driver="GTiff",
+        width=2,
+        height=2,
+        count=1,
+        dtype=str(raw.dtype),
+        crs=CRS.from_epsg(3857),
+        transform=Affine(1, 0, 0, 0, -1, 0),
+    ) as dst:
+        dst.write(raw)
+
+    item = _make_item(
+        {"B04": str(tif_path), "product_metadata": "https://example.com/meta.xml"},
+        boa_offset_applied=True,
+    )
+    ds = Sentinel2L2A(harmonize=True, assets=["B04"], cache_dir=None)
+    monkeypatch.setattr(ds, "get_item_by_name", lambda _name: item)
+    monkeypatch.setattr(
+        ds,
+        "_get_product_xml",
+        lambda _item: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    out = ds.read_raster(
+        layer_name="layer",
+        item=item,
+        bands=["B04"],
+        projection=Projection(CRS.from_epsg(3857), 1, -1),
+        bounds=(0, 0, 2, 2),
+    ).get_chw_array()
+
+    np.testing.assert_array_equal(out, raw)
+
+
+@pytest.mark.parametrize("boa_offset_applied", [True, False])
+def test_stac_item_preserves_boa_offset_applied(boa_offset_applied: bool) -> None:
+    """Keep the Earth Search harmonization flag when converting STAC items."""
+    stac_item = pystac.Item(
+        id="S2A_TEST",
+        geometry=shapely.geometry.mapping(shapely.box(0, 0, 1, 1)),
+        bbox=[0, 0, 1, 1],
+        datetime=datetime(2024, 1, 1, tzinfo=UTC),
+        properties={"earthsearch:boa_offset_applied": boa_offset_applied},
+    )
+    stac_item.add_asset(
+        "B04",
+        pystac.Asset(
+            href="s3://source/B04.tif",
+            extra_fields={
+                "alternate": {"download": {"href": "https://example.com/B04.tif"}}
+            },
+        ),
+    )
+    ds = Sentinel2L2A(harmonize=True, assets=["B04"], cache_dir=None)
+
+    item = ds._stac_item_to_item(stac_item)
+
+    assert item.boa_offset_applied is boa_offset_applied
 
 
 def test_read_raster_does_not_harmonize_visual(


### PR DESCRIPTION
EarthDaily STAC items expose `earthsearch:boa_offset_applied`. When this is true, applying Sentinel-2 harmonization again subtracts another 1000 DN.

This PR preserves that field on EarthDailyItem and skips harmonization when the offset is already applied. Missing or false values retain the existing XML/baseline fallback.

Live STAC queries confirmed the field is returned as a boolean, including both true and false values.

Testing:

- Added STAC conversion, serialization, and raster harmonization tests
- 39 focused tests pass
- Ruff and mypy pass